### PR TITLE
Support for OpenAI compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,10 @@ For advanced features and AI configuration, CQLAI uses its own JSON format:
   "requireConfirmation": true,
   "consistency": "LOCAL_ONE",
   "pageSize": 100,
+  "maxMemoryMB": 10,
+  "connectTimeout": 10,
+  "requestTimeout": 10,
+  "debug": false,
   "historyFile": "~/.cqlai/history",
   "aiHistoryFile": "~/.cqlai/ai_history",
   "ssl": {
@@ -669,10 +673,20 @@ For advanced features and AI configuration, CQLAI uses its own JSON format:
   },
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
+  }
+}
+```
+
+**Note:** You can also use the `url` field to override the API endpoint for OpenAI-compatible APIs:
+```json
+{
+  "ai": {
+    "provider": "openai",
+    "apiKey": "your-api-key",
+    "url": "https://api.synthetic.new/openai/v1",
+    "model": "hf:Qwen/Qwen2.5-Coder-32B-Instruct"
   }
 }
 ```
@@ -697,10 +711,8 @@ Use OpenAI for high-quality, general-purpose query generation. Requires an OpenA
 {
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
   }
 }
 ```
@@ -720,10 +732,8 @@ Use Anthropic for powerful, context-aware models. Ideal for complex queries and 
 {
   "ai": {
     "provider": "anthropic",
-    "anthropic": {
-      "apiKey": "sk-ant-...",
-      "model": "claude-3-sonnet-20240229"
-    }
+    "apiKey": "sk-ant-...",
+    "model": "claude-3-sonnet-20240229"
   }
 }
 ```
@@ -741,10 +751,8 @@ Use Google Gemini for a fast and capable model from Google. Requires a Google AI
 {
   "ai": {
     "provider": "gemini",
-    "gemini": {
-      "apiKey": "...",
-      "model": "gemini-pro"
-    }
+    "apiKey": "...",
+    "model": "gemini-pro"
   }
 }
 ```
@@ -760,30 +768,13 @@ Use Ollama for running AI models locally or connecting to OpenAI-compatible APIs
   - `mistral` (Mistral AI's model)
   - `qwen2.5-coder` (Alibaba's code model)
 
-**Configuration for Local Ollama:**
+**Configuration:**
 ```json
 {
   "ai": {
     "provider": "ollama",
-    "ollama": {
-      "model": "llama3.2",
-      "url": "http://localhost:11434/v1"
-    }
-  }
-}
-```
-
-**Configuration for OpenAI-Compatible APIs:**
-
-You can also use the Ollama provider to connect to any OpenAI-compatible API endpoint:
-
-```json
-{
-  "ai": {
-    "provider": "ollama",
-    "apiKey": "your-api-key",
-    "url": "https://api.example.com/v1",
-    "model": "gpt-4o-mini"
+    "model": "llama3.2",
+    "url": "http://localhost:11434/v1"
   }
 }
 ```
@@ -809,11 +800,9 @@ Use OpenRouter to access multiple AI models through a single API. OpenRouter pro
 {
   "ai": {
     "provider": "openrouter",
-    "openrouter": {
-      "apiKey": "sk-or-...",
-      "model": "anthropic/claude-3-sonnet",
-      "url": "https://openrouter.ai/api/v1"
-    }
+    "apiKey": "sk-or-...",
+    "model": "anthropic/claude-3-sonnet",
+    "url": "https://openrouter.ai/api/v1"
   }
 }
 ```

--- a/README_es.md
+++ b/README_es.md
@@ -657,6 +657,10 @@ Para características avanzadas y configuración de IA, CQLAI usa su propio form
   "requireConfirmation": true,
   "consistency": "LOCAL_ONE",
   "pageSize": 100,
+  "maxMemoryMB": 10,
+  "connectTimeout": 10,
+  "requestTimeout": 10,
+  "debug": false,
   "historyFile": "~/.cqlai/history",
   "aiHistoryFile": "~/.cqlai/ai_history",
   "ssl": {
@@ -669,10 +673,20 @@ Para características avanzadas y configuración de IA, CQLAI usa su propio form
   },
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
+  }
+}
+```
+
+**Nota:** También puedes usar el campo `url` para sobrescribir el endpoint de la API para APIs compatibles con OpenAI:
+```json
+{
+  "ai": {
+    "provider": "openai",
+    "apiKey": "tu-clave-api",
+    "url": "https://api.synthetic.new/openai/v1",
+    "model": "hf:Qwen/Qwen2.5-Coder-32B-Instruct"
   }
 }
 ```
@@ -697,10 +711,8 @@ Usa OpenAI para generación de consultas de alta calidad y propósito general. R
 {
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
   }
 }
 ```
@@ -720,10 +732,8 @@ Usa Anthropic para modelos potentes y conscientes del contexto. Ideal para consu
 {
   "ai": {
     "provider": "anthropic",
-    "anthropic": {
-      "apiKey": "sk-ant-...",
-      "model": "claude-3-sonnet-20240229"
-    }
+    "apiKey": "sk-ant-...",
+    "model": "claude-3-sonnet-20240229"
   }
 }
 ```
@@ -741,10 +751,8 @@ Usa Google Gemini para un modelo rápido y capaz de Google. Requiere una clave A
 {
   "ai": {
     "provider": "gemini",
-    "gemini": {
-      "apiKey": "...",
-      "model": "gemini-pro"
-    }
+    "apiKey": "...",
+    "model": "gemini-pro"
   }
 }
 ```
@@ -760,27 +768,13 @@ Usa Ollama para ejecutar modelos de IA localmente o conectarte a APIs compatible
   - `mistral` (Modelo de Mistral AI)
   - `qwen2.5-coder` (Modelo de código de Alibaba)
 
-**Configuración para Ollama Local:**
+**Configuración:**
 ```json
 {
   "ai": {
     "provider": "ollama",
-    "ollama": {
-      "model": "llama3.2",
-      "url": "http://localhost:11434/v1"
-    }
-  }
-}
-```
-
-**Configuración para APIs Compatibles con OpenAI:**
-```json
-{
-  "ai": {
-    "provider": "ollama",
-    "apiKey": "tu-clave-api",
-    "url": "https://api.example.com/v1",
-    "model": "gpt-4o-mini"
+    "model": "llama3.2",
+    "url": "http://localhost:11434/v1"
   }
 }
 ```
@@ -806,11 +800,9 @@ Usa OpenRouter para acceder a múltiples modelos de IA a través de una sola API
 {
   "ai": {
     "provider": "openrouter",
-    "openrouter": {
-      "apiKey": "sk-or-...",
-      "model": "anthropic/claude-3-sonnet",
-      "url": "https://openrouter.ai/api/v1"
-    }
+    "apiKey": "sk-or-...",
+    "model": "anthropic/claude-3-sonnet",
+    "url": "https://openrouter.ai/api/v1"
   }
 }
 ```

--- a/README_gl.md
+++ b/README_gl.md
@@ -657,6 +657,10 @@ Para características avanzadas e configuración de IA, CQLAI usa o seu propio f
   "requireConfirmation": true,
   "consistency": "LOCAL_ONE",
   "pageSize": 100,
+  "maxMemoryMB": 10,
+  "connectTimeout": 10,
+  "requestTimeout": 10,
+  "debug": false,
   "historyFile": "~/.cqlai/history",
   "aiHistoryFile": "~/.cqlai/ai_history",
   "ssl": {
@@ -669,10 +673,20 @@ Para características avanzadas e configuración de IA, CQLAI usa o seu propio f
   },
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
+  }
+}
+```
+
+**Nota:** Tamén podes usar o campo `url` para sobrescribir o endpoint da API para APIs compatibles con OpenAI:
+```json
+{
+  "ai": {
+    "provider": "openai",
+    "apiKey": "a-túa-clave-api",
+    "url": "https://api.synthetic.new/openai/v1",
+    "model": "hf:Qwen/Qwen2.5-Coder-32B-Instruct"
   }
 }
 ```
@@ -697,10 +711,8 @@ Usa OpenAI para xeración de consultas de alta calidade e propósito xeral. Requ
 {
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
   }
 }
 ```
@@ -720,10 +732,8 @@ Usa Anthropic para modelos potentes e conscientes do contexto. Ideal para consul
 {
   "ai": {
     "provider": "anthropic",
-    "anthropic": {
-      "apiKey": "sk-ant-...",
-      "model": "claude-3-sonnet-20240229"
-    }
+    "apiKey": "sk-ant-...",
+    "model": "claude-3-sonnet-20240229"
   }
 }
 ```
@@ -741,10 +751,8 @@ Usa Google Gemini para un modelo rápido e capaz de Google. Require unha clave A
 {
   "ai": {
     "provider": "gemini",
-    "gemini": {
-      "apiKey": "...",
-      "model": "gemini-pro"
-    }
+    "apiKey": "...",
+    "model": "gemini-pro"
   }
 }
 ```
@@ -760,27 +768,13 @@ Usa Ollama para executar modelos de IA localmente ou conectarte a APIs compatibl
   - `mistral` (Modelo de Mistral AI)
   - `qwen2.5-coder` (Modelo de código de Alibaba)
 
-**Configuración para Ollama Local:**
+**Configuración:**
 ```json
 {
   "ai": {
     "provider": "ollama",
-    "ollama": {
-      "model": "llama3.2",
-      "url": "http://localhost:11434/v1"
-    }
-  }
-}
-```
-
-**Configuración para APIs Compatibles con OpenAI:**
-```json
-{
-  "ai": {
-    "provider": "ollama",
-    "apiKey": "a-túa-clave-api",
-    "url": "https://api.example.com/v1",
-    "model": "gpt-4o-mini"
+    "model": "llama3.2",
+    "url": "http://localhost:11434/v1"
   }
 }
 ```
@@ -806,11 +800,9 @@ Usa OpenRouter para acceder a múltiples modelos de IA a través dunha soa API.
 {
   "ai": {
     "provider": "openrouter",
-    "openrouter": {
-      "apiKey": "sk-or-...",
-      "model": "anthropic/claude-3-sonnet",
-      "url": "https://openrouter.ai/api/v1"
-    }
+    "apiKey": "sk-or-...",
+    "model": "anthropic/claude-3-sonnet",
+    "url": "https://openrouter.ai/api/v1"
   }
 }
 ```

--- a/README_jp.md
+++ b/README_jp.md
@@ -656,6 +656,10 @@ validate = true
   "requireConfirmation": true,
   "consistency": "LOCAL_ONE",
   "pageSize": 100,
+  "maxMemoryMB": 10,
+  "connectTimeout": 10,
+  "requestTimeout": 10,
+  "debug": false,
   "historyFile": "~/.cqlai/history",
   "aiHistoryFile": "~/.cqlai/ai_history",
   "ssl": {
@@ -668,10 +672,20 @@ validate = true
   },
   "ai": {
     "provider": "openai",
-    "openai": {
-      "apiKey": "sk-...",
-      "model": "gpt-4-turbo-preview"
-    }
+    "apiKey": "sk-...",
+    "model": "gpt-4-turbo-preview"
+  }
+}
+```
+
+**注意:** `url`フィールドを使用してOpenAI互換APIのAPIエンドポイントを上書きできます:
+```json
+{
+  "ai": {
+    "provider": "openai",
+    "apiKey": "your-api-key",
+    "url": "https://api.synthetic.new/openai/v1",
+    "model": "hf:Qwen/Qwen2.5-Coder-32B-Instruct"
   }
 }
 ```

--- a/cqlai.json.example
+++ b/cqlai.json.example
@@ -5,9 +5,14 @@
    "username": "cassandra",
    "password": "cassandra",
    "requireConfirmation": true,
+   "consistency": "LOCAL_ONE",
+   "pageSize": 100,
+   "maxMemoryMB": 10,
    "connectTimeout": 10,
    "requestTimeout": 10,
    "debug": false,
+   "historyFile": "~/.cqlai/history",
+   "aiHistoryFile": "~/.cqlai/ai_history",
    "ssl": {
       "enabled": false,
       "certPath": "/path/to/client-cert.pem",
@@ -20,6 +25,7 @@
       "provider": "mock",
       "apiKey": "",
       "model": "",
+      "url": "",
       "openai": {
          "apiKey": "",
          "model": "gpt-4-turbo-preview"
@@ -32,9 +38,15 @@
          "apiKey": "",
          "model": "gemini-pro"
       },
+      "ollama": {
+         "apiKey": "",
+         "model": "llama3.2",
+         "url": "http://localhost:11434/v1"
+      },
       "openrouter": {
          "apiKey": "",
-         "model": "openai/gpt-4-turbo-preview"
+         "model": "anthropic/claude-3-sonnet",
+         "url": "https://openrouter.ai/api/v1"
       }
    }
 }

--- a/docs/AI_CONFIG.md
+++ b/docs/AI_CONFIG.md
@@ -26,9 +26,10 @@ AI providers are configured in the `cqlai.json` configuration file. Copy `cqlai.
   "port": 9042,
   ...
   "ai": {
-    "provider": "mock",  // Options: mock, openai, anthropic, gemini
+    "provider": "mock",  // Options: mock, openai, anthropic, gemini, ollama, openrouter
     "apiKey": "",        // General API key (overridden by provider-specific)
-    "model": ""          // General model (overridden by provider-specific)
+    "model": "",         // General model (overridden by provider-specific)
+    "url": ""            // General URL (overridden by provider-specific, for Ollama/OpenRouter)
   }
 }
 ```
@@ -62,6 +63,29 @@ AI providers are configured in the `cqlai.json` configuration file. Copy `cqlai.
   "gemini": {
     "apiKey": "your-gemini-api-key-here",
     "model": "gemini-pro"  // Optional, defaults to gemini-pro
+  }
+}
+```
+
+### Ollama Configuration
+```json
+"ai": {
+  "provider": "ollama",
+  "ollama": {
+    "model": "llama3.2",  // Optional, model to use
+    "url": "http://localhost:11434/v1"  // Optional, defaults to http://localhost:11434/v1
+  }
+}
+```
+
+### OpenRouter Configuration
+```json
+"ai": {
+  "provider": "openrouter",
+  "openrouter": {
+    "apiKey": "your-openrouter-api-key-here",
+    "model": "anthropic/claude-3-sonnet",  // Optional
+    "url": "https://openrouter.ai/api/v1"  // Optional, defaults to https://openrouter.ai/api/v1
   }
 }
 ```
@@ -105,14 +129,18 @@ When the AI generates a query, you can:
 
 Currently implemented:
 - ✅ Mock provider for testing
+- ✅ OpenAI API integration (GPT-4, GPT-3.5)
+- ✅ Anthropic API integration (Claude 3)
+- ✅ Google Gemini API integration
+- ✅ Ollama support (local models and OpenAI-compatible APIs)
+- ✅ OpenRouter integration (multiple model access)
 - ✅ Query plan generation and validation
 - ✅ CQL rendering from plans
 - ✅ UI modal for preview and confirmation
 - ✅ Schema context extraction
 
-TODO:
-- ⏳ Real OpenAI API integration
-- ⏳ Real Anthropic API integration
-- ⏳ Real Google Gemini API integration
+Future enhancements:
 - ⏳ Query optimization suggestions
 - ⏳ Natural language explanations of existing queries
+- ⏳ Enhanced context awareness with table statistics
+- ⏳ Multi-turn conversation support

--- a/internal/ai/conversation_manager.go
+++ b/internal/ai/conversation_manager.go
@@ -68,7 +68,7 @@ func (cm *ConversationManager) StartConversation(provider, model, apiKey, baseUR
 			openaioption.WithAPIKey(apiKey),
 			openaioption.WithBaseURL(url),
 		)
-		conv.ollamaClient = &client
+		conv.openaiClient = &client
 	case "openrouter":
 		url := baseURL
 		if url == "" {

--- a/internal/ai/ollama_client.go
+++ b/internal/ai/ollama_client.go
@@ -318,6 +318,8 @@ func (conv *AIConversation) continueOllama(ctx context.Context, userInput string
 		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	logger.DebugfToFile("AIConversation", "[%s] Payload: %s", conv.ID, string(payloadBytes))
+
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)

--- a/internal/logger/debug.go
+++ b/internal/logger/debug.go
@@ -31,10 +31,13 @@ func DebugToFile(context string, message string) {
 	if !IsDebugEnabled() {
 		return
 	}
-	
-	cwd, _ := os.Getwd()
-	logPath := cwd + "/cqlai_debug.log"
 
+	var logPath string
+	logPath = os.Getenv("CQLAI_DEBUG_LOG_PATH")
+	if logPath == "" {
+		cwd, _ := os.Getwd()
+		logPath = cwd + "/cqlai_debug.log"
+	}
 	// Check if file exists to print message only once
 	_, statErr := os.Stat(logPath)
 	isNewFile := os.IsNotExist(statErr)


### PR DESCRIPTION
This MR introduces a breaking change in the AI configuration from

```json
{
  "ai": {
    "provider": "openai",
    "openai": {
      "apiKey": "sk-...",
      "model": "gpt-4-turbo-preview"
    }
  }
}
```

to

```json
{
  "ai": {
    "provider": "openai",
    "apiKey": "your-api-key",
     "model": "gpt-4-turbo-preview"
  }
}
```