### PR TITLE
fix: Display results when CAPTURE is active

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -192,6 +192,18 @@ func ProcessCommand(command string, session *db.Session, sessionMgr *session.Man
 						_ = metaHandler.WriteCaptureResultWithRawData(command, v.Headers, rows, rawRows)
 					}
 				}
+
+				// Convert streaming result to regular QueryResult so it can be displayed
+				// Build data with headers as first row
+				data := [][]string{v.Headers}
+				data = append(data, rows...)
+				logger.DebugfToFile("ProcessCommand", "Converting StreamingQueryResult to QueryResult: headers=%d, data rows=%d, total data=%d", len(v.Headers), len(rows), len(data))
+				result = db.QueryResult{
+					Data:        data,
+					ColumnTypes: v.ColumnTypes,
+					RawData:     rawRows,
+				}
+				logger.DebugfToFile("ProcessCommand", "Converted result type: %T, Data length: %d", result, len(result.(db.QueryResult).Data))
 			}
 		}
 


### PR DESCRIPTION
Fixes issue where query results were not displayed in the application when CAPTURE was enabled.

Problem:
When capturing streaming query results (like SELECT queries), the code consumed the iterator to write to the capture file, then returned the original StreamingQueryResult with an exhausted iterator. The UI had nothing to display, showing "No results".

Solution:
After consuming the iterator for capture, convert the StreamingQueryResult to a regular QueryResult containing the fetched rows. This allows both:
- Rows to be written to capture file
- Rows to be displayed in the UI

Added debug logging to track the conversion process.

Now "CAPTURE JSON '/tmp/test.json'" followed by "SELECT * FROM ..." will:
1. Write results to /tmp/test.json
2. Display results in the application