### PR TITLE
fix(ui): keep mouse selection and right-click paste working

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ cqlai -e "SELECT * FROM large_table;" --page-size 50
 | `Enter` (empty input) | Load next page when more data available | Same |
 | `Alt+↑`/`Alt+↓` | Scroll viewport by single row (respects row boundaries) | `Option+↑`/`Option+↓` |
 | `Alt+←`/`Alt+→` | Scroll table horizontally (wide tables) | `Option+←`/`Option+→` |
-| `↑`/`↓` | Navigate table rows (when in navigation mode) | Same |
+| `↑`/`↓` | Scroll results in the table and trace views. In the normal view they step through command history; `Ctrl+P` recalls history from any view | Same |
 
 #### Navigation Mode (Table/Trace Views)
 Press `Esc` to toggle navigation mode when viewing tables or traces.
@@ -344,15 +344,26 @@ Press `Esc` to toggle navigation mode when viewing tables or traces.
 | `Esc` | Exit navigation mode / Cancel pagination if active |
 
 #### Mouse Support
+
+cqlai leaves the mouse buttons to your terminal, so selecting text, right-click
+paste and middle-click paste all behave exactly as they do in any other program.
+No modifier key needed.
+
+It gets the scroll wheel through alternate scroll mode, where the terminal turns
+wheel spins into `↑`/`↓` key presses. That means the wheel scrolls whatever `↑`
+and `↓` scroll: results in the table view, the trace in the trace view, and the
+conversation in the AI view.
+
 | Action | Function |
 |--------|----------|
 | Mouse Wheel | Scroll vertically with automatic data loading |
-| Alt+Mouse Wheel | Scroll horizontally in tables |
-| Shift+Mouse Wheel | Scroll horizontally (alternative) |
-| Ctrl+Mouse Wheel | Scroll horizontally (alternative) |
-| Shift+Click+Drag | Select text for copying |
-| Ctrl+Shift+C | Copy selected text to clipboard |
+| Click+Drag | Select text (your terminal's own selection) |
+| Right Click | Paste (if your terminal binds it that way) |
 | Middle Click | Paste from selection buffer (Linux/Unix) |
+
+Scroll wide tables sideways with `Alt+←`/`Alt+→`, or `<` and `>` in navigation
+mode. Horizontal scrolling with the wheel is not available, because the terminal
+only reports vertical wheel spins as key presses.
 
 **Note for macOS Users:**
 - Most `Ctrl` shortcuts work as-is on macOS, but you can also use `⌘` (Command) key as an alternative

--- a/cmd/cqlai/main.go
+++ b/cmd/cqlai/main.go
@@ -336,18 +336,34 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Create program with alternate screen buffer (like less) and mouse support
-		// This hides the terminal scrollbar and provides a clean full-screen experience
-		p := tea.NewProgram(m,
-			tea.WithAltScreen(),
-			// Don't use WithMouseCellMotion - we'll enable mouse manually in Init
-		)
-
-		if _, err := p.Run(); err != nil {
+		if err := runInteractive(m); err != nil {
 			fmt.Fprintf(os.Stderr, "Error starting program: %v", err)
 			os.Exit(1)
 		}
 	}
+}
+
+// runInteractive runs the Bubble Tea UI.
+//
+// It exists so the alternate scroll mode set up in the model's Init has a defer
+// to undo it on the way out, whether that is a clean quit, an error or a panic.
+func runInteractive(m tea.Model) error {
+	// Alternate screen buffer (like less) hides the terminal scrollbar and gives
+	// a clean full-screen experience.
+	//
+	// Deliberately no WithMouseCellMotion: taking the mouse buttons would stop the
+	// terminal doing its own text selection and right-click paste. Init turns on
+	// alternate scroll mode instead, which gives us the wheel only.
+	p := tea.NewProgram(m,
+		tea.WithAltScreen(),
+	)
+
+	// Give the wheel back to the terminal however we leave. Bubble Tea already
+	// restores the alternate screen and mouse state itself.
+	defer ui.DisableAlternateScroll()
+
+	_, err := p.Run()
+	return err
 }
 
 // isTerminal checks if stdin is a terminal

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -332,6 +332,13 @@ func (m *MainModel) handleUpArrow(msg tea.KeyMsg) (*MainModel, tea.Cmd) {
 		return m.handleAltScrollUp()
 	}
 
+	// While a result set is on screen, scroll it. Alternate scroll mode delivers
+	// wheel events as plain Up presses, so this is also what the wheel does here.
+	// Command history stays on Up in the normal view.
+	if m.viewportOwnsArrows() {
+		return m.handleAltScrollUp()
+	}
+
 	// Handle command history navigation up
 	return m.handleCommandHistoryUp()
 }
@@ -371,6 +378,11 @@ func (m *MainModel) handleDownArrow(msg tea.KeyMsg) (*MainModel, tea.Cmd) {
 
 	// If Alt is held, scroll viewport down by one line
 	if msg.Alt {
+		return m.handleAltScrollDown()
+	}
+
+	// See handleUpArrow: the wheel arrives here too while a result set is up.
+	if m.viewportOwnsArrows() {
 		return m.handleAltScrollDown()
 	}
 

--- a/internal/ui/keyboard_handler_ai_conversation.go
+++ b/internal/ui/keyboard_handler_ai_conversation.go
@@ -172,12 +172,12 @@ func (m *MainModel) handleAIConversationInput(msg tea.KeyMsg) (*MainModel, tea.C
 		}
 		return m, nil
 	case tea.KeyUp:
-		// Check for Alt modifier first for scrolling
-		if msg.Alt {
-			// Scroll conversation up by one line
-			m.aiConversationViewport.YOffset = max(0, m.aiConversationViewport.YOffset-1)
-			return m, nil
-		}
+		// Scroll the conversation. Alternate scroll mode delivers wheel events as
+		// plain Up presses, so this is what the wheel does here too. AI command
+		// history is on Ctrl+P.
+		m.aiConversationViewport.YOffset = max(0, m.aiConversationViewport.YOffset-1)
+		return m, nil
+	case tea.KeyCtrlP:
 		// Navigate AI command history (not CQL history)
 		if len(m.aiCommandHistory) > 0 {
 			if m.aiHistoryIndex == -1 {
@@ -191,13 +191,11 @@ func (m *MainModel) handleAIConversationInput(msg tea.KeyMsg) (*MainModel, tea.C
 		}
 		return m, nil
 	case tea.KeyDown:
-		// Check for Alt modifier first for scrolling
-		if msg.Alt {
-			// Scroll conversation down by one line
-			maxOffset := max(0, m.aiConversationViewport.TotalLineCount()-m.aiConversationViewport.Height)
-			m.aiConversationViewport.YOffset = min(maxOffset, m.aiConversationViewport.YOffset+1)
-			return m, nil
-		}
+		// See KeyUp: the wheel arrives here too.
+		maxOffset := max(0, m.aiConversationViewport.TotalLineCount()-m.aiConversationViewport.Height)
+		m.aiConversationViewport.YOffset = min(maxOffset, m.aiConversationViewport.YOffset+1)
+		return m, nil
+	case tea.KeyCtrlN:
 		// Navigate AI command history (not CQL history)
 		if m.aiHistoryIndex != -1 {
 			if m.aiHistoryIndex < len(m.aiCommandHistory)-1 {

--- a/internal/ui/keyboard_handler_control.go
+++ b/internal/ui/keyboard_handler_control.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"fmt"
-
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -61,9 +59,8 @@ func (m *MainModel) handleCtrlC() (*MainModel, tea.Cmd) {
 
 	// If already confirming, exit. Otherwise show confirmation.
 	if m.confirmExit {
-		// Disable mouse tracking on exit
-		fmt.Print("\x1b[?1000l") // Disable basic mouse tracking
-		fmt.Print("\x1b[?1006l") // Disable SGR mouse mode
+		// Give the wheel back to the terminal on exit.
+		DisableAlternateScroll()
 		return m, tea.Quit
 	}
 	m.confirmExit = true
@@ -76,9 +73,8 @@ func (m *MainModel) handleCtrlC() (*MainModel, tea.Cmd) {
 func (m *MainModel) handleCtrlD() (*MainModel, tea.Cmd) {
 	// If confirming exit, quit. Otherwise show confirmation.
 	if m.confirmExit {
-		// Disable mouse tracking on exit
-		fmt.Print("\x1b[?1000l") // Disable basic mouse tracking
-		fmt.Print("\x1b[?1006l") // Disable SGR mouse mode
+		// Give the wheel back to the terminal on exit.
+		DisableAlternateScroll()
 		return m, tea.Quit
 	}
 	m.confirmExit = true

--- a/internal/ui/keyboard_handler_enter_special.go
+++ b/internal/ui/keyboard_handler_enter_special.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,9 +11,8 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 	upperCommand := strings.ToUpper(command)
 
 	if upperCommand == "EXIT" || upperCommand == "QUIT" {
-		// Disable mouse tracking on exit
-		fmt.Print("\x1b[?1000l") // Disable basic mouse tracking
-		fmt.Print("\x1b[?1006l") // Disable SGR mouse mode
+		// Give the wheel back to the terminal on exit.
+		DisableAlternateScroll()
 		return m, tea.Quit, true
 	}
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -453,11 +453,10 @@ func NewMainModelWithConnectionOptions(options ConnectionOptions) (*MainModel, e
 
 // Init initializes the main model.
 func (m *MainModel) Init() tea.Cmd {
-	// Enable ONLY wheel button events (buttons 4 and 5)
-	// This is a special mode that some terminals support
-	// Standard button event mode but we'll try to be more specific
-	fmt.Print("\x1b[?1000h") // Enable basic mouse tracking
-	fmt.Print("\x1b[?1006h") // Use SGR encoding for larger coordinates
+	// Take the wheel without taking the mouse buttons, so the terminal keeps
+	// its own text selection and right-click paste. Wheel events arrive as
+	// Up/Down key presses instead of mouse events.
+	EnableAlternateScroll()
 	return textinput.Blink
 }
 

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -9,7 +9,16 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// handleMouseInput handles mouse events
+// handleMouseInput handles mouse events.
+//
+// Nothing reaches this today: cqlai no longer turns on mouse reporting, because
+// doing so takes the buttons away from the terminal and breaks its text
+// selection and right-click paste. The wheel arrives as Up/Down key presses via
+// alternate scroll mode instead - see mouse_mode.go.
+//
+// It is kept for the day something clickable needs mouse reporting switched on
+// while it is on screen, which is the point at which wheel events start
+// arriving here again.
 func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 	// Debug log ALL mouse events
 	logger.DebugfToFile("Mouse", "MouseEvent: Action=%v, Button=%v, X=%d, Y=%d, Shift=%v, Alt=%v, Ctrl=%v",
@@ -44,8 +53,10 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 		// Native horizontal scroll right (for mice/trackpads that support it)
 		return m.handleMouseWheelRight()
 	default:
-		// Ignore all other button events (left, middle, right clicks)
-		// This allows terminal to handle text selection
+		// Ignore left, middle and right clicks. Note that ignoring them here is
+		// not what lets the terminal select text - by the time an event reaches
+		// this function the terminal has already given the button up. Leaving
+		// mouse reporting off is what does that.
 		return m, nil
 	}
 }

--- a/internal/ui/mouse_mode.go
+++ b/internal/ui/mouse_mode.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"fmt"
+)
+
+// Alternate scroll mode (DECSET 1007).
+//
+// cqlai runs on the alternate screen and only ever wanted the scroll wheel.
+// Asking for that with mouse reporting (DECSET 1000) is too blunt: the terminal
+// then hands us every click, so its own text selection and right-click paste
+// stop working and users have to hold Shift to select anything.
+//
+// Alternate scroll mode gets the wheel without the buttons. While the alternate
+// screen is active and mouse reporting is off, the terminal turns wheel events
+// into Up/Down key presses and sends those instead, so it keeps the buttons and
+// we still get to scroll. See handleUpArrow/handleDownArrow for the receiving
+// end.
+const (
+	seqEnableAlternateScroll  = "\x1b[?1007h"
+	seqDisableAlternateScroll = "\x1b[?1007l"
+)
+
+// EnableAlternateScroll turns on alternate scroll mode.
+//
+// Bubble Tea has no command for this mode, so it is written straight to stdout
+// the same way the mouse sequences used to be.
+func EnableAlternateScroll() {
+	fmt.Print(seqEnableAlternateScroll)
+}
+
+// DisableAlternateScroll gives the wheel back to the terminal.
+func DisableAlternateScroll() {
+	fmt.Print(seqDisableAlternateScroll)
+}
+
+// viewportOwnsArrows reports whether a bare Up/Down should scroll the current
+// view instead of walking back through command history.
+//
+// This matters because of alternate scroll mode: a wheel spin reaches us as an
+// Up or Down key press that is indistinguishable from a real one. Scrolling is
+// the useful reading of both while a result set or a trace is on screen. In the
+// normal view there is nothing to scroll through, so Up keeps recalling the last
+// command, and Ctrl+P still recalls it in every view.
+//
+// The AI conversation view is not listed here because handleAIConversationInput
+// consumes Up/Down before they reach handleUpArrow and does its own scrolling.
+//
+// Alt+Up/Down, PgUp/PgDn and navigation mode are unaffected and still scroll
+// everywhere.
+func (m *MainModel) viewportOwnsArrows() bool {
+	switch m.viewMode {
+	case "table":
+		return m.hasTable
+	case "trace":
+		return m.hasTrace
+	default:
+		return false
+	}
+}

--- a/internal/ui/mouse_mode_test.go
+++ b/internal/ui/mouse_mode_test.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs f and returns whatever it printed to stdout.
+//
+// The mouse mode helpers write escape sequences straight to stdout, which is the
+// only thing worth asserting about them.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+	f()
+	os.Stdout = orig
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestInitEnablesAlternateScrollNotMouseReporting guards the fix for the mouse
+// selection bug. Turning on mouse reporting (DECSET 1000) makes the terminal
+// hand us every click, which kills its own text selection and right-click paste.
+// Init must ask for alternate scroll mode instead.
+func TestInitEnablesAlternateScrollNotMouseReporting(t *testing.T) {
+	m := &MainModel{}
+
+	out := captureStdout(t, func() {
+		m.Init()
+	})
+
+	if !strings.Contains(out, "\x1b[?1007h") {
+		t.Errorf("Init did not enable alternate scroll mode (DECSET 1007); wrote %q", out)
+	}
+
+	for _, banned := range []string{"\x1b[?1000h", "\x1b[?1002h", "\x1b[?1003h", "\x1b[?1006h"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("Init enabled mouse reporting %q, which breaks terminal text selection and right-click paste", banned)
+		}
+	}
+}
+
+func TestDisableAlternateScroll(t *testing.T) {
+	out := captureStdout(t, DisableAlternateScroll)
+
+	if !strings.Contains(out, "\x1b[?1007l") {
+		t.Errorf("DisableAlternateScroll wrote %q, want it to reset DECSET 1007", out)
+	}
+}
+
+// TestViewportOwnsArrows covers which views treat a bare Up/Down as scrolling.
+// Alternate scroll mode delivers wheel spins as Up/Down key presses, so this is
+// also the answer to "what does the wheel do here".
+func TestViewportOwnsArrows(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    MainModel
+		expected bool
+	}{
+		{
+			name:     "table view with results scrolls",
+			model:    MainModel{viewMode: "table", hasTable: true},
+			expected: true,
+		},
+		{
+			name:     "table view without results recalls history",
+			model:    MainModel{viewMode: "table"},
+			expected: false,
+		},
+		{
+			name:     "trace view with a trace scrolls",
+			model:    MainModel{viewMode: "trace", hasTrace: true},
+			expected: true,
+		},
+		{
+			name:     "trace view without a trace recalls history",
+			model:    MainModel{viewMode: "trace"},
+			expected: false,
+		},
+		{
+			name:     "normal view recalls history",
+			model:    MainModel{viewMode: "history"},
+			expected: false,
+		},
+		{
+			// handleAIConversationInput takes Up/Down before handleUpArrow sees
+			// them and scrolls the conversation itself.
+			name:     "ai view is handled elsewhere",
+			model:    MainModel{viewMode: "ai", aiConversationActive: true},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.model.viewportOwnsArrows(); got != tt.expected {
+				t.Errorf("viewportOwnsArrows() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #86.

## The problem

`Init()` turned on mouse reporting (`\x1b[?1000h`) so cqlai could get the scroll wheel. That mode sends the app *every* click, not just wheel spins, so the terminal gives up the mouse buttons - and with them its own text selection and right-click paste. Hence needing Shift to select anything.

cqlai never used those clicks. It threw them away, under a comment claiming that let the terminal handle selection. It doesn't: by the time an event arrives, the terminal has already given the button up.

## The fix

Alternate scroll mode (`\x1b[?1007h`) instead. On the alternate screen with mouse reporting off, the terminal converts wheel spins into Up/Down key presses and keeps the buttons. cqlai gets the wheel; the terminal keeps selection and paste.

## Knock-on: wheel now looks like arrow keys

A wheel spin is indistinguishable from a real Up/Down press, so the two have to share:

- **Table and trace views** - Up/Down scroll the viewport.
- **Normal view** - Up/Down keep recalling command history.
- **`Ctrl+P`** - recalls command history from any view, so nothing lost its binding.
- **AI conversation** - Up/Down scroll; AI command history moves to `Ctrl+P`/`Ctrl+N`.

That last one also fixes an existing bug: `Ctrl+P` in the AI view fell through to the main handler and recalled CQL history rather than AI history. `Ctrl+N` was documented in the README but never bound in code.

## Also

- Teardown was three raw `fmt.Print` calls on specific quit paths, so a panic or `SIGTERM` left the terminal reporting mouse events to your shell. The program run now sits in `runInteractive()` so a `defer` covers it. Bubble Tea already restores alt-screen and mouse state itself.
- `handleMouseInput` is unreachable now that nothing enables reporting. Kept, with a comment explaining why - it is what you would re-enable to make modals clickable - and the incorrect comment corrected.

## Trade-off

Horizontal wheel scrolling (`Alt`/`Shift`/`Ctrl`+wheel) is gone. Terminals only convert vertical wheel spins into keys, so there is no way to keep it. `Alt+Left/Right` and `<`/`>` in navigation mode still scroll wide tables. Documented as a limitation rather than hidden.

## Testing

`internal/ui/mouse_mode_test.go` asserts `Init()` emits `?1007h` and none of `?1000h`/`?1002h`/`?1003h`/`?1006h`, so this cannot silently regress. First test file in `internal/ui`, which was at 0% coverage.

`go build ./...`, `go test ./internal/... ./test/bdd/...` and `golangci-lint run` all clean.

Confirmed by hand against a live cluster: selection without Shift, right-click paste, wheel scrolling a result table.

## Note for reviewers

`README_es.md`, `README_gl.md` and `README_jp.md` still describe the old mouse behaviour. Only the English README is updated here.
