### PR TITLE
fix(parquet): stop ReadBatch discarding rows past the first batch

### DIFF
--- a/internal/parquet/partitioned_reader.go
+++ b/internal/parquet/partitioned_reader.go
@@ -205,9 +205,15 @@ func (pr *PartitionedParquetReader) GetSchema() ([]string, []string) {
 func (pr *PartitionedParquetReader) ReadAll() ([]map[string]interface{}, error) {
 	var allRows []map[string]interface{}
 
-	// Reset to first file
+	// Reset to first file. Close the reader the constructor opened rather than
+	// dropping it, and clear the row tally so the walk does not count the first
+	// file twice.
+	if pr.currentReader != nil {
+		_ = pr.currentReader.Close()
+		pr.currentReader = nil
+	}
 	pr.currentFileIndex = -1
-	pr.currentReader = nil
+	pr.totalRowCount = 0
 
 	for {
 		if err := pr.nextFile(); err != nil {
@@ -327,7 +333,12 @@ func (pr *PartitionedParquetReader) ReadBatch(batchSize int) ([]map[string]inter
 	return batch, nil
 }
 
-// GetRowCount returns the total row count across all partitions
+// GetRowCount returns the number of rows in the partition files opened so far.
+//
+// Files are opened lazily as reading advances, so this is a running total, not
+// the size of the dataset. Straight after construction it reports the row count
+// of the first file only; it reaches the dataset total once every file has been
+// read. Callers that need the total up front have to sum it themselves.
 func (pr *PartitionedParquetReader) GetRowCount() int64 {
 	return pr.totalRowCount
 }

--- a/internal/parquet/partitioned_reader_test.go
+++ b/internal/parquet/partitioned_reader_test.go
@@ -1,0 +1,160 @@
+package parquet
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePartitionedDataset builds a Hive-style dataset:
+//
+//	<base>/year=2024/month=01/data.parquet
+//	<base>/year=2024/month=02/data.parquet
+//	<base>/year=2025/month=01/data.parquet
+//
+// Each file holds rowsPerFile rows with a globally increasing id, so the
+// concatenation of every file is 0..(3*rowsPerFile-1) in order.
+func writePartitionedDataset(t *testing.T, rowsPerFile, chunkSize int) (base string, total int) {
+	t.Helper()
+
+	base = t.TempDir()
+	parts := []struct{ year, month string }{
+		{"2024", "01"},
+		{"2024", "02"},
+		{"2025", "01"},
+	}
+
+	id := 0
+	for _, p := range parts {
+		dir := filepath.Join(base, "year="+p.year, "month="+p.month)
+		require.NoError(t, os.MkdirAll(dir, 0o750))
+
+		opts := DefaultWriterOptions()
+		opts.ChunkSize = int64(chunkSize)
+
+		w, err := NewParquetCaptureWriter(filepath.Join(dir, "data.parquet"),
+			[]string{"id", "name"}, []string{"int", "text"}, opts)
+		require.NoError(t, err)
+
+		for range rowsPerFile {
+			require.NoError(t, w.WriteRow(map[string]interface{}{
+				"id":   id,
+				"name": fmt.Sprintf("row-%d", id),
+			}))
+			id++
+		}
+		require.NoError(t, w.Close())
+	}
+
+	return base, id
+}
+
+func drainPartitioned(t *testing.T, pr *PartitionedParquetReader, batchSize int) []map[string]interface{} {
+	t.Helper()
+
+	var all []map[string]interface{}
+	for range 1000 {
+		batch, err := pr.ReadBatch(batchSize)
+		if errors.Is(err, io.EOF) {
+			all = append(all, batch...)
+			return all
+		}
+		require.NoError(t, err)
+		require.NotEmpty(t, batch, "ReadBatch returned no rows and no io.EOF")
+		all = append(all, batch...)
+	}
+
+	t.Fatal("ReadBatch never returned io.EOF")
+	return nil
+}
+
+// TestPartitionedReadBatchAcrossFiles is the reachable path: COPY FROM a
+// partitioned dataset streams through it.
+func TestPartitionedReadBatchAcrossFiles(t *testing.T) {
+	const rowsPerFile = 250
+
+	base, total := writePartitionedDataset(t, rowsPerFile, 100)
+
+	for _, batchSize := range []int{1, 30, 250, 400, 10000} {
+		t.Run(fmt.Sprintf("batch=%d", batchSize), func(t *testing.T) {
+			pr, err := NewPartitionedParquetReader(base)
+			require.NoError(t, err)
+			defer pr.Close()
+
+			rows := drainPartitioned(t, pr, batchSize)
+
+			require.Equal(t, total, len(rows), "rows lost or duplicated across partition files")
+			for i, row := range rows {
+				assert.Equal(t, int32(i), row["id"], "row %d out of order or wrong", i)
+			}
+		})
+	}
+}
+
+// TestPartitionedReadBatchAddsPartitionColumns checks the partition values from
+// the directory names land on the rows, with the numeric coercion the reader does.
+func TestPartitionedReadBatchAddsPartitionColumns(t *testing.T) {
+	base, total := writePartitionedDataset(t, 10, 100)
+
+	pr, err := NewPartitionedParquetReader(base)
+	require.NoError(t, err)
+	defer pr.Close()
+
+	assert.Equal(t, []string{"month", "year"}, pr.GetPartitionColumns())
+
+	rows := drainPartitioned(t, pr, 7)
+	require.Equal(t, total, len(rows))
+
+	// Files sort by path, so the first 10 rows are year=2024/month=01.
+	assert.Equal(t, int64(2024), rows[0]["year"], "partition value should be coerced to a number")
+	assert.Equal(t, int64(1), rows[0]["month"], "month=01 should parse as 1")
+
+	// Last file is year=2025/month=01.
+	assert.Equal(t, int64(2025), rows[total-1]["year"])
+}
+
+// TestPartitionedGetRowCount pins down what GetRowCount actually reports.
+func TestPartitionedGetRowCount(t *testing.T) {
+	const rowsPerFile = 100
+
+	base, total := writePartitionedDataset(t, rowsPerFile, 1000)
+
+	pr, err := NewPartitionedParquetReader(base)
+	require.NoError(t, err)
+	defer pr.Close()
+
+	// Files are opened lazily, so before reading only the first one is counted.
+	assert.Equal(t, int64(rowsPerFile), pr.GetRowCount(),
+		"straight after construction only the first file has been opened")
+
+	rows := drainPartitioned(t, pr, 50)
+	require.Equal(t, total, len(rows))
+
+	assert.Equal(t, int64(total), pr.GetRowCount(),
+		"once every file has been read the tally should equal the dataset")
+}
+
+// TestPartitionedReadAllRowCount exercises ReadAll, which has no production
+// caller today but is exported.
+func TestPartitionedReadAllRowCount(t *testing.T) {
+	base, total := writePartitionedDataset(t, 100, 1000)
+
+	pr, err := NewPartitionedParquetReader(base)
+	require.NoError(t, err)
+	defer pr.Close()
+
+	rows, err := pr.ReadAll()
+	require.NoError(t, err)
+	assert.Equal(t, total, len(rows))
+
+	// ReadAll restarts the walk from the first file. It must reset the tally
+	// rather than adding the first file's rows on top of the constructor's.
+	assert.Equal(t, int64(total), pr.GetRowCount(),
+		"ReadAll double-counted the file opened by the constructor")
+}

--- a/internal/parquet/reader.go
+++ b/internal/parquet/reader.go
@@ -22,11 +22,12 @@ type ParquetReader struct {
 	schema       *arrow.Schema
 	columnNames  []string
 	columnTypes  []string
-	allColumns   []int             // Explicit list of all leaf column indices; nil means "no columns" in pqarrow
-	rowGroupIdx  int               // Current row group being processed
-	numRowGroups int               // Total number of row groups
-	currentBatch arrow.RecordBatch // Current record batch
-	batchIdx     int               // Current row index within current batch
+	allColumns   []int              // Explicit list of all leaf column indices; nil means "no columns" in pqarrow
+	rowGroupIdx  int                // Next row group to read
+	numRowGroups int                // Total number of row groups
+	tableReader  *array.TableReader // Reader over the current row group
+	currentBatch arrow.RecordBatch  // Current record batch
+	batchIdx     int                // Current row index within current batch
 	totalRows    int64
 	exhausted    bool // True when all data has been read
 }
@@ -137,47 +138,13 @@ func (r *ParquetReader) ReadBatch(batchSize int) ([]map[string]any, error) {
 	for len(rows) < batchSize {
 		// If we don't have a current batch or we've consumed it, get the next one
 		if r.currentBatch == nil || r.batchIdx >= int(r.currentBatch.NumRows()) {
-			// Release previous batch if any
-			if r.currentBatch != nil {
-				r.currentBatch.Release()
-				r.currentBatch = nil
+			more, err := r.nextRecordBatch(ctx)
+			if err != nil {
+				return nil, err
 			}
-
-			// Move to next row group if needed
-			if r.rowGroupIdx >= r.numRowGroups {
+			if !more {
 				r.exhausted = true
 				break
-			}
-
-			// Read the next row group
-			table, err := r.arrowReader.ReadRowGroups(ctx, r.allColumns, []int{r.rowGroupIdx})
-			if err != nil {
-				return nil, fmt.Errorf("failed to read row group %d: %w", r.rowGroupIdx, err)
-			}
-			r.rowGroupIdx++
-
-			if table.NumRows() == 0 {
-				table.Release()
-				continue // Try next row group
-			}
-
-			// Create a record reader from the table
-			chunkSize := int64(batchSize)
-			if chunkSize <= 0 || chunkSize > table.NumRows() {
-				chunkSize = table.NumRows()
-			}
-			tableReader := array.NewTableReader(table, chunkSize)
-
-			if tableReader.Next() {
-				r.currentBatch = tableReader.RecordBatch()
-				r.currentBatch.Retain() // Keep the record alive after releasing tableReader
-				r.batchIdx = 0
-			}
-			tableReader.Release()
-			table.Release()
-
-			if r.currentBatch == nil {
-				continue // Try next row group
 			}
 		}
 
@@ -201,6 +168,54 @@ func (r *ParquetReader) ReadBatch(batchSize int) ([]map[string]any, error) {
 	}
 
 	return rows, nil
+}
+
+// nextRecordBatch advances to the next record batch, opening row groups as it
+// goes, and reports whether one was found.
+//
+// The reader has to hold on to the current row group's TableReader between
+// ReadBatch calls. A row group holds many more rows than a typical batch size,
+// so finishing a batch part-way through a row group is the normal case, and
+// dropping the reader there would discard the rest of that row group.
+func (r *ParquetReader) nextRecordBatch(ctx context.Context) (bool, error) {
+	if r.currentBatch != nil {
+		r.currentBatch.Release()
+		r.currentBatch = nil
+	}
+
+	for {
+		// Finish the row group we are already in before opening another.
+		if r.tableReader != nil {
+			if r.tableReader.Next() {
+				r.currentBatch = r.tableReader.RecordBatch()
+				r.currentBatch.Retain() // Outlives the TableReader
+				r.batchIdx = 0
+				return true, nil
+			}
+			r.tableReader.Release()
+			r.tableReader = nil
+		}
+
+		if r.rowGroupIdx >= r.numRowGroups {
+			return false, nil
+		}
+
+		table, err := r.arrowReader.ReadRowGroups(ctx, r.allColumns, []int{r.rowGroupIdx})
+		if err != nil {
+			return false, fmt.Errorf("failed to read row group %d: %w", r.rowGroupIdx, err)
+		}
+		r.rowGroupIdx++
+
+		if table.NumRows() == 0 {
+			table.Release()
+			continue // Try next row group
+		}
+
+		// Hand the whole row group to the TableReader and let it decide how to
+		// chunk. It retains the table, so releasing our reference is safe.
+		r.tableReader = array.NewTableReader(table, table.NumRows())
+		table.Release()
+	}
 }
 
 // ReadAll reads all rows from the file
@@ -243,6 +258,11 @@ func (r *ParquetReader) ReadAll() ([]map[string]any, error) {
 func (r *ParquetReader) Close() error {
 	if r.currentBatch != nil {
 		r.currentBatch.Release()
+		r.currentBatch = nil
+	}
+	if r.tableReader != nil {
+		r.tableReader.Release()
+		r.tableReader = nil
 	}
 	if r.reader != nil {
 		_ = r.reader.Close()

--- a/internal/parquet/reader_batch_test.go
+++ b/internal/parquet/reader_batch_test.go
@@ -1,0 +1,171 @@
+package parquet
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeNumberedRows writes rowCount rows of {id, name} into a Parquet file whose
+// row groups hold chunkSize rows each, and returns the path.
+func writeNumberedRows(t *testing.T, rowCount, chunkSize int) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "batches.parquet")
+
+	opts := DefaultWriterOptions()
+	opts.ChunkSize = int64(chunkSize)
+
+	writer, err := NewParquetCaptureWriter(path, []string{"id", "name"}, []string{"int", "text"}, opts)
+	require.NoError(t, err)
+
+	for i := range rowCount {
+		require.NoError(t, writer.WriteRow(map[string]interface{}{
+			"id":   i,
+			"name": string(rune('a'+i%26)) + "-row",
+		}))
+	}
+	require.NoError(t, writer.Close())
+
+	return path
+}
+
+// drainBatches calls ReadBatch until io.EOF and returns everything it handed back.
+func drainBatches(t *testing.T, r *ParquetReader, batchSize int) []map[string]any {
+	t.Helper()
+
+	var all []map[string]any
+	for range 1000 { // guard against a reader that never reports EOF
+		batch, err := r.ReadBatch(batchSize)
+		if errors.Is(err, io.EOF) {
+			return all
+		}
+		require.NoError(t, err)
+		require.NotEmpty(t, batch, "ReadBatch returned no rows and no io.EOF, which would spin forever")
+		all = append(all, batch...)
+	}
+
+	t.Fatal("ReadBatch never returned io.EOF")
+	return nil
+}
+
+// TestReadBatchSpansRowGroups is the regression guard for row-group streaming.
+//
+// This path has broken before against an arrow-go upgrade, in a way that made
+// every batch come back with zero rows while ReadAll kept working - so the rest
+// of the suite stayed green. It is worth testing on its own for that reason.
+func TestReadBatchSpansRowGroups(t *testing.T) {
+	const (
+		rowCount  = 350
+		chunkSize = 100
+	)
+
+	path := writeNumberedRows(t, rowCount, chunkSize)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	require.Greater(t, reader.NumRowGroups(), 1,
+		"test needs more than one row group to be meaningful")
+	require.Equal(t, int64(rowCount), reader.GetRowCount())
+
+	// A batch size that divides neither the row count nor the row group size,
+	// so batches straddle row group boundaries.
+	rows := drainBatches(t, reader, 60)
+
+	require.Len(t, rows, rowCount, "streaming read lost or duplicated rows")
+
+	for i, row := range rows {
+		assert.Equal(t, int32(i), row["id"], "row %d out of order or wrong", i)
+	}
+}
+
+// TestReadBatchSizes checks the batch size edge cases around row group
+// boundaries, since that is where the streaming bookkeeping goes wrong.
+func TestReadBatchSizes(t *testing.T) {
+	const (
+		rowCount  = 250
+		chunkSize = 100
+	)
+
+	tests := []struct {
+		name      string
+		batchSize int
+	}{
+		{"one row at a time", 1},
+		{"smaller than a row group", 30},
+		{"exactly a row group", 100},
+		{"larger than a row group", 175},
+		{"larger than the whole file", 5000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeNumberedRows(t, rowCount, chunkSize)
+
+			reader, err := NewParquetReader(path)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			rows := drainBatches(t, reader, tt.batchSize)
+
+			require.Len(t, rows, rowCount)
+			for i, row := range rows {
+				assert.Equal(t, int32(i), row["id"], "row %d out of order or wrong", i)
+			}
+		})
+	}
+}
+
+// TestReadBatchAfterExhaustion checks that a reader keeps reporting io.EOF once
+// it is drained, rather than restarting or erroring.
+func TestReadBatchAfterExhaustion(t *testing.T) {
+	path := writeNumberedRows(t, 50, 100)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	rows := drainBatches(t, reader, 20)
+	require.Len(t, rows, 50)
+
+	for range 3 {
+		_, err := reader.ReadBatch(20)
+		assert.ErrorIs(t, err, io.EOF)
+	}
+}
+
+// TestReadBatchAtProductionDefaults uses the sizes COPY actually runs with.
+//
+// The writer defaults to 10000 rows per row group and COPY FROM PARQUET reads
+// in batches of 1000, so the batch size is well under the row group size - the
+// case that used to drop every row after the first batch of each group.
+func TestReadBatchAtProductionDefaults(t *testing.T) {
+	const (
+		writerChunkSize = 10000 // DefaultWriterOptions().ChunkSize
+		copyBatchSize   = 1000  // copy_from_parquet.go
+		rowCount        = 25000 // spans three row groups, last one partial
+	)
+
+	path := writeNumberedRows(t, rowCount, writerChunkSize)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	require.Equal(t, int64(rowCount), reader.GetRowCount())
+
+	rows := drainBatches(t, reader, copyBatchSize)
+
+	require.Len(t, rows, rowCount,
+		"COPY FROM PARQUET would import %d of %d rows", len(rows), rowCount)
+
+	for i, row := range rows {
+		assert.Equal(t, int32(i), row["id"], "row %d out of order or wrong", i)
+	}
+}


### PR DESCRIPTION
`COPY FROM PARQUET` silently imports a fraction of the rows in the file. No error, no warning, exit code 0.

## What happens

`ParquetReader.ReadBatch` streams a Parquet file row group by row group. For each row group it built an Arrow `TableReader` sized to the caller's batch, pulled **one** record out of it, then released the reader and advanced to the next row group - discarding whatever was left in the current one.

So any batch size smaller than the row group loses rows. The defaults line up exactly wrong:

| Setting | Value | Where |
|---|---|---|
| Rows per row group | 10000 | `DefaultWriterOptions().ChunkSize` |
| COPY FROM batch size | 1000 | `copy_from_parquet.go:133` |

Import a Parquet file that cqlai itself wrote, and you keep the first 1000 rows of every 10000-row group and lose the other 9000.

Measured against the unfixed code with a 25000-row file at those exact defaults:

```
would import 3000 of 25000 rows
```

88% of the data gone, silently.

### Partitioned datasets are hit harder

`copy_from_parquet_partitioned.go:96` goes through the same path, and the truncation happens once per row group **per file**, so it compounds. Measured on a three-file Hive-style dataset of 750 rows:

| COPY batch size | Rows imported |
|---|---|
| 1 | **9** of 750 |
| 30 | **270** of 750 |
| 250 | 750 of 750 |

At batch size 1 that is 1.2% of the data. `PartitionedParquetReader.ReadBatch` delegates to the fixed function, so it needs no change of its own - the second commit adds the tests that demonstrate it.

`ReadAll` was never affected, which is part of why this went unnoticed - it reads the whole table in one call.

## The fix

Hold the row group's `TableReader` on the reader and resume from it on the next call, only opening a new row group once the current one is genuinely drained. Pulled out into `nextRecordBatch`; `Close` releases it.

`NewTableReader` retains the table, so ownership transfers cleanly and the table reference is released immediately.

## Why this survived

`ReadBatch` had **0% test coverage**. It has broken before - 1b3d0eb, "Fix row-group streaming reader against arrow-go v18.5.2", where every batch came back with zero rows - and the suite stayed green through that too, because nothing exercised it.

I found this while checking whether an arrow-go bump was safe. It is: these tests fail identically on v18.5.2 and v18.7.0, so this is not a regression from any upgrade. It has been there.

## Testing

New `internal/parquet/reader_batch_test.go` covers:

- batch sizes of 1, smaller than, equal to, and larger than a row group, and larger than the whole file
- batches straddling row group boundaries, asserting row order and total count
- repeated `ReadBatch` after exhaustion keeps returning `io.EOF`
- the production writer/COPY defaults above, named so the impact is obvious if it ever regresses

Coverage: `ReadBatch` 0% -> 96%, `nextRecordBatch` 87%.

`go build ./...`, the full suite including `./test/parquet/...`, `go test -race ./internal/parquet/...` and `golangci-lint run` all clean.

## Second commit: partitioned reader coverage and a row-count fix

`partitioned_reader.go` was at **0% coverage** across every function - the same gap that hid the bug above. New tests cover reading across partition files at a range of batch sizes, the partition values parsed out of Hive-style directory names, and their numeric coercion.

That coverage also turned up a separate bug. `GetRowCount` is documented as "the total row count across all partitions" and is neither total nor stable:

- **after construction:** returns 100 of 300 - files open lazily, so only the first has been counted
- **after `ReadAll`:** returns 400 of 300 - `ReadAll` restarts the walk from the first file without clearing the tally, so that file is counted twice

`ReadAll` also dropped the reader opened by the constructor instead of closing it. I chased that as a possible file descriptor leak and **it is not one** - measured over 20, 100 and 500 cycles the count plateaus, because `os.File`'s finalizer reclaims it. Fixed as tidiness, not as a leak.

Neither `GetRowCount` nor the partitioned `ReadAll` has a production caller today (`copy_from_parquet.go:599` calls `GetRowCount` on the *single-file* reader), so that part is a correctness fix for a landmine rather than a live bug.

`partitioned_reader.go` coverage: **0% -> 47%**, with the path COPY actually uses at 76-93%.

## Suggested follow-up

`GetSchema`, `GetFileInfo` and `GetPartitionFiles` on the partitioned reader are still untested.
