### PR TITLE
chore: remove leftover ANTLR references from the build

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,6 @@ linters:
   disable:
     - errcheck
   exclusions:
-    paths:
-      - internal/parser/grammar
     rules:
       # Exclude test files from gosec linter
       - path: _test\.go

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ NC := \033[0m # No Color
 .DEFAULT_GOAL := build
 
 # Phony targets
-.PHONY: all build clean install uninstall run test lint fmt deps vendor grammar help release-all licenses
+.PHONY: all build clean install uninstall run test lint fmt deps vendor help release-all licenses
 
 ## all: Clean, format, lint, test, and build
 all: clean fmt lint test build
@@ -153,19 +153,6 @@ vendor: deps
 	@echo "$(BLUE)Creating vendor directory...$(NC)"
 	@go mod vendor
 	@echo "$(GREEN)✓ Vendor directory created$(NC)"
-
-## grammar: Regenerate ANTLR grammar files
-grammar:
-	@echo "$(BLUE)Regenerating ANTLR grammar files...$(NC)"
-	@if command -v antlr4 >/dev/null 2>&1; then \
-		cd internal/parser/grammar && \
-		antlr4 -Dlanguage=Go -package grammar CqlLexer.g4 && \
-		antlr4 -Dlanguage=Go -package grammar -visitor CqlParser.g4; \
-		echo "$(GREEN)✓ Grammar files regenerated$(NC)"; \
-	else \
-		echo "$(RED)✗ antlr4 not found. Install with: go install github.com/antlr4-go/antlr/v4/cmd/antlr4@latest$(NC)"; \
-		exit 1; \
-	fi
 
 ## licenses: Generate third-party license attributions
 licenses:


### PR DESCRIPTION
ANTLR was replaced with a hand-written parser some time ago. Two pieces of tooling still pointed at it.

## The Makefile `grammar` target lied

It ran `cd internal/parser/grammar`, a directory that no longer exists. It also did not fail cleanly:

```
$ make grammar
Regenerating ANTLR grammar files...
/bin/sh: 2: cd: can't cd to internal/parser/grammar
✓ Grammar files regenerated
$ echo $?
0
```

Green tick, exit 0, nothing done. Anyone reaching for it to regenerate grammar would have believed it worked.

## `.golangci.yml` excluded a path that does not exist

`internal/parser/grammar` was still in the lint exclusions.

## What stays

Only the accurate mentions: the READMEs list "no ANTLR dependency" as a feature, and a few comments in `command_parser.go`, `save_command.go` and `simple_parser.go` note that parsing is done without it. Those describe the current design and are correct.

## Verified

`make help` no longer lists `grammar`, `make lint` still runs clean against the edited config (0 issues), and `make build` is unaffected. Deletions only, apart from the `.PHONY` line losing the target name.
