### PR TITLE
fix(copy): bind values in COPY FROM PARQUET instead of formatting them

### DIFF
--- a/internal/db/executor.go
+++ b/internal/db/executor.go
@@ -285,6 +285,26 @@ func (t *captureTracer) Trace(traceID []byte) {
 	t.traceID = traceID
 }
 
+// ExecuteCQLQueryWithValues executes a statement with bind parameters.
+//
+// Use this for anything built from data rather than typed by the user: values
+// travel to Cassandra as parameters instead of being pasted into the statement
+// text, so they cannot alter it. It returns the same shapes as ExecuteCQLQuery,
+// an error or a QueryResult, so callers can handle both the same way.
+//
+// This is for statements that do not return rows. SELECTs still go through
+// ExecuteCQLQuery, which routes them to the streaming path.
+func (s *Session) ExecuteCQLQueryWithValues(query string, values ...interface{}) interface{} {
+	if s == nil || s.Session == nil {
+		return fmt.Errorf("not connected to database")
+	}
+
+	if err := s.Query(query, values...).Exec(); err != nil {
+		return err
+	}
+	return QueryResult{}
+}
+
 // ExecuteCQLQuery executes a regular CQL query
 func (s *Session) ExecuteCQLQuery(query string) interface{} {
 	logger.DebugfToFile("ExecuteCQLQuery", "Called with query: %s", query)

--- a/internal/router/copy_from_parquet.go
+++ b/internal/router/copy_from_parquet.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
@@ -152,9 +150,6 @@ func (h *MetaCommandHandler) processParquetFile(table string, columns []string, 
 		}
 	}
 
-	// Get schema for type information
-	_, parquetTypes := reader.GetSchema()
-
 	// Process data in batches
 	for opts.maxRows <= 0 || stats.processedRows < opts.maxRows {
 		batch, err := reader.ReadBatch(opts.batchSize)
@@ -175,7 +170,7 @@ func (h *MetaCommandHandler) processParquetFile(table string, columns []string, 
 
 			stats.processedRows++
 
-			if err := h.insertRow(table, columns, row, parquetTypes, opts, stats, columnTypes); err != nil {
+			if err := h.insertRow(table, columns, row, opts, stats, columnTypes); err != nil {
 				// Error already handled in insertRow
 				if opts.maxInsertErrors > 0 && stats.insertErrorCount >= opts.maxInsertErrors {
 					return fmt.Errorf("aborted after %d insert errors. Successfully imported %d rows",
@@ -211,20 +206,20 @@ func (h *MetaCommandHandler) skipRows(reader *parquet.ParquetReader, opts *copyO
 }
 
 // insertRow inserts a single row into Cassandra
-func (h *MetaCommandHandler) insertRow(table string, columns []string, row map[string]interface{}, parquetTypes []string, opts *copyOptions, stats *copyStats, columnTypes map[string]string) error {
+func (h *MetaCommandHandler) insertRow(table string, columns []string, row map[string]interface{}, opts *copyOptions, stats *copyStats, columnTypes map[string]string) error {
 	// Build values array for the INSERT
 	values := h.extractRowValues(columns, row)
 
-	// Format values for CQL
-	valueStrings := h.formatValuesForCQL(values, columns, parquetTypes, columnTypes)
-
-	// Build and execute the INSERT query
-	query := h.buildInsertQuery(table, columns, valueStrings)
+	// Bind the values rather than formatting them into the statement. Data in a
+	// Parquet file is not trusted input: pasted into CQL text it can alter the
+	// statement, and it round-trips badly for blobs, floats and timestamps.
+	query := buildInsertTemplate(table, columns)
+	bound := bindValuesForInsert(columns, values, columnTypes)
 
 	logger.DebugfToFile("CopyFromParquet", "INSERT query: %s", query)
 
 	// Execute the query
-	result := h.session.ExecuteCQLQuery(query)
+	result := h.session.ExecuteCQLQueryWithValues(query, bound...)
 
 	// Check for errors
 	if err, isError := result.(error); isError {
@@ -258,153 +253,10 @@ func (h *MetaCommandHandler) extractRowValues(columns []string, row map[string]i
 	return values
 }
 
-// formatValuesForCQL formats values for use in CQL INSERT statement
-func (h *MetaCommandHandler) formatValuesForCQL(values []interface{}, columns []string, parquetTypes []string, columnTypes map[string]string) []string {
-	valueStrings := make([]string, len(values))
-	for i, val := range values {
-		valueStrings[i] = h.formatValue(val, columns[i], getColumnType(i, parquetTypes), columnTypes)
-	}
-	return valueStrings
-}
-
-// getColumnType safely gets column type from parquetTypes array
-func getColumnType(index int, parquetTypes []string) string {
-	if index < len(parquetTypes) {
-		return parquetTypes[index]
-	}
-	return ""
-}
-
-// formatValue formats a single value for CQL based on its type
-func (h *MetaCommandHandler) formatValue(val interface{}, columnName string, parquetType string, columnTypes map[string]string) string {
-	if val == nil {
-		return "null"
-	}
-
-	switch v := val.(type) {
-	case string:
-		return h.formatStringValue(v, columnName, parquetType, columnTypes)
-	case time.Time:
-		return fmt.Sprintf("'%s'", v.Format(time.RFC3339Nano))
-	case bool:
-		return fmt.Sprintf("%t", v)
-	case []byte:
-		return fmt.Sprintf("0x%x", v)
-	case []interface{}:
-		return h.formatListValue(v, columnName, columnTypes)
-	case map[string]interface{}:
-		return h.formatUDTValue(v)
-	case map[interface{}]interface{}:
-		return h.formatMapValue(v)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
-// formatStringValue handles formatting of string values
-func (h *MetaCommandHandler) formatStringValue(value string, columnName string, parquetType string, columnTypes map[string]string) string {
-	trimmed := strings.TrimSpace(value)
-
-	// Check if this is a UUID
-	if h.isUUIDColumn(columnName, parquetType) && isUUIDFormat(trimmed) {
-		return trimmed // No quotes for UUIDs
-	}
-
-	// Check for collections and special formats
-	if formatted, isSpecial := h.formatSpecialStringValue(trimmed, columnName, columnTypes); isSpecial {
-		return formatted
-	}
-
-	// Regular string value
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(trimmed, "'", "''"))
-}
-
-// isUUIDColumn checks if a column should be treated as UUID
-// Only matches columns where the parquet type or column name explicitly contains "uuid".
-// Avoids false positives for columns like "provider_id" or "valid" that might store
-// UUID-formatted strings in TEXT columns.
-func (h *MetaCommandHandler) isUUIDColumn(columnName string, parquetType string) bool {
-	lowerType := strings.ToLower(parquetType)
-	lowerCol := strings.ToLower(columnName)
-
-	return strings.Contains(lowerType, "uuid") ||
-		strings.Contains(lowerCol, "uuid")
-}
-
 // isUUIDFormat checks if a string is a valid UUID using the google/uuid library
 func isUUIDFormat(s string) bool {
 	_, err := uuid.Parse(s)
 	return err == nil
-}
-
-// formatSpecialStringValue handles special string formats (collections, UDTs, etc)
-func (h *MetaCommandHandler) formatSpecialStringValue(value string, columnName string, columnTypes map[string]string) (string, bool) {
-	switch {
-	case strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]"):
-		return h.formatListString(value, columnName, columnTypes), true
-	case strings.HasPrefix(value, "map[") && strings.HasSuffix(value, "]"):
-		return h.formatMapString(value), true
-	case strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") &&
-		strings.Contains(value, ":") && strings.Contains(value, "\""):
-		return h.formatJSONUDTString(value), true
-	default:
-		return "", false
-	}
-}
-
-// formatListString formats a list/set string value
-func (h *MetaCommandHandler) formatListString(value string, columnName string, columnTypes map[string]string) string {
-	inner := strings.Trim(value, "[]")
-	if inner == "" {
-		return h.getEmptyCollectionSyntax(columnName, columnTypes)
-	}
-
-	parts := strings.Fields(inner)
-	quotedParts := make([]string, len(parts))
-	for i, part := range parts {
-		quotedParts[i] = h.quoteValueIfNeeded(part)
-	}
-
-	if h.isSetColumn(columnName, columnTypes) {
-		return "{" + strings.Join(quotedParts, ", ") + "}"
-	}
-	return "[" + strings.Join(quotedParts, ", ") + "]"
-}
-
-// formatMapString formats a map string value
-func (h *MetaCommandHandler) formatMapString(value string) string {
-	inner := strings.TrimPrefix(value, "map[")
-	inner = strings.TrimSuffix(inner, "]")
-
-	if inner == "" {
-		return "{}"
-	}
-
-	pairs := strings.Fields(inner)
-	mapPairs := make([]string, 0, len(pairs))
-
-	for _, pair := range pairs {
-		kv := strings.SplitN(pair, ":", 2)
-		if len(kv) == 2 {
-			key := fmt.Sprintf("'%s'", strings.ReplaceAll(kv[0], "'", "''"))
-			val := h.quoteValueIfNeeded(kv[1])
-			mapPairs = append(mapPairs, fmt.Sprintf("%s: %s", key, val))
-		}
-	}
-
-	return "{" + strings.Join(mapPairs, ", ") + "}"
-}
-
-// formatJSONUDTString formats a JSON-like UDT string
-func (h *MetaCommandHandler) formatJSONUDTString(value string) string {
-	// Remove quotes from all field names using regex (generic approach)
-	// Matches patterns like: "field_name": and replaces with: field_name:
-	re := regexp.MustCompile(`"([a-zA-Z_][a-zA-Z0-9_]*)" *:`)
-	udtValue := re.ReplaceAllString(value, "$1:")
-
-	// Replace remaining double quotes with single quotes for string values
-	udtValue = strings.ReplaceAll(udtValue, "\"", "'")
-	return udtValue
 }
 
 // formatListValue formats a list/array value
@@ -437,79 +289,6 @@ func (h *MetaCommandHandler) formatListItem(item interface{}) string {
 	}
 }
 
-// formatUDTValue formats a UDT (User-Defined Type) value
-func (h *MetaCommandHandler) formatUDTValue(v map[string]interface{}) string {
-	if len(v) == 0 {
-		return "{}"
-	}
-
-	udtPairs := make([]string, 0, len(v))
-	for fieldName, fieldValue := range v {
-		formattedValue := h.formatUDTField(fieldValue)
-		udtPairs = append(udtPairs, fmt.Sprintf("%s: %s", fieldName, formattedValue))
-	}
-
-	return "{" + strings.Join(udtPairs, ", ") + "}"
-}
-
-// formatUDTField formats a single field in a UDT
-func (h *MetaCommandHandler) formatUDTField(fieldValue interface{}) string {
-	if fieldValue == nil {
-		return "null"
-	}
-
-	switch fv := fieldValue.(type) {
-	case string:
-		return fmt.Sprintf("'%s'", strings.ReplaceAll(fv, "'", "''"))
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%v", fv)
-	case float32, float64:
-		return fmt.Sprintf("%v", fv)
-	case bool:
-		return fmt.Sprintf("%t", fv)
-	default:
-		return fmt.Sprintf("'%v'", fv)
-	}
-}
-
-// formatMapValue formats a map value
-func (h *MetaCommandHandler) formatMapValue(v map[interface{}]interface{}) string {
-	if len(v) == 0 {
-		return "{}"
-	}
-
-	mapPairs := make([]string, 0, len(v))
-	for key, val := range v {
-		quotedKey := h.formatMapKey(key)
-		quotedVal := h.formatMapValue2(val)
-		mapPairs = append(mapPairs, fmt.Sprintf("%s: %s", quotedKey, quotedVal))
-	}
-
-	return "{" + strings.Join(mapPairs, ", ") + "}"
-}
-
-// formatMapKey formats a map key
-func (h *MetaCommandHandler) formatMapKey(key interface{}) string {
-	switch k := key.(type) {
-	case string:
-		return fmt.Sprintf("'%s'", strings.ReplaceAll(k, "'", "''"))
-	default:
-		return fmt.Sprintf("'%v'", k)
-	}
-}
-
-// formatMapValue2 formats a map value (named to avoid conflict with main function)
-func (h *MetaCommandHandler) formatMapValue2(val interface{}) string {
-	switch vt := val.(type) {
-	case string:
-		return fmt.Sprintf("'%s'", strings.ReplaceAll(vt, "'", "''"))
-	case int, int32, int64, float32, float64:
-		return fmt.Sprintf("%v", vt)
-	default:
-		return fmt.Sprintf("'%v'", vt)
-	}
-}
-
 // Helper functions
 
 // isSetColumn determines if a column is a CQL set type by looking up the
@@ -533,36 +312,6 @@ func (h *MetaCommandHandler) getEmptyCollectionSyntax(columnName string, columnT
 		return "{}"
 	}
 	return "[]"
-}
-
-// quoteValueIfNeeded quotes a value if it's not a number
-func (h *MetaCommandHandler) quoteValueIfNeeded(value string) string {
-	// Check if it's a number
-	if _, err := strconv.Atoi(value); err == nil {
-		return value
-	}
-	if _, err := strconv.ParseFloat(value, 64); err == nil {
-		return value
-	}
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(value, "'", "''"))
-}
-
-// buildInsertQuery builds the INSERT query
-func (h *MetaCommandHandler) buildInsertQuery(table string, columns []string, valueStrings []string) string {
-	fullyQualifiedTable := h.getFullyQualifiedTableName(table)
-	columnList := strings.Join(columns, ", ")
-	valueList := strings.Join(valueStrings, ", ")
-
-	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-		fullyQualifiedTable, columnList, valueList)
-}
-
-// getFullyQualifiedTableName returns the fully qualified table name
-func (h *MetaCommandHandler) getFullyQualifiedTableName(table string) string {
-	if h.session.Keyspace() != "" && !strings.Contains(table, ".") {
-		return fmt.Sprintf("%s.%s", h.session.Keyspace(), table)
-	}
-	return table
 }
 
 // formatCopyResult formats the final result message

--- a/internal/router/copy_from_parquet_bind.go
+++ b/internal/router/copy_from_parquet_bind.go
@@ -44,9 +44,52 @@ func bindValuesForInsert(columns []string, values []interface{}, columnTypes map
 	return bound
 }
 
+// cqlPrimitives are the CQL types gocql marshals from a plain Go value,
+// including from an untyped nil.
+var cqlPrimitives = map[string]bool{
+	"ascii": true, "bigint": true, "blob": true, "boolean": true,
+	"counter": true, "date": true, "decimal": true, "double": true,
+	"duration": true, "float": true, "inet": true, "int": true,
+	"smallint": true, "text": true, "time": true, "timestamp": true,
+	"timeuuid": true, "tinyint": true, "uuid": true, "varchar": true,
+	"varint": true,
+}
+
+// normaliseCQLType lowercases a type and unwraps frozen<...>, so frozen<profile>
+// and profile are treated alike.
+func normaliseCQLType(cqlType string) string {
+	t := strings.ToLower(strings.TrimSpace(cqlType))
+	for strings.HasPrefix(t, "frozen<") && strings.HasSuffix(t, ">") {
+		t = strings.TrimSpace(t[len("frozen<") : len(t)-1])
+	}
+	return t
+}
+
+// isUserDefinedType reports whether a column type is a UDT, meaning neither a
+// primitive nor one of the built-in containers.
+func isUserDefinedType(cqlType string) bool {
+	t := normaliseCQLType(cqlType)
+	if t == "" || cqlPrimitives[t] {
+		return false
+	}
+	for _, container := range []string{"list<", "set<", "map<", "tuple<", "vector<"} {
+		if strings.HasPrefix(t, container) {
+			return false
+		}
+	}
+	return true
+}
+
 // bindValue converts a single Parquet value for the destination CQL type.
 func bindValue(val interface{}, cqlType string) interface{} {
 	if val == nil {
+		// gocql marshals an untyped nil for every primitive and container, but
+		// refuses it for a UDT. Binding a nil or empty map there is not a
+		// substitute: that writes a non-null UDT whose fields are all zero.
+		// UnsetValue leaves the column unwritten, which is a real null.
+		if isUserDefinedType(cqlType) {
+			return gocql.UnsetValue
+		}
 		return nil
 	}
 
@@ -57,7 +100,7 @@ func bindValue(val interface{}, cqlType string) interface{} {
 
 	// gocql will not bind a plain string to a uuid column, and Parquet has no
 	// UUID type of its own so these arrive as text.
-	switch strings.ToLower(strings.TrimSpace(cqlType)) {
+	switch normaliseCQLType(cqlType) {
 	case "uuid", "timeuuid":
 		parsed, err := gocql.ParseUUID(strings.TrimSpace(s))
 		if err != nil {

--- a/internal/router/copy_from_parquet_bind.go
+++ b/internal/router/copy_from_parquet_bind.go
@@ -1,0 +1,72 @@
+package router
+
+import (
+	"strings"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+)
+
+// buildInsertTemplate returns an INSERT whose values are placeholders.
+//
+// The table and column names are identifiers rather than data - they come from
+// the COPY command the user typed, not from the Parquet file - so they are the
+// only things interpolated. Every value travels as a bind parameter.
+func buildInsertTemplate(table string, columns []string) string {
+	placeholders := make([]string, len(columns))
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+
+	return "INSERT INTO " + table +
+		" (" + strings.Join(columns, ", ") + ")" +
+		" VALUES (" + strings.Join(placeholders, ", ") + ")"
+}
+
+// bindValuesForInsert converts a row's values into what gocql should bind.
+//
+// Most values go through untouched: gocql marshals Go strings, numbers, bools,
+// byte slices, times, slices and maps against whatever the destination column
+// is. The exceptions are the CQL types gocql will not accept a plain string
+// for, which is what this handles.
+//
+// columnTypes holds the destination table's real CQL types, read from
+// system_schema.columns. Where a column is missing from it - no keyspace, or a
+// table we could not read - the value is passed through and gocql decides.
+func bindValuesForInsert(columns []string, values []interface{}, columnTypes map[string]string) []interface{} {
+	bound := make([]interface{}, len(values))
+	for i, val := range values {
+		var cqlType string
+		if i < len(columns) {
+			cqlType = columnTypes[columns[i]]
+		}
+		bound[i] = bindValue(val, cqlType)
+	}
+	return bound
+}
+
+// bindValue converts a single Parquet value for the destination CQL type.
+func bindValue(val interface{}, cqlType string) interface{} {
+	if val == nil {
+		return nil
+	}
+
+	s, isString := val.(string)
+	if !isString {
+		return val
+	}
+
+	// gocql will not bind a plain string to a uuid column, and Parquet has no
+	// UUID type of its own so these arrive as text.
+	switch strings.ToLower(strings.TrimSpace(cqlType)) {
+	case "uuid", "timeuuid":
+		parsed, err := gocql.ParseUUID(strings.TrimSpace(s))
+		if err != nil {
+			// Leave it alone and let the insert fail with Cassandra's own
+			// message, rather than silently substituting something else.
+			return val
+		}
+		return parsed
+	}
+
+	return val
+}

--- a/internal/router/copy_from_parquet_bind_test.go
+++ b/internal/router/copy_from_parquet_bind_test.go
@@ -1,0 +1,128 @@
+package router
+
+import (
+	"strings"
+	"testing"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hostile values a malicious Parquet file could carry. Each one changes the
+// meaning of the statement if it is pasted into CQL text instead of bound.
+var hostileValues = map[string]string{
+	"closes the string literal":   "'; DROP TABLE users; --",
+	"doubled quote is not enough": "'' OR 1=1; --",
+	"ends the statement":          "x'); DROP KEYSPACE app; --",
+	"comment terminator":          "x' -- ",
+	"newline and a second stmt":   "x'\nAPPLY BATCH;\nDROP TABLE users;",
+	"collection punctuation":      "[1, 2]}); DROP TABLE users; --",
+	"looks like a UDT":            "{a: 1}); DROP TABLE users; --",
+	"backslash":                   `x\'; DROP TABLE users; --`,
+}
+
+// TestInsertTemplateCarriesNoData is the core guarantee: the statement text is
+// built from the table and column names only, so nothing from the file can
+// reach it.
+func TestInsertTemplateCarriesNoData(t *testing.T) {
+	query := buildInsertTemplate("app.users", []string{"id", "name", "note"})
+
+	assert.Equal(t, "INSERT INTO app.users (id, name, note) VALUES (?, ?, ?)", query)
+
+	// One placeholder per column, and no literal quoting anywhere.
+	assert.Equal(t, 3, strings.Count(query, "?"))
+	assert.NotContains(t, query, "'")
+}
+
+// TestHostileValuesAreBoundNotFormatted checks the hostile strings above reach
+// gocql as parameters, byte for byte, and never touch the statement.
+func TestHostileValuesAreBoundNotFormatted(t *testing.T) {
+	for name, hostile := range hostileValues {
+		t.Run(name, func(t *testing.T) {
+			columns := []string{"id", "note"}
+			values := []interface{}{int32(1), hostile}
+
+			query := buildInsertTemplate("users", columns)
+			bound := bindValuesForInsert(columns, values, map[string]string{
+				"id":   "int",
+				"note": "text",
+			})
+
+			// The statement is unchanged by the payload.
+			assert.Equal(t, "INSERT INTO users (id, note) VALUES (?, ?)", query)
+			assert.NotContains(t, query, "DROP")
+
+			// The value arrives intact - not escaped, not mangled, not truncated.
+			require.Len(t, bound, 2)
+			assert.Equal(t, hostile, bound[1],
+				"a bound value must reach the driver exactly as it was read")
+		})
+	}
+}
+
+// TestHostileUDTFieldNamesAreBound covers the specific hole in issue #83: UDT
+// field names came from the file and were written into the statement raw.
+func TestHostileUDTFieldNamesAreBound(t *testing.T) {
+	udt := map[string]interface{}{
+		"name":                         "alice",
+		"x: 1}); DROP TABLE users; --": "surprise",
+	}
+
+	columns := []string{"id", "profile"}
+	query := buildInsertTemplate("users", columns)
+	bound := bindValuesForInsert(columns, []interface{}{int32(1), udt},
+		map[string]string{"id": "int", "profile": "profile_type"})
+
+	assert.NotContains(t, query, "DROP")
+	assert.NotContains(t, query, "profile_type")
+
+	// The whole map is one parameter; its keys are never statement text.
+	require.Len(t, bound, 2)
+	assert.Equal(t, udt, bound[1])
+}
+
+// TestBindValueConvertsUUIDs covers the one conversion that has to happen:
+// Parquet has no UUID type, so these arrive as strings, and gocql will not bind
+// a plain string to a uuid column.
+func TestBindValueConvertsUUIDs(t *testing.T) {
+	const raw = "550e8400-e29b-41d4-a716-446655440000"
+
+	for _, cqlType := range []string{"uuid", "timeuuid", "UUID", " TimeUUID "} {
+		t.Run(cqlType, func(t *testing.T) {
+			got := bindValue(raw, cqlType)
+
+			parsed, ok := got.(gocql.UUID)
+			require.True(t, ok, "expected a gocql.UUID, got %T", got)
+			assert.Equal(t, raw, parsed.String())
+		})
+	}
+}
+
+func TestBindValueLeavesEverythingElseAlone(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     interface{}
+		cqlType string
+	}{
+		{"text is not touched", "hello", "text"},
+		{"a uuid-shaped string in a text column stays a string", "550e8400-e29b-41d4-a716-446655440000", "text"},
+		{"numbers pass through", int64(42), "bigint"},
+		{"bools pass through", true, "boolean"},
+		{"blobs pass through", []byte{0xde, 0xad}, "blob"},
+		{"lists pass through", []interface{}{"a", "b"}, "list<text>"},
+		{"unknown column type passes through", "hello", ""},
+		{"a malformed uuid is left for Cassandra to reject", "not-a-uuid", "uuid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.val, bindValue(tt.val, tt.cqlType))
+		})
+	}
+}
+
+func TestBindValueKeepsNil(t *testing.T) {
+	assert.Nil(t, bindValue(nil, "text"))
+	assert.Nil(t, bindValue(nil, "uuid"))
+}

--- a/internal/router/copy_from_parquet_bind_test.go
+++ b/internal/router/copy_from_parquet_bind_test.go
@@ -125,4 +125,35 @@ func TestBindValueLeavesEverythingElseAlone(t *testing.T) {
 func TestBindValueKeepsNil(t *testing.T) {
 	assert.Nil(t, bindValue(nil, "text"))
 	assert.Nil(t, bindValue(nil, "uuid"))
+	assert.Nil(t, bindValue(nil, "list<text>"))
+	assert.Nil(t, bindValue(nil, ""))
+}
+
+// TestBindValueUnsetsNilUDT covers the one type gocql will not take an untyped
+// nil for. Binding a nil or empty map instead is not a substitute: measured
+// against Cassandra 5.0, that writes a non-null UDT whose fields are all zero,
+// where UnsetValue leaves the column unwritten and so genuinely null.
+func TestBindValueUnsetsNilUDT(t *testing.T) {
+	for _, cqlType := range []string{"profile", "frozen<profile>", "FROZEN<Profile>"} {
+		t.Run(cqlType, func(t *testing.T) {
+			assert.Equal(t, gocql.UnsetValue, bindValue(nil, cqlType))
+		})
+	}
+}
+
+func TestIsUserDefinedType(t *testing.T) {
+	udt := []string{"profile", "frozen<profile>", "my_ks.address"}
+	notUDT := []string{
+		"text", "int", "uuid", "timeuuid", "timestamp", "blob", "varint",
+		"list<text>", "set<int>", "map<text, int>", "tuple<int, text>",
+		"frozen<list<text>>", "frozen<map<text, int>>", "vector<float, 3>",
+		"", "  ",
+	}
+
+	for _, ty := range udt {
+		assert.True(t, isUserDefinedType(ty), "%q should be a UDT", ty)
+	}
+	for _, ty := range notUDT {
+		assert.False(t, isUserDefinedType(ty), "%q should not be a UDT", ty)
+	}
 }


### PR DESCRIPTION
Part of #83. This is piece 1 of 3: the single-file `COPY FROM PARQUET` path. The partitioned path follows in its own PR.

## The hole

`copy_from_parquet.go` pasted values from the Parquet file straight into the CQL statement text. Most string paths escaped quotes, but two did not:

```go
// formatUDTValue - the field name comes from a map key in the file
udtPairs = append(udtPairs, fmt.Sprintf("%s: %s", fieldName, formattedValue))

// formatValue's default case
default:
    return fmt.Sprintf("%v", v)
```

Escaping was the wrong tool regardless of those gaps. Doubling `''` is only valid *inside* a string literal, and this code also emitted unquoted contexts: UUIDs, numbers, blobs, and the punctuation holding collections and UDTs together. No amount of escaping makes those safe.

## The fix

Values travel as bind parameters, the way `copy.go` already does for CSV. Only the table and column names are interpolated, and those come from the COPY command the user typed rather than from the file.

Adds `Session.ExecuteCQLQueryWithValues`, mirroring `ExecuteCQLQuery`'s contract including its nil-session guard, so callers handle the result the same way.

## The one conversion that stays

Parquet has no UUID type, so `uuid` and `timeuuid` values arrive as strings, and gocql will not bind a plain string to those columns. `bindValue` handles it - and keys off the destination column's **real CQL type** from `system_schema.columns`, rather than guessing from the column name the way `isUUIDColumn` did. Everything else is left to gocql's marshaller.

A malformed UUID is passed through untouched so Cassandra rejects it with its own message, rather than being silently replaced.

## 17 functions deleted

Not optional tidying - `golangci-lint`'s `unused` check fails with them in place, so the deletion has to land with the change that orphans them. Net **+28 / -259** in the non-test files.

## Tests

`copy_from_parquet_bind_test.go` runs eight hostile payloads through the builder - closing the string literal, ending the statement, comment terminators, embedded newlines with a second statement, collection and UDT punctuation, backslashes - and asserts two things each time: the statement is byte-identical to the clean one, and the value reaches the driver exactly as it was read.

There is a dedicated test for the specific hole in the issue: a UDT whose **field name** is `x: 1}); DROP TABLE users; --`. The whole map becomes one parameter, so its keys are never statement text.

## Verified against a live cluster

Since opening this I ran the round-trip against **Cassandra 5.0.9**, on a table covering `text`, `uuid`, `timeuuid`, `timestamp`, `boolean`, `double`, `blob`, `list<text>`, `set<int>`, `map<text,int>` and a frozen UDT, with rows carrying `'; DROP TABLE t; --` in a text column, inside a list, as a **map key**, and inside a UDT field.

| | rows imported |
|---|---|
| `main` as it stands | **0 of 4** |
| this branch | **3 of 4** |

Rows 1-3 come back byte-identical to the baseline, hostile values and all, and the table is still there afterwards. Row 4 fails for an unrelated reason, below.

**`COPY FROM PARQUET` on `main` did not work at all for this table.** Every row was rejected with `Invalid STRING constant (63a34600-...) for "tuid" of type timeuuid`. The name heuristic looked for `uuid` in the column name, and `tuid` does not contain it, so every timeuuid was quoted as a string. Reading the destination type from `system_schema.columns` fixes that as a side effect.

Two things the live run caught that the unit tests could not:

**A null UDT failed to import.** gocql takes an untyped nil for every primitive and container but refuses it for a UDT. Fixed in the second commit with `gocql.UnsetValue` - measured, because binding a nil or empty map instead stores a non-null UDT of all-zero fields rather than a null.

**Row 4 still fails, and it is not this PR's doing.** `COPY TO PARQUET` writes nulls as Go zero values: a null `timeuuid` is exported as `00000000-0000-0000-0000-000000000000`, null text as `""`, null timestamp as year 1. Cassandra then rejects the zero UUID because a timeuuid must be version 1. That is a pre-existing export bug, filed separately.

## Not in this PR

`copy_from_parquet_partitioned.go` still formats its own values through `formatParquetValueForInsert`, which has the same class of bug in its `map[string]interface{}` and `default` cases. That is piece 2.
