### PR TITLE
fix(copy): bind values in partitioned COPY FROM PARQUET too

### DIFF
--- a/internal/router/copy_from_parquet.go
+++ b/internal/router/copy_from_parquet.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
-	"github.com/google/uuid"
 )
 
 // copyOptions holds parsed options for COPY operation
@@ -251,12 +250,6 @@ func (h *MetaCommandHandler) extractRowValues(columns []string, row map[string]i
 		}
 	}
 	return values
-}
-
-// isUUIDFormat checks if a string is a valid UUID using the google/uuid library
-func isUUIDFormat(s string) bool {
-	_, err := uuid.Parse(s)
-	return err == nil
 }
 
 // formatListValue formats a list/array value

--- a/internal/router/copy_from_parquet_partitioned.go
+++ b/internal/router/copy_from_parquet_partitioned.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
@@ -62,8 +61,9 @@ func (h *MetaCommandHandler) executeCopyFromParquetPartitioned(table string, col
 		}
 	}
 
-	// Build column list for INSERT
-	columnList := strings.Join(columns, ", ")
+	// Build the INSERT once. Values are bound, so the statement text never
+	// changes from row to row and nothing from the file reaches it.
+	insertTemplate := buildInsertTemplate(table, columns)
 
 	// Parse numeric options
 	batchSize, _ := strconv.Atoi(options["CHUNKSIZE"])
@@ -89,7 +89,7 @@ func (h *MetaCommandHandler) executeCopyFromParquetPartitioned(table string, col
 	skippedRows := 0
 	errorMessages := make([]string, 0, 5) // Store first few error messages
 
-	batch := make([]string, 0, batchSize)
+	batch := make([]batchEntry, 0, batchSize)
 
 	for {
 		// Read a batch of rows
@@ -120,21 +120,11 @@ func (h *MetaCommandHandler) executeCopyFromParquetPartitioned(table string, col
 				goto done
 			}
 
-			// Build INSERT statement
-			values := make([]string, len(columns))
-			for i, col := range columns {
-				if val, ok := row[col]; ok {
-					values[i] = h.formatParquetValueForInsert(val, col, columnTypes)
-				} else {
-					values[i] = "NULL"
-				}
-			}
+			// Bind the row's values. Data in a Parquet file is not trusted
+			// input: pasted into CQL text it can alter the statement.
+			bound := bindValuesForInsert(columns, h.extractRowValues(columns, row), columnTypes)
 
-			insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-				table, columnList, strings.Join(values, ", "))
-			logger.DebugfToFile("CopyFromPartitioned", "Insert query: %s", insertQuery)
-
-			batch = append(batch, insertQuery)
+			batch = append(batch, batchEntry{query: insertTemplate, values: bound})
 
 			// Execute batch when full
 			if len(batch) >= batchSize {
@@ -219,71 +209,14 @@ func matchesPartitionFilter(row map[string]interface{}, filter string) bool {
 	return true
 }
 
-// formatParquetValueForInsert formats a Parquet value for use in an INSERT statement.
-// columnTypes carries the destination CQL column types so collections are emitted
-// as list (`[...]`) or set (`{...}`) literals matching the actual schema.
-func (h *MetaCommandHandler) formatParquetValueForInsert(value interface{}, columnName string, columnTypes map[string]string) string {
-	if value == nil {
-		return "NULL"
-	}
-
-	switch v := value.(type) {
-	case string:
-		trimmed := strings.TrimSpace(v)
-
-		// Check if this is a UUID (for UUID/TIMEUUID columns)
-		if strings.Contains(strings.ToLower(columnName), "uuid") ||
-			strings.Contains(strings.ToLower(columnName), "id") {
-			// Check if it looks like a UUID (8-4-4-4-12 format)
-			if isUUIDFormat(trimmed) {
-				return trimmed // No quotes for UUIDs
-			}
-		}
-
-		// Regular string - escape single quotes
-		escaped := strings.ReplaceAll(v, "'", "''")
-		return fmt.Sprintf("'%s'", escaped)
-	case time.Time:
-		// Format timestamp for CQL (use RFC3339 format with quotes)
-		return fmt.Sprintf("'%s'", v.Format(time.RFC3339Nano))
-	case bool:
-		return fmt.Sprintf("%t", v)
-	case float32, float64:
-		return fmt.Sprintf("%f", v)
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v)
-	case []byte:
-		// Format as hex blob
-		return fmt.Sprintf("0x%x", v)
-	case map[string]interface{}:
-		// Format as JSON for complex types
-		// This is a simplified version - actual implementation would need proper JSON encoding
-		return fmt.Sprintf("'%v'", v)
-	case []interface{}:
-		// Emit set literal for set<...> columns; list literal otherwise.
-		items := make([]string, len(v))
-		for i, item := range v {
-			items[i] = h.formatParquetValueForInsert(item, columnName, columnTypes)
-		}
-		joined := strings.Join(items, ", ")
-		if h.isSetColumn(columnName, columnTypes) {
-			return fmt.Sprintf("{%s}", joined)
-		}
-		return fmt.Sprintf("[%s]", joined)
-	default:
-		// Default to string representation
-		return fmt.Sprintf("'%v'", v)
-	}
-}
-
 // executePartitionedBatch executes a batch of INSERT statements for partitioned data
-func (h *MetaCommandHandler) executePartitionedBatch(batch []string, rowIndex int, errorMessages *[]string) int {
+func (h *MetaCommandHandler) executePartitionedBatch(batch []batchEntry, rowIndex int, errorMessages *[]string) int {
 	errorCount := 0
-	for i, query := range batch {
-		result := h.session.ExecuteCQLQuery(query)
+	for i, entry := range batch {
+		result := h.session.ExecuteCQLQueryWithValues(entry.query, entry.values...)
 		if err, ok := result.(error); ok {
 			logger.DebugfToFile("CopyFromPartitioned", "Insert error: %v", err)
-			logger.DebugfToFile("CopyFromPartitioned", "Failed query: %s", query)
+			logger.DebugfToFile("CopyFromPartitioned", "Failed query: %s", entry.query)
 			errorCount++
 
 			// Store first few error messages for user display (limit to 5)


### PR DESCRIPTION
Closes #83. Second and final piece - **stacked on #94**, so review that first. The diff here is against #94's branch; merging #94 first makes this one small.

## The remaining holes

`copy_from_parquet_partitioned.go` built its own INSERT text through `formatParquetValueForInsert`, which had the same class of bug as the single-file path plus two of its own:

```go
case map[string]interface{}:
    return fmt.Sprintf("'%v'", v)   // %v prints map[k:v] - nothing escaped
default:
    return fmt.Sprintf("'%v'", v)   // any type not listed - nothing escaped
```

Neither escaped anything, so a single quote anywhere in a map key or value broke straight out of the literal. The `default` case caught every type not in the switch.

## The fix

Same helpers as #94 - `buildInsertTemplate` and `bindValuesForInsert` - and the batch now carries `batchEntry` (statement plus values) rather than pre-formatted SQL. The statement text is built once per COPY instead of once per row, since it no longer varies.

## UUID guessing was worse here

The single-file path matched columns whose name or Parquet type contained `uuid`. This one matched **any column whose name contained `id`**:

```go
if strings.Contains(strings.ToLower(columnName), "uuid") ||
    strings.Contains(strings.ToLower(columnName), "id") {
```

So `provider_id`, `valid`, `width` - anything with `id` in it - was a UUID candidate. Destination CQL types from `system_schema.columns` replace the guess entirely.

## Deletions

`formatParquetValueForInsert` (53 lines) and `isUUIDFormat`. Required rather than tidying: `golangci-lint`'s `unused` check fails with them in place.

Net **+12 / -86**. Across both PRs, 19 formatter functions and roughly 345 lines of ad-hoc quoting are gone.

## Verified against a live cluster

See #94 for the full write-up. Against **Cassandra 5.0.9**, `COPY FROM PARQUET` went from **0 of 4 rows** on `main` to **3 of 4**, with the three hostile rows round-tripping byte-identically and the table surviving. The remaining failure is a pre-existing `COPY TO PARQUET` bug that exports nulls as zero values, filed separately.

The partitioned path shares these helpers, so it inherits both the fix and that verification.

## Follow-up worth doing separately

`bindValue` only converts `uuid` and `timeuuid`, because those are the types gocql will not accept a string for. If Parquet delivers a string where the column is `timestamp`, `date`, `time`, `inet` or `decimal`, it is passed through and gocql decides. Those may want explicit conversion too - but that is a typing improvement, not a security fix, and it should not hold this up.
