### PR TITLE
fix(db): stop losing NULLs when scanning rows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/axonops/cqlai => ./
 require (
 	github.com/anthropics/anthropic-sdk-go v1.30.0
 	github.com/apache/arrow-go/v18 v18.7.0
-	github.com/apache/cassandra-gocql-driver/v2 v2.1.0
+	github.com/apache/cassandra-gocql-driver/v2 v2.1.2
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/anthropics/anthropic-sdk-go v1.30.0 h1:5kGeZTNWE9UVChnM1xEbpjKEr9zka5
 github.com/anthropics/anthropic-sdk-go v1.30.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
 github.com/apache/arrow-go/v18 v18.7.0 h1:Vw/i+cJyebUofT7JlqFpe65LrmwxULn166jjwStM4HY=
 github.com/apache/arrow-go/v18 v18.7.0/go.mod h1:PM6IigLJkdMwIpeHXnymo+xZ52f42a9EYiLtRel4p/A=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0 h1:VEbbeJ2ift4deKMZ6Fs55Vs3fq/RrkjCcxCnqUxhwf8=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2 h1:lu/p0Db2av18enHJvWJQoChLssI0P+AR06STq4VdvCc=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
 github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/batch/output_csv.go
+++ b/internal/batch/output_csv.go
@@ -82,7 +82,9 @@ func (e *Executor) outputStreamingCSV(ctx context.Context, result db.StreamingQu
 				}
 			}
 		} else {
-			scanDest[i] = new(interface{})
+			// Not *interface{}: gocql panics on a NULL there, and silently
+			// stores the previous row's zero value once it has one.
+			scanDest[i] = db.NewScanDest(col.TypeInfo)
 		}
 	}
 
@@ -135,7 +137,7 @@ func (e *Executor) outputStreamingCSV(ctx context.Context, result db.StreamingQu
 					}
 				} else {
 					// Regular column
-					val := *(scanDest[i].(*interface{}))
+					val := db.ScanValue(scanDest[i])
 					if val == nil {
 						row[colIdx] = ""
 					} else {

--- a/internal/batch/output_json.go
+++ b/internal/batch/output_json.go
@@ -98,7 +98,9 @@ func (e *Executor) outputStreamingJSON(ctx context.Context, result db.StreamingQ
 				}
 			}
 		} else {
-			scanDest[i] = new(interface{})
+			// Not *interface{}: gocql panics on a NULL there, and silently
+			// stores the previous row's zero value once it has one.
+			scanDest[i] = db.NewScanDest(col.TypeInfo)
 		}
 	}
 
@@ -150,7 +152,7 @@ func (e *Executor) outputStreamingJSON(ctx context.Context, result db.StreamingQ
 					}
 				} else {
 					// Regular column
-					val := *(scanDest[i].(*interface{}))
+					val := db.ScanValue(scanDest[i])
 					rowMap[colName] = val
 				}
 			}

--- a/internal/db/executor.go
+++ b/internal/db/executor.go
@@ -534,32 +534,16 @@ func (s *Session) ExecuteSelectQuery(query string) interface{} {
 			// Create a slice to scan into - use RawBytes for UDT columns
 			scanDest := make([]interface{}, len(filteredColumns))
 			for i, col := range filteredColumns {
-				// Handle nil TypeInfo (can happen with virtual tables)
-				if col.TypeInfo == nil {
-					scanDest[i] = new(interface{})
-					continue
-				}
-
-				// Use defer/recover to catch any panic from Type() call
-				// TypeInfo might be non-nil but internally invalid
-				func(idx int) {
+				// TypeInfo can be non-nil but internally invalid on virtual
+				// tables, where Type() panics; fall back to a plain destination.
+				func(idx int, info gocql.TypeInfo) {
 					defer func() {
 						if r := recover(); r != nil {
-							// TypeInfo is invalid, treat as regular column
 							scanDest[idx] = new(interface{})
 						}
 					}()
-
-					switch col.TypeInfo.Type() {
-					case gocql.TypeUDT:
-						// Use map[string]interface{} for UDT columns
-						// Note: gocql doesn't populate UDTs properly when scanning into interface{}
-						// but it does work when scanning into *map[string]interface{}
-						scanDest[idx] = new(map[string]interface{})
-					default:
-						scanDest[idx] = new(interface{})
-					}
-				}(i)
+					scanDest[idx] = NewScanDest(info)
+				}(i, col.TypeInfo)
 			}
 
 			// Scan the row
@@ -574,24 +558,8 @@ func (s *Session) ExecuteSelectQuery(query string) interface{} {
 			row := make([]string, len(filteredColumns))
 
 			for i, col := range filteredColumns {
-				// Extract value based on type
-				var val interface{}
-				switch {
-				case col.TypeInfo == nil:
-					// Handle nil TypeInfo (virtual tables)
-					val = *(scanDest[i].(*interface{}))
-				case col.TypeInfo.Type() == gocql.TypeUDT:
-					// For UDT columns, we used *map[string]interface{}
-					udtMap := scanDest[i].(*map[string]interface{})
-					if udtMap != nil && *udtMap != nil {
-						val = *udtMap
-					} else {
-						val = nil
-					}
-				default:
-					// Regular column - dereference the pointer
-					val = *(scanDest[i].(*interface{}))
-				}
+				// nil here is a real NULL, not a zero value standing in for one.
+				val := ScanValue(scanDest[i])
 
 				if val == nil {
 					rawRow[cleanHeaders[i]] = nil

--- a/internal/db/scan.go
+++ b/internal/db/scan.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"reflect"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+)
+
+// Scanning a row without losing NULLs.
+//
+// The obvious destination for a column of unknown type is *interface{}, and it
+// does not work. When gocql unmarshals a NULL into one it takes the type
+// currently inside the interface and stores that type's zero value:
+//
+//   - on the first row the interface is empty, there is no type to take, and
+//     gocql panics with "reflect: call of reflect.Value.Type on zero Value"
+//   - on later rows the interface still holds the previous row's value, so the
+//     NULL is silently recorded as ""  or 0 or false
+//
+// Reusing one destination across rows makes both happen in the same scan, which
+// is why a table whose first row is NULL crashes while the same table with a
+// populated row first exports quietly wrong data.
+//
+// Scanning into a pointer to a pointer avoids it. gocql sets the inner pointer
+// to nil for a NULL and allocates a value otherwise, so the two are told apart
+// without guessing.
+
+// NewScanDest returns a scan destination for a column that can represent NULL.
+//
+// Pass the column's TypeInfo from Iter.Columns(). The result goes straight into
+// Iter.Scan, and ScanValue reads it back.
+func NewScanDest(info gocql.TypeInfo) interface{} {
+	if info == nil {
+		return new(interface{})
+	}
+
+	// gocql populates a UDT only when the destination is a map, and it already
+	// leaves that map nil for a NULL, so there is nothing to fix here.
+	if info.Type() == gocql.TypeUDT {
+		return new(map[string]interface{})
+	}
+
+	zero := info.Zero()
+	if zero == nil {
+		return new(interface{})
+	}
+
+	// **T: gocql nils the inner pointer for a NULL.
+	return reflect.New(reflect.PointerTo(reflect.TypeOf(zero))).Interface()
+}
+
+// ScanValue reads back a destination from NewScanDest, returning nil for a NULL.
+func ScanValue(dest interface{}) interface{} {
+	if dest == nil {
+		return nil
+	}
+
+	if udt, ok := dest.(*map[string]interface{}); ok {
+		if udt == nil || *udt == nil {
+			return nil
+		}
+		return *udt
+	}
+
+	ref := reflect.ValueOf(dest)
+	if ref.Kind() != reflect.Pointer || ref.IsNil() {
+		return nil
+	}
+
+	inner := ref.Elem()
+	if inner.Kind() == reflect.Pointer {
+		if inner.IsNil() {
+			return nil // NULL
+		}
+		return inner.Elem().Interface()
+	}
+
+	// Fell back to *interface{} for a column with no usable type information.
+	return inner.Interface()
+}

--- a/internal/db/scan_test.go
+++ b/internal/db/scan_test.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"testing"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewScanDestIsNotABareInterface is the guard for this bug. A *interface{}
+// destination cannot represent NULL: gocql panics when the interface is empty
+// and silently stores the previous row's zero value once it is not.
+func TestNewScanDestIsNotABareInterface(t *testing.T) {
+	types := map[string]gocql.Type{
+		"text": gocql.TypeText, "int": gocql.TypeInt, "bigint": gocql.TypeBigInt,
+		"boolean": gocql.TypeBoolean, "double": gocql.TypeDouble,
+		"timestamp": gocql.TypeTimestamp, "uuid": gocql.TypeUUID,
+		"timeuuid": gocql.TypeTimeUUID,
+	}
+
+	for name, ty := range types {
+		t.Run(name, func(t *testing.T) {
+			dest := NewScanDest(gocql.NewNativeType(0x04, ty, ""))
+
+			_, isBare := dest.(*interface{})
+			assert.False(t, isBare, "%s must not scan into *interface{}", name)
+		})
+	}
+}
+
+// TestScanValueDistinguishesNullFromZero is the behaviour that was missing: an
+// unwritten column and a column holding a zero must not look the same.
+func TestScanValueDistinguishesNullFromZero(t *testing.T) {
+	// What gocql leaves behind for a NULL: the inner pointer stays nil.
+	var nullText *string
+	assert.Nil(t, ScanValue(&nullText), "a nil inner pointer is a NULL")
+
+	// What it leaves for a real empty string: an allocated pointer to "".
+	empty := ""
+	notNull := &empty
+	assert.Equal(t, "", ScanValue(&notNull), "an allocated pointer to \"\" is not a NULL")
+
+	var zeroInt *int
+	assert.Nil(t, ScanValue(&zeroInt))
+
+	n := 0
+	zero := &n
+	assert.Equal(t, 0, ScanValue(&zero), "a real zero is not a NULL")
+
+	var f *bool
+	assert.Nil(t, ScanValue(&f))
+
+	b := false
+	falsePtr := &b
+	assert.Equal(t, false, ScanValue(&falsePtr), "a real false is not a NULL")
+}
+
+func TestScanValueHandlesUDTs(t *testing.T) {
+	var missing map[string]interface{}
+	assert.Nil(t, ScanValue(&missing), "a nil UDT map is a NULL")
+
+	present := map[string]interface{}{"nick": "alice"}
+	assert.Equal(t, present, ScanValue(&present))
+}
+
+func TestScanValueHandlesNilAndFallback(t *testing.T) {
+	assert.Nil(t, ScanValue(nil))
+
+	// The *interface{} fallback, used when a column has no usable type info.
+	var iface interface{} = "hello"
+	assert.Equal(t, "hello", ScanValue(&iface))
+}
+
+func TestNewScanDestFallsBackWithoutTypeInfo(t *testing.T) {
+	dest := NewScanDest(nil)
+	_, ok := dest.(*interface{})
+	require.True(t, ok, "no type info leaves nothing to build a typed destination from")
+}

--- a/internal/router/copy_parquet.go
+++ b/internal/router/copy_parquet.go
@@ -5,22 +5,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/apache/cassandra-gocql-driver/v2"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
 )
-
-// isNullValue checks if a value from gocql scanning represents a NULL value.
-// LIMITATION: When scanning into interface{}, gocql doesn't preserve NULL information.
-// It returns zero values (empty string, 0, empty slice, etc.) for NULL columns.
-// There's no way to distinguish between a NULL and an actual zero value when using interface{}.
-// This would require scanning into typed pointers instead of interface{}.
-func isNullValue(val interface{}) bool {
-	// Only return true for actual nil values
-	// We cannot reliably detect other NULL values when scanning into interface{}
-	return val == nil
-}
 
 // executeCopyToParquet executes COPY TO operation for Parquet format
 func (h *MetaCommandHandler) executeCopyToParquet(table string, columns []string, filename string, options map[string]string) interface{} {
@@ -146,14 +135,11 @@ func (h *MetaCommandHandler) executeCopyToParquet(table string, columns []string
 		columns := v.Iterator.Columns()
 		scanDest := make([]interface{}, len(cleanHeaders))
 		for i := range scanDest {
-			// Check if this column is a UDT
-			if i < len(columns) && columns[i].TypeInfo != nil &&
-				columns[i].TypeInfo.Type() == gocql.TypeUDT {
-				// Use map[string]interface{} for UDT columns to get populated data
-				scanDest[i] = new(map[string]interface{})
-			} else {
-				scanDest[i] = new(interface{})
+			var info gocql.TypeInfo
+			if i < len(columns) {
+				info = columns[i].TypeInfo
 			}
+			scanDest[i] = db.NewScanDest(info)
 		}
 
 		for v.Iterator.Scan(scanDest...) {
@@ -162,30 +148,8 @@ func (h *MetaCommandHandler) executeCopyToParquet(table string, columns []string
 			cleanedRow := make(map[string]interface{})
 			for i := range cleanHeaders {
 				if i < len(scanDest) {
-					var val interface{}
-
-					// Extract value based on how it was scanned
-					if i < len(columns) && columns[i].TypeInfo != nil &&
-						columns[i].TypeInfo.Type() == gocql.TypeUDT {
-						// For UDT columns, we scanned into *map[string]interface{}
-						udtMap := scanDest[i].(*map[string]interface{})
-						if udtMap != nil && *udtMap != nil {
-							val = *udtMap
-						} else {
-							val = nil
-						}
-					} else {
-						// Regular column
-						val = *(scanDest[i].(*interface{}))
-					}
-
-					// Check if the value is a "zero" value that should be NULL
-					// gocql returns typed zero values for NULL columns
-					if isNullValue(val) {
-						cleanedRow[cleanHeaders[i]] = nil
-					} else {
-						cleanedRow[cleanHeaders[i]] = val
-					}
+					// nil here is a real NULL, not a zero value standing in for one.
+					cleanedRow[cleanHeaders[i]] = db.ScanValue(scanDest[i])
 				}
 			}
 

--- a/internal/router/copy_parquet_partitioned.go
+++ b/internal/router/copy_parquet_partitioned.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
@@ -115,9 +116,14 @@ func (h *MetaCommandHandler) executeCopyToParquetPartitioned(table string, colum
 		batch := make([]map[string]interface{}, 0, batchSize)
 
 		// Prepare scan destinations - use cleanHeaders since that's what we'll iterate with
+		cols := v.Iterator.Columns()
 		scanDest := make([]interface{}, len(cleanHeaders))
 		for i := range scanDest {
-			scanDest[i] = new(interface{})
+			var info gocql.TypeInfo
+			if i < len(cols) {
+				info = cols[i].TypeInfo
+			}
+			scanDest[i] = db.NewScanDest(info)
 		}
 
 		for v.Iterator.Scan(scanDest...) {
@@ -125,13 +131,8 @@ func (h *MetaCommandHandler) executeCopyToParquetPartitioned(table string, colum
 			rowData := make(map[string]interface{})
 			for i, colName := range cleanHeaders {
 				if i < len(scanDest) {
-					val := *(scanDest[i].(*interface{}))
-					// Handle NULL values
-					if val == nil {
-						rowData[colName] = nil
-					} else {
-						rowData[colName] = val
-					}
+					// nil here is a real NULL, not a zero value standing in for one.
+					rowData[colName] = db.ScanValue(scanDest[i])
 				}
 			}
 

--- a/test/integration/null_roundtrip_test.go
+++ b/test/integration/null_roundtrip_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+// +build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/axonops/cqlai/internal/parquet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNullFirstRowDoesNotPanic covers the crash in #96.
+//
+// Rows used to be scanned into *interface{}, which cannot hold a NULL. On the
+// first row the interface is empty, so gocql had no type to take the zero value
+// from and panicked with "reflect: call of reflect.Value.Type on zero Value".
+// A table whose first row contains a NULL was therefore impossible to export.
+func TestNullFirstRowDoesNotPanic(t *testing.T) {
+	dbSession, handler, cleanup := getTestSession(t)
+	defer cleanup()
+
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS null_first (
+		id int PRIMARY KEY,
+		name text,
+		uid uuid,
+		ts timestamp,
+		amount double,
+		ok boolean,
+		tags list<text>
+	)`).Exec())
+
+	// id 1 sorts first and has nothing but its key, so the first row the
+	// exporter sees is all NULL.
+	require.NoError(t, dbSession.Query(`INSERT INTO null_first (id) VALUES (1)`).Exec())
+	require.NoError(t, dbSession.Query(
+		`INSERT INTO null_first (id, name, ts, amount, ok) VALUES (2, '', 0, 0.0, false)`).Exec())
+
+	parquetFile := filepath.Join(os.TempDir(), "null_first.parquet")
+	defer os.Remove(parquetFile)
+
+	// This is the call that used to panic and take the process with it.
+	result := handler.HandleMetaCommand(
+		fmt.Sprintf("COPY null_first TO '%s' WITH FORMAT='PARQUET';", parquetFile))
+	t.Logf("COPY TO result: %v", result)
+
+	require.FileExists(t, parquetFile)
+}
+
+// TestNullSurvivesParquetRoundTrip is the other half of #96: a NULL must stay a
+// NULL rather than turning into the zero value of whatever the previous row
+// happened to hold, and a genuine zero must stay a zero.
+func TestNullSurvivesParquetRoundTrip(t *testing.T) {
+	dbSession, handler, cleanup := getTestSession(t)
+	defer cleanup()
+
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS null_rt (
+		id int PRIMARY KEY,
+		name text,
+		amount double,
+		ok boolean
+	)`).Exec())
+
+	// Row 1 is entirely NULL. Row 2 holds real zeros that must not be mistaken
+	// for NULLs: an empty string, 0.0 and false are all legitimate values.
+	require.NoError(t, dbSession.Query(`INSERT INTO null_rt (id) VALUES (1)`).Exec())
+	require.NoError(t, dbSession.Query(
+		`INSERT INTO null_rt (id, name, amount, ok) VALUES (2, '', 0.0, false)`).Exec())
+
+	parquetFile := filepath.Join(os.TempDir(), "null_rt.parquet")
+	defer os.Remove(parquetFile)
+
+	result := handler.HandleMetaCommand(
+		fmt.Sprintf("COPY null_rt TO '%s' WITH FORMAT='PARQUET';", parquetFile))
+	t.Logf("COPY TO result: %v", result)
+
+	// Read the file directly: this is where a lost NULL shows up as "" or 0.
+	reader, err := parquet.NewParquetReader(parquetFile)
+	require.NoError(t, err)
+	// Close reports "file already closed" even on success, so ignore it here
+	// the way every other caller does.
+	defer reader.Close()
+
+	rows, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	byID := map[int32]map[string]interface{}{}
+	for _, row := range rows {
+		id, ok := row["id"].(int32)
+		require.True(t, ok, "unexpected id type %T", row["id"])
+		byID[id] = row
+	}
+
+	nullRow := byID[1]
+	require.NotNil(t, nullRow)
+	for _, col := range []string{"name", "amount", "ok"} {
+		assert.Nil(t, nullRow[col],
+			"column %q was NULL in Cassandra and must be null in the Parquet file, got %#v",
+			col, nullRow[col])
+	}
+
+	zeroRow := byID[2]
+	require.NotNil(t, zeroRow)
+	assert.NotNil(t, zeroRow["name"], "an empty string is a value, not a NULL")
+	assert.Equal(t, "", zeroRow["name"])
+	assert.Equal(t, float64(0), zeroRow["amount"], "0.0 is a value, not a NULL")
+	assert.Equal(t, false, zeroRow["ok"], "false is a value, not a NULL")
+
+	// And back into Cassandra: both rows must return exactly as they went out.
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS null_rt_dest (
+		id int PRIMARY KEY,
+		name text,
+		amount double,
+		ok boolean
+	)`).Exec())
+
+	result = handler.HandleMetaCommand(
+		fmt.Sprintf("COPY null_rt_dest FROM '%s' WITH FORMAT='PARQUET';", parquetFile))
+	t.Logf("COPY FROM result: %v", result)
+
+	var gotName *string
+	var gotAmount *float64
+	var gotOK *bool
+
+	require.NoError(t, dbSession.Query(
+		`SELECT name, amount, ok FROM null_rt_dest WHERE id = 1`).Scan(&gotName, &gotAmount, &gotOK))
+	assert.Nil(t, gotName, "a NULL must not come back as an empty string")
+	assert.Nil(t, gotAmount, "a NULL must not come back as 0")
+	assert.Nil(t, gotOK, "a NULL must not come back as false")
+
+	require.NoError(t, dbSession.Query(
+		`SELECT name, amount, ok FROM null_rt_dest WHERE id = 2`).Scan(&gotName, &gotAmount, &gotOK))
+	require.NotNil(t, gotName)
+	assert.Equal(t, "", *gotName)
+	require.NotNil(t, gotAmount)
+	assert.Equal(t, float64(0), *gotAmount)
+	require.NotNil(t, gotOK)
+	assert.Equal(t, false, *gotOK)
+}


### PR DESCRIPTION
Closes #96. What I originally filed there was wrong about the cause - it is not the Parquet writer, and it is not only Parquet.

## The actual bug

Rows were scanned into `*interface{}` destinations. gocql cannot represent a NULL in one. It takes whatever type is currently *inside* the interface and stores that type's zero value:

- **first row**: the interface is empty, there is no type to take, and gocql panics with `reflect: call of reflect.Value.Type on zero Value`
- **later rows**: the interface still holds the previous row's value, so the NULL is silently recorded as `""` or `0` or `false`

One cause, two symptoms. It explains the thing that confused me while investigating: a table whose first row is NULL *crashes*, while the same table with a populated row first exports quietly wrong data.

Measured against **Cassandra 5.0.9**, on a table whose first row has a NULL:

| | before | after |
|---|---|---|
| `--format csv` | **panic** | works |
| `--format json` | **panic** | works, emits `null` |
| `COPY TO PARQUET` | **panic** | works |
| `COPY TO PARQUET` partitioned | same code | works |
| `--format ascii` | worked, NULL shown as empty | unchanged |

So `--format csv` and `--format json` crashed on a perfectly ordinary table. That is well beyond what #96 described.

## Someone already knew

`internal/batch/streaming.go:36`:

```go
// Use MapScan to handle NULLs properly - gocql can panic on NULL values with Scan()
```

That is why ascii survived. The workaround was applied to one path and never the other six. It also does not really fix anything: gocql documents that `MapScan` returns the *zero value* for a NULL, per type, so ascii still cannot tell `''` from NULL.

## The fix

Scan into a pointer to a pointer. gocql nils the inner pointer for a NULL and allocates a value otherwise (`marshal.go`, the `reflect.Ptr` case), so the two are distinguished rather than guessed at.

Adds `db.NewScanDest` and `db.ScanValue`, and routes every scan site through them: both Parquet export paths, the CSV and JSON batch writers, and `executeSelectQuery`.

Also removes `isNullValue`, whose comment claimed NULLs "cannot reliably be detected when scanning into interface{}". True of that approach, not of the problem.

Net **+31 / -94** in non-test code - the special-casing each call site had grown goes away.

## gocql v2.1.0 to v2.1.2

Included as asked. **It does not fix this** - I diffed the relevant function and it is byte-identical in both releases. The project was simply two patch releases behind.

## Tests

**Unit** - `internal/db/scan_test.go` covers `NewScanDest` and `ScanValue`: a NULL and a zero must not look alike, UDT maps, and the fallback when a column has no usable type info.

**Integration** - `test/integration/null_roundtrip_test.go`, run by the existing `cassandra-tests` job against Cassandra 5. The unit tests alone would not catch a regression: someone could put `new(interface{})` back into `copy_parquet.go` and they would all still pass.

- `TestNullFirstRowDoesNotPanic` exports a table whose first row is entirely NULL - the case that used to take the process down.
- `TestNullSurvivesParquetRoundTrip` asserts both directions, because the bug turns one into the other: a NULL must survive as a NULL, and a genuine `''`, `0.0` and `false` must survive as values.

Both were checked against the previous commit and **fail there**, the first with `panic: reflect: call of reflect.Value.Type on zero Value`.

## Verified end to end

Test table with one all-NULL row and one row of *genuine* zeros - `name=''`, `amount=0.0`, `ok=false`, `ts=epoch` - so the distinction is visible.

Reading the exported Parquet file back:

```
  id=1  (all NULL)
      name    NULL    amount  NULL    ok      NULL    ts      NULL
  id=2  (real zeros)
      name    value ""
      amount  value 0
      ok      value false
      ts      value 1970-01-01 00:00:00 UTC
      raw     NULL           <- genuinely unset
      tags    NULL
```

Full `COPY TO` then `COPY FROM` round-trip: both rows identical to the originals.

## Note on #94 and #95

Independent of those - different files, no conflicts, merges in any order. Worth knowing that this makes their job easier: with real NULLs in the file, `COPY FROM` binds nil instead of trying to parse `00000000-0000-0000-0000-000000000000` as a timeuuid.
