### PR TITLE
fix(parquet): stop Close reporting an error on success

### DIFF
--- a/internal/parquet/reader.go
+++ b/internal/parquet/reader.go
@@ -264,11 +264,18 @@ func (r *ParquetReader) Close() error {
 		r.tableReader.Release()
 		r.tableReader = nil
 	}
+	// The parquet reader owns the file handle and closes it, so closing r.file
+	// afterwards would return "file already closed" on every successful Close.
+	// Nil the fields out so a second Close is a no-op rather than an error.
 	if r.reader != nil {
-		_ = r.reader.Close()
+		reader := r.reader
+		r.reader, r.file = nil, nil
+		return reader.Close()
 	}
 	if r.file != nil {
-		return r.file.Close()
+		file := r.file
+		r.file = nil
+		return file.Close()
 	}
 	return nil
 }

--- a/internal/parquet/reader_close_test.go
+++ b/internal/parquet/reader_close_test.go
@@ -1,0 +1,50 @@
+package parquet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReaderCloseReportsSuccess guards against Close reporting a failure on a
+// perfectly good reader.
+//
+// The parquet reader owns the file handle and closes it. Closing the handle
+// again afterwards returned "file already closed" from every successful Close,
+// which every caller had to ignore for the code to work at all.
+func TestReaderCloseReportsSuccess(t *testing.T) {
+	path := writeNumberedRows(t, 10, 100)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+
+	assert.NoError(t, reader.Close(), "closing a healthy reader must not report an error")
+}
+
+// TestReaderCloseIsIdempotent covers the common pattern of a deferred Close
+// alongside an explicit one.
+func TestReaderCloseIsIdempotent(t *testing.T) {
+	path := writeNumberedRows(t, 10, 100)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+
+	require.NoError(t, reader.Close())
+	assert.NoError(t, reader.Close(), "a second Close must be a no-op")
+	assert.NoError(t, reader.Close())
+}
+
+// TestReaderCloseAfterReadingReportsSuccess checks the same once the reader has
+// actually done some work, so the batch and row-group state is populated.
+func TestReaderCloseAfterReadingReportsSuccess(t *testing.T) {
+	path := writeNumberedRows(t, 350, 100)
+
+	reader, err := NewParquetReader(path)
+	require.NoError(t, err)
+
+	rows := drainBatches(t, reader, 60)
+	require.Equal(t, 350, len(rows))
+
+	assert.NoError(t, reader.Close())
+}


### PR DESCRIPTION
`ParquetReader.Close` returned an error every time it succeeded.

```go
if r.reader != nil {
    _ = r.reader.Close()
}
if r.file != nil {
    return r.file.Close()   // the handle is already closed by then
}
```

Arrow's `file.Reader.Close` closes the underlying `io.Closer`, which is our `*os.File` (`parquet/file/file_reader.go:149`). So the second close always failed:

```
close /tmp/out.parquet: file already closed
```

It went unnoticed because every caller either defers `Close` and drops the result or assigns it to `_`. Nothing was actually leaking - the file was closed exactly once - but any caller that checked the error got a failure on a healthy reader.

## The fix

Let the parquet reader do the closing and return its error rather than discarding it. Clearing the fields on the way out makes a second `Close` a no-op, which matters for the common pattern of a deferred `Close` alongside an explicit one.

## Tests

Three, all of which fail against `main`:

- `TestReaderCloseReportsSuccess` - closing a healthy reader returns nil
- `TestReaderCloseIsIdempotent` - a second and third `Close` are no-ops
- `TestReaderCloseAfterReadingReportsSuccess` - the same once row-group and batch state is populated

## How it was found

Writing the integration tests for #96. A `require.NoError(t, reader.Close())` failed on a file that had just been read successfully, which is exactly the case the old code could not report correctly.

Independent of #94, #95 and #97 - different function, no conflicts, any merge order.
