### PR TITLE
fix: drop the self-replace directive so go install works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/axonops/cqlai
 
 go 1.26.6
 
-replace github.com/axonops/cqlai => ./
-
 require (
 	github.com/anthropics/anthropic-sdk-go v1.30.0
 	github.com/apache/arrow-go/v18 v18.7.0


### PR DESCRIPTION
Closes #78.

`go.mod` carried a replace pointing the module at itself:

```
replace github.com/axonops/cqlai => ./
```

It has been there since the initial commit and does nothing for a local build, but Go refuses to install a module whose `go.mod` contains replace directives at all. So the command the README publishes at line 150 has never worked for anyone.

## Proof

The exact command from the issue, run against `main` and then against this branch:

```
$ go install github.com/axonops/cqlai/cmd/cqlai@main
go: github.com/axonops/cqlai/cmd/cqlai@main (in github.com/axonops/cqlai@v0.1.8-...):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.

$ go install github.com/axonops/cqlai/cmd/cqlai@2026-09-08-78-go-install
$ cqlai --version
cqlai version dev
```

The installed binary connects and queries a real cluster, so this is not just a compile.

## Risk

None that I can find. A module replacing itself with its own directory resolves to the same thing either way, so removing it changes nothing locally: build, unit tests, BDD suite, parquet tests and lint are all unaffected.

## Note on the version string

The installed binary reports `dev` rather than a real version, because the version is injected with `-ldflags -X main.Version=...` by the Makefile and `go install` does not run that. That is expected for a `go install` build and separate from this issue - worth its own if you want `go install` builds to carry a version, which needs `runtime/debug.ReadBuildInfo` as a fallback.
