### PR TITLE
fix(describe): order primary key columns by schema position

### DIFF
--- a/internal/db/describe_table.go
+++ b/internal/db/describe_table.go
@@ -82,8 +82,6 @@ func (s *Session) DescribeTableQuery(keyspace string, tableName string) (*TableI
 	colIter := s.Query(colQuery, keyspace, tableName).Iter()
 
 	var columns []ColumnInfo
-	var partitionKeys []string
-	var clusteringKeys []string
 
 	var colName, colType, colKind string
 	var colPosition int
@@ -95,13 +93,6 @@ func (s *Session) DescribeTableQuery(keyspace string, tableName string) (*TableI
 			Kind:     colKind,
 			Position: colPosition,
 		})
-
-		switch colKind {
-		case "partition_key":
-			partitionKeys = append(partitionKeys, colName)
-		case "clustering":
-			clusteringKeys = append(clusteringKeys, colName)
-		}
 	}
 	_ = colIter.Close()
 
@@ -123,6 +114,23 @@ func (s *Session) DescribeTableQuery(keyspace string, tableName string) (*TableI
 		// Within same kind, sort by position
 		return columns[i].Position < columns[j].Position
 	})
+
+	// Collect the key columns only after sorting. system_schema.columns is
+	// clustered by column_name, so it comes back alphabetically; taking the
+	// keys in iteration order gives "PRIMARY KEY ((a, b, c), x, y, z)" for a
+	// table declared as ((c, a, b), z, y, x). That is not the same table: the
+	// partition key order changes how rows are distributed and the clustering
+	// order changes how they are sorted on disk.
+	var partitionKeys []string
+	var clusteringKeys []string
+	for _, col := range columns {
+		switch col.Kind {
+		case "partition_key":
+			partitionKeys = append(partitionKeys, col.Name)
+		case "clustering":
+			clusteringKeys = append(clusteringKeys, col.Name)
+		}
+	}
 
 	return &TableInfo{
 		KeyspaceName:   keyspace,

--- a/test/integration/describe_key_order_test.go
+++ b/test/integration/describe_key_order_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+// +build integration
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDescribeKeyOrderFollowsSchemaPosition covers #84.
+//
+// DescribeTableQuery is the pre-4.0 fallback: on Cassandra 4.0 and later
+// DBDescribeTable asks the server for the CREATE statement instead, which is
+// why this only ever showed up for people on 3.x. Calling it directly exercises
+// the fallback whatever the server version.
+//
+// system_schema.columns is clustered by column_name, so it comes back
+// alphabetically. Taking the key columns in that order rewrites the primary
+// key: a table declared ((c, a, b), z, y, x) was described as
+// ((a, b, c), x, y, z), which is a different table. The partition key order
+// decides how rows are distributed, and the clustering order decides how they
+// are sorted.
+func TestDescribeKeyOrderFollowsSchemaPosition(t *testing.T) {
+	dbSession, _, cleanup := getTestSession(t)
+	defer cleanup()
+
+	// Declared deliberately so that alphabetical order differs from schema
+	// position for both halves of the key.
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS key_order (
+		a int, b int, c int,
+		x int, y int, z int,
+		v text,
+		PRIMARY KEY ((c, a, b), z, y, x)
+	)`).Exec())
+
+	info, err := dbSession.DescribeTableQuery("test_roundtrip", "key_order")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"c", "a", "b"}, info.PartitionKeys,
+		"partition keys must follow schema position, not the alphabet")
+	assert.Equal(t, []string{"z", "y", "x"}, info.ClusteringKeys,
+		"clustering keys must follow schema position, not the alphabet")
+
+	ddl := db.FormatTableCreateStatement(info, false)
+	assert.Contains(t, ddl, "PRIMARY KEY ((c, a, b), z, y, x)",
+		"the generated DDL must recreate the same table")
+	assert.NotContains(t, ddl, "PRIMARY KEY ((a, b, c), x, y, z)")
+}


### PR DESCRIPTION
Closes #84. The reporter was right, and it is worse than reported.

## What happened

`DescribeTableQuery` collected the key column names while iterating:

```sql
SELECT column_name, type, kind, position FROM system_schema.columns
WHERE keyspace_name = ? AND table_name = ?
```

That table is clustered by `column_name`, so rows come back **alphabetically**. The `columns` slice was sorted by position afterwards, but the two key slices were not - and those are what the CREATE statement is built from.

A table declared as `PRIMARY KEY ((c, a, b), z, y, x)` was described as `PRIMARY KEY ((a, b, c), x, y, z)`. That is a different table. Partition key order decides how rows are distributed across the cluster; clustering order decides how they are sorted within a partition. Anyone using DESCRIBE output to recreate a table got neither back.

## The partition key was affected too

The issue only mentions clustering columns. The partition key had the same bug - it just looked correct in the example, because `a, b, c` is alphabetically the same as its declared order. With `((c, a, b), ...)` it is visibly wrong:

```
  PartitionKeys:  [a b c]   want [c a b]
  ClusteringKeys: [x y z]   want [z y x]
  rendered: PRIMARY KEY ((a, b, c), x, y, z)
```

after:

```
  PartitionKeys:  [c a b]
  ClusteringKeys: [z y x]
  rendered: PRIMARY KEY ((c, a, b), z, y, x)
```

## Why it only affects older clusters

`DBDescribeTable` asks the server for the CREATE statement on Cassandra 4.0 and later, and only falls back to building it locally below that. So this was invisible on 4.0+ and hit exactly the people on 3.x - consistent with the report against 0.1.6 and 0.1.7.

## Test

`test/integration/describe_key_order_test.go` calls `DescribeTableQuery` directly, so it covers the fallback whatever the server version - otherwise the CI matrix would pass on 4.0+ without ever running the code in question. It declares a table whose alphabetical order differs from schema position in **both** halves of the key, and asserts the generated DDL recreates the same table.

Verified to fail against the previous commit:

```
expected: []string{"c", "a", "b"}
actual  : []string{"a", "b", "c"}
expected: []string{"z", "y", "x"}
actual  : []string{"x", "y", "z"}
```

## Found while investigating: a separate, bigger bug

`internal/db/schema.go:105` runs the same kind of query with `ORDER BY position` appended, which Cassandra rejects outright:

```
Order by is currently only supported on the clustered columns of the PRIMARY KEY, got position
```

`loadTablesForKeyspace` swallows that with `continue // Skip tables we can't load`, so **every table is silently skipped**. That path feeds `GetSchemaContext`, which is what the AI is given as context. Measured against a live cluster, the AI currently receives only a list of keyspace names - no tables, no columns.

Not fixed here; filed separately, since it is a different symptom with a different blast radius.
