### PR TITLE
fix(ui): make paging reach the end of EXPAND output

### DIFF
--- a/internal/ui/expand_formatter.go
+++ b/internal/ui/expand_formatter.go
@@ -8,15 +8,27 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// FormatExpandTable formats query results in expanded vertical format
+// FormatExpandTable formats query results in expanded vertical format.
 func FormatExpandTable(data [][]string, styles *Styles) string {
+	out, _ := FormatExpandTableWithBoundaries(data, styles)
+	return out
+}
+
+// FormatExpandTableWithBoundaries formats query results in expanded vertical
+// format and reports the line each record starts on.
+//
+// Paging snaps to those line numbers. In this layout a record is as tall as the
+// table is wide - often ten or more lines - so boundaries taken from the boxed
+// table renderer, where a record is a single line, cap scrolling near the row
+// count and leave the rest of the result unreachable.
+func FormatExpandTableWithBoundaries(data [][]string, styles *Styles) (string, []int) {
 	if len(data) == 0 {
-		return "No results"
+		return "No results", nil
 	}
 
 	if len(data) == 1 {
 		// Only headers, no data rows
-		return "No results"
+		return "No results", nil
 	}
 
 	headers := data[0]
@@ -32,6 +44,10 @@ func FormatExpandTable(data [][]string, styles *Styles) string {
 	}
 
 	var buf bytes.Buffer
+
+	// Line the next write lands on, and where each record begins.
+	line := 0
+	boundaries := make([]int, 0, len(rows)+1)
 
 	// Define styles for different parts
 	rowHeaderStyle := lipgloss.NewStyle().
@@ -49,15 +65,23 @@ func FormatExpandTable(data [][]string, styles *Styles) string {
 
 	// Process each row
 	for rowIdx, row := range rows {
-		// Row header with color
+		// Blank line between records
 		buf.WriteString("\n")
+		line++
+
+		// The record starts here, so this is what paging should land on
+		boundaries = append(boundaries, line)
+
+		// Row header with color
 		buf.WriteString(rowHeaderStyle.Render(fmt.Sprintf("@ Row %d", rowIdx+1)))
 		buf.WriteString("\n")
+		line++
 
 		// Separator line with muted color
 		separator := strings.Repeat("-", maxColWidth+2) + "+" + strings.Repeat("-", 40)
 		buf.WriteString(separatorStyle.Render(separator))
 		buf.WriteString("\n")
+		line++
 
 		// Column name and value pairs
 		for colIdx, value := range row {
@@ -91,6 +115,7 @@ func FormatExpandTable(data [][]string, styles *Styles) string {
 				buf.WriteString(pipeStyle.Render(" | "))
 				buf.WriteString(value)
 				buf.WriteString("\n")
+				line++
 			}
 		}
 	}
@@ -100,6 +125,7 @@ func FormatExpandTable(data [][]string, styles *Styles) string {
 		Foreground(styles.Muted)
 
 	buf.WriteString("\n")
+	line++
 	if len(rows) == 1 {
 		buf.WriteString(rowCountStyle.Render(fmt.Sprintf("(%d row)", len(rows))))
 	} else {
@@ -107,5 +133,9 @@ func FormatExpandTable(data [][]string, styles *Styles) string {
 	}
 	buf.WriteString("\n")
 
-	return buf.String()
+	// A final boundary on the last line, so paging can reach the end of the
+	// last record rather than stopping at the line it starts on.
+	boundaries = append(boundaries, line)
+
+	return buf.String(), boundaries
 }

--- a/internal/ui/expand_formatter_test.go
+++ b/internal/ui/expand_formatter_test.go
@@ -1,0 +1,222 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stripAnsiForTest removes styling so the assertions look at the text.
+func stripAnsiForTest(s string) string {
+	var out strings.Builder
+	inEscape := false
+	for _, r := range s {
+		switch {
+		case r == '\x1b':
+			inEscape = true
+		case inEscape && r == 'm':
+			inEscape = false
+		case !inEscape:
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
+}
+
+func expandTestData(rows, cols int) [][]string {
+	headers := make([]string, cols)
+	for c := range cols {
+		headers[c] = "col" + string(rune('a'+c))
+	}
+	data := [][]string{headers}
+	for r := range rows {
+		row := make([]string, cols)
+		for c := range cols {
+			row[c] = "r" + string(rune('0'+r)) + "c" + string(rune('a'+c))
+		}
+		data = append(data, row)
+	}
+	return data
+}
+
+// TestExpandBoundariesPointAtRecordStarts is the guard for #85. The boundaries
+// have to describe the layout actually on screen: paging snaps to them, so if
+// they come from a different renderer the tail of the result is unreachable.
+func TestExpandBoundariesPointAtRecordStarts(t *testing.T) {
+	const rows = 5
+
+	out, boundaries := FormatExpandTableWithBoundaries(expandTestData(rows, 4), DefaultStyles())
+
+	// One per record, plus a final one so paging can reach the end.
+	require.Len(t, boundaries, rows+1)
+
+	lines := strings.Split(stripAnsiForTest(out), "\n")
+
+	for i := range rows {
+		at := boundaries[i]
+		require.Less(t, at, len(lines), "boundary %d is past the end of the output", i)
+		assert.Equal(t, "@ Row "+string(rune('1'+i)), lines[at],
+			"boundary %d should land on the start of record %d", i, i+1)
+	}
+
+	last := boundaries[rows]
+	assert.Less(t, last, len(lines))
+	assert.Greater(t, last, boundaries[rows-1],
+		"the final boundary must be past the last record start, or the last record cannot be scrolled through")
+}
+
+// TestExpandBoundariesGrowWithRecordHeight is the actual bug in miniature: a
+// record here is many lines tall, so the boundaries must be spaced accordingly
+// rather than tracking the row count.
+func TestExpandBoundariesGrowWithRecordHeight(t *testing.T) {
+	const rows = 10
+
+	narrow, narrowBounds := FormatExpandTableWithBoundaries(expandTestData(rows, 2), DefaultStyles())
+	wide, wideBounds := FormatExpandTableWithBoundaries(expandTestData(rows, 20), DefaultStyles())
+
+	narrowLines := len(strings.Split(narrow, "\n"))
+	wideLines := len(strings.Split(wide, "\n"))
+	require.Greater(t, wideLines, narrowLines*2, "more columns must mean taller records")
+
+	// Both have the same number of records...
+	require.Len(t, narrowBounds, rows+1)
+	require.Len(t, wideBounds, rows+1)
+
+	// ...but the wide one spreads them much further down the output. This is
+	// what boundaries taken from the boxed table renderer cannot express.
+	assert.Greater(t, wideBounds[rows-1], narrowBounds[rows-1]*2,
+		"boundaries must follow the rendered height, not the row count")
+
+	assert.Greater(t, wideBounds[rows-1], rows,
+		"the last record must start well below line %d, or paging stops near the row count", rows)
+}
+
+func TestExpandBoundariesEmptyResults(t *testing.T) {
+	out, boundaries := FormatExpandTableWithBoundaries(nil, DefaultStyles())
+	assert.Equal(t, "No results", out)
+	assert.Nil(t, boundaries)
+
+	out, boundaries = FormatExpandTableWithBoundaries([][]string{{"a", "b"}}, DefaultStyles())
+	assert.Equal(t, "No results", out)
+	assert.Nil(t, boundaries)
+}
+
+// TestExpandPagingReachesTheLastRecord is the behaviour reported in #85: in
+// expand format, paging down could not get past roughly the row count, leaving
+// most of the result unreachable.
+//
+// Paging clamps to the viewport's line count and then snaps to the nearest row
+// boundary at or below that. When the boundaries describe a different layout,
+// the snap silently undoes the clamp.
+func TestExpandPagingReachesTheLastRecord(t *testing.T) {
+	const (
+		rows          = 52 // as reported
+		cols          = 8
+		viewportLines = 20
+	)
+
+	content, boundaries := FormatExpandTableWithBoundaries(expandTestData(rows, cols), DefaultStyles())
+	totalLines := len(strings.Split(content, "\n"))
+	require.Greater(t, totalLines, rows*8, "each record should be several lines tall")
+
+	newModel := func(b []int) *MainModel {
+		m := &MainModel{
+			viewMode:           "table",
+			hasTable:           true,
+			tableViewport:      viewport.New(120, viewportLines),
+			tableRowBoundaries: b,
+		}
+		m.tableViewport.SetContent(content)
+		return m
+	}
+
+	pageToBottom := func(m *MainModel) int {
+		last := -1
+		for range 500 {
+			m.handleHalfPageDown()
+			if m.tableViewport.YOffset == last {
+				break // stuck
+			}
+			last = m.tableViewport.YOffset
+		}
+		return m.tableViewport.YOffset
+	}
+
+	maxOffset := totalLines - viewportLines
+
+	// Paging walks all the way to the bottom, so every record is reachable.
+	m := newModel(boundaries)
+	got := pageToBottom(m)
+	assert.Equal(t, maxOffset, got,
+		"paging must reach the bottom of the result (line %d), stopped at %d", maxOffset, got)
+
+	// And it lands on record starts on the way, which is the point of tracking
+	// boundaries at all rather than scrolling by raw lines.
+	m = newModel(boundaries)
+	starts := make(map[int]bool, len(boundaries))
+	for _, b := range boundaries {
+		starts[b] = true
+	}
+	offsets := []int{}
+	last := -1
+	for range 500 {
+		m.handleHalfPageDown()
+		o := m.tableViewport.YOffset
+		if o == last {
+			break
+		}
+		last = o
+		offsets = append(offsets, o)
+	}
+	require.NotEmpty(t, offsets)
+	for _, o := range offsets[:len(offsets)-1] { // the final stop is the clamp to the bottom
+		assert.True(t, starts[o], "paging stopped at line %d, which is not the start of a record", o)
+	}
+
+	t.Logf("paged to the bottom in %d steps, landing on record starts", len(offsets))
+}
+
+// TestSnapDownToBoundaryAlwaysAdvances covers the second half of #85.
+//
+// Snapping used to take the last boundary at or before the target and nothing
+// else. When a record is taller than the scroll amount there is no such
+// boundary past the current position, so the snap returned where it started and
+// scrolling wedged. Boxed-table boundaries are one line apart and hid this;
+// expand records are ten or more lines apart and expose it.
+func TestSnapDownToBoundaryAlwaysAdvances(t *testing.T) {
+	// Records 11 lines apart, half a page is 10 lines: the target never reaches
+	// the next boundary.
+	boundaries := []int{1, 12, 23, 34, 45}
+
+	tests := []struct {
+		name            string
+		current, target int
+		want            int
+	}{
+		{"steps to the next record when none is in range", 1, 11, 12},
+		{"lands on a record start when one is in range", 1, 30, 23},
+		{"advances from the top", 0, 10, 1},
+		{"keeps going past the middle", 23, 33, 34},
+		{"scrolls freely past the last record", 45, 55, 55},
+		{"does not move when the target is behind", 23, 20, 23},
+		{"does not move when the target is level", 23, 23, 23},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := snapDownToBoundary(tt.current, tt.target, boundaries)
+			assert.Equal(t, tt.want, got)
+			if tt.target > tt.current {
+				assert.Greater(t, got, tt.current, "a downward scroll must make progress")
+			}
+		})
+	}
+}
+
+func TestSnapDownToBoundaryWithoutBoundaries(t *testing.T) {
+	assert.Equal(t, 10, snapDownToBoundary(0, 10, nil))
+}

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -206,8 +206,10 @@ func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) 
 	m.lastTableData = allData // Store for pagination
 	m.horizontalOffset = 0    // Reset horizontal scroll
 
-	// Format as expanded vertical table
-	expandStr := FormatExpandTable(allData, m.styles)
+	// Format as expanded vertical table. The boundaries have to come from this
+	// layout: paging snaps to them, and a record here is many lines tall.
+	expandStr, boundaries := FormatExpandTableWithBoundaries(allData, m.styles)
+	m.tableRowBoundaries = boundaries
 	m.tableViewport.SetContent(expandStr)
 	m.tableViewport.GotoTop()
 
@@ -290,6 +292,8 @@ func (m *MainModel) displayASCIIFormat(headers []string, columnTypes []string) (
 		}
 
 		// Set content in table viewport
+		// No record boundaries in this layout; stale ones would cap scrolling.
+		m.tableRowBoundaries = nil
 		m.tableViewport.SetContent(asciiStr)
 		m.tableViewport.GotoTop()
 
@@ -422,6 +426,8 @@ func (m *MainModel) displayJSONFormat(headers []string, columnTypes []string, co
 		}
 
 		// Set content in table viewport
+		// No record boundaries in this layout; stale ones would cap scrolling.
+		m.tableRowBoundaries = nil
 		m.tableViewport.SetContent(jsonStr)
 		m.tableViewport.GotoTop()
 
@@ -516,7 +522,8 @@ func (m *MainModel) processQueryResult(command string, v db.QueryResult) (*MainM
 			m.cachedTableLines = nil    // Clear cache for new table
 
 			// Format as expanded vertical table
-			expandOutput := FormatExpandTable(v.Data, m.styles)
+			expandOutput, boundaries := FormatExpandTableWithBoundaries(v.Data, m.styles)
+			m.tableRowBoundaries = boundaries
 			m.tableViewport.SetContent(expandOutput)
 			m.tableViewport.GotoTop() // Start at top of table
 		case config.OutputFormatJSON:

--- a/internal/ui/keyboard_navigation_pager.go
+++ b/internal/ui/keyboard_navigation_pager.go
@@ -1,9 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
-
-	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
 	tea "github.com/charmbracelet/bubbletea"
@@ -100,6 +97,39 @@ func (m *MainModel) handleSingleLineUp() (*MainModel, tea.Cmd) {
 	return m, nil
 }
 
+// snapDownToBoundary aligns a downward scroll to the start of a record.
+//
+// It prefers the last boundary at or before the target, so a page lands on a
+// record start rather than mid-record. Where a record is taller than the scroll
+// amount - expand format, or a table with tall multi-line cells - there is no
+// such boundary past the current position, and returning the current offset
+// would wedge scrolling entirely. Step to the next record in that case.
+func snapDownToBoundary(current, target int, boundaries []int) int {
+	if target <= current {
+		return current
+	}
+
+	snapped := current
+	for _, boundary := range boundaries {
+		if boundary <= target && boundary > snapped {
+			snapped = boundary
+		}
+	}
+	if snapped > current {
+		return snapped
+	}
+
+	// Nothing between here and the target: move on to the next record.
+	for _, boundary := range boundaries {
+		if boundary > current {
+			return boundary
+		}
+	}
+
+	// Past the last record, so ordinary scrolling applies.
+	return target
+}
+
 // handleHalfPageDown scrolls down by half a page (d key)
 func (m *MainModel) handleHalfPageDown() (*MainModel, tea.Cmd) {
 	scrollAmount := 0
@@ -135,13 +165,10 @@ func (m *MainModel) handleHalfPageDown() (*MainModel, tea.Cmd) {
 
 		// Snap to row boundary if we have multi-line cells
 		if len(m.tableRowBoundaries) > 0 {
-			bestOffset := m.tableViewport.YOffset
-			for _, boundary := range m.tableRowBoundaries {
-				if boundary <= newOffset && boundary > bestOffset {
-					bestOffset = boundary
-				}
+			newOffset = snapDownToBoundary(m.tableViewport.YOffset, newOffset, m.tableRowBoundaries)
+			if newOffset > maxOffset {
+				newOffset = maxOffset
 			}
-			newOffset = bestOffset
 		}
 
 		m.tableViewport.YOffset = newOffset
@@ -439,48 +466,7 @@ func (m *MainModel) loadMoreTableDataHelper() {
 		m.cachedTableLines = nil
 		// NOTE: Don't update m.lastTableData - formatTableForViewport will handle it
 
-		// Format based on current output format
-		var contentStr string
-		if m.sessionManager != nil {
-			switch m.sessionManager.GetOutputFormat() {
-			case config.OutputFormatASCII:
-				contentStr = FormatASCIITable(allData)
-			case config.OutputFormatExpand:
-				contentStr = FormatExpandTable(allData, m.styles)
-			case config.OutputFormatJSON:
-				// Check if we have a single [json] column from SELECT JSON
-				if len(m.slidingWindow.Headers) == 1 && m.slidingWindow.Headers[0] == "[json]" {
-					jsonStr := ""
-					for _, row := range m.slidingWindow.Rows {
-						if len(row) > 0 {
-							jsonStr += row[0] + "\n"
-						}
-					}
-					contentStr = jsonStr
-				} else {
-					// Convert regular table data to JSON
-					jsonStr := ""
-					for _, row := range m.slidingWindow.Rows {
-						jsonMap := make(map[string]interface{})
-						for i, header := range m.slidingWindow.Headers {
-							if i < len(row) {
-								jsonMap[header] = row[i]
-							}
-						}
-						jsonBytes, err := json.Marshal(jsonMap)
-						if err == nil {
-							jsonStr += string(jsonBytes) + "\n"
-						}
-					}
-					contentStr = jsonStr
-				}
-			default:
-				contentStr = m.formatTableForViewport(allData)
-			}
-		} else {
-			contentStr = m.formatTableForViewport(allData)
-		}
-		m.tableViewport.SetContent(contentStr)
+		m.refreshTableContent(allData)
 
 		// Update row count
 		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)

--- a/internal/ui/keyboard_navtigation.go
+++ b/internal/ui/keyboard_navtigation.go
@@ -1,9 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
-
-	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
 	tea "github.com/charmbracelet/bubbletea"
@@ -162,48 +159,7 @@ func (m *MainModel) handlePageDown(msg tea.KeyMsg) (*MainModel, tea.Cmd) {
 					// Clear cache to force rebuild
 					m.cachedTableLines = nil
 
-					// Format based on current output format
-					var contentStr string
-					if m.sessionManager != nil {
-						switch m.sessionManager.GetOutputFormat() {
-						case config.OutputFormatASCII:
-							contentStr = FormatASCIITable(allData)
-						case config.OutputFormatExpand:
-							contentStr = FormatExpandTable(allData, m.styles)
-						case config.OutputFormatJSON:
-							// Check if we have a single [json] column from SELECT JSON
-							if len(m.slidingWindow.Headers) == 1 && m.slidingWindow.Headers[0] == "[json]" {
-								jsonStr := ""
-								for _, row := range m.slidingWindow.Rows {
-									if len(row) > 0 {
-										jsonStr += row[0] + "\n"
-									}
-								}
-								contentStr = jsonStr
-							} else {
-								// Convert regular table data to JSON
-								jsonStr := ""
-								for _, row := range m.slidingWindow.Rows {
-									jsonMap := make(map[string]interface{})
-									for i, header := range m.slidingWindow.Headers {
-										if i < len(row) {
-											jsonMap[header] = row[i]
-										}
-									}
-									jsonBytes, err := json.Marshal(jsonMap)
-									if err == nil {
-										jsonStr += string(jsonBytes) + "\n"
-									}
-								}
-								contentStr = jsonStr
-							}
-						default:
-							contentStr = m.formatTableForViewport(allData)
-						}
-					} else {
-						contentStr = m.formatTableForViewport(allData)
-					}
-					m.tableViewport.SetContent(contentStr)
+					m.refreshTableContent(allData)
 
 					// Update row count
 					m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"encoding/json"
 
-	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
 	tea "github.com/charmbracelet/bubbletea"
@@ -233,23 +232,7 @@ func (m *MainModel) loadMoreTableData() {
 		m.cachedTableLines = nil
 		m.lastTableData = allData
 
-		// Format based on current output format
-		var contentStr string
-		if m.sessionManager != nil {
-			switch m.sessionManager.GetOutputFormat() {
-			case config.OutputFormatASCII:
-				contentStr = FormatASCIITable(allData)
-			case config.OutputFormatExpand:
-				contentStr = FormatExpandTable(allData, m.styles)
-			case config.OutputFormatJSON:
-				contentStr = m.formatTableAsJSON()
-			default:
-				contentStr = m.formatTableForViewport(allData)
-			}
-		} else {
-			contentStr = m.formatTableForViewport(allData)
-		}
-		m.tableViewport.SetContent(contentStr)
+		m.refreshTableContent(allData)
 
 		// Update row count
 		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)

--- a/internal/ui/table_renderer.go
+++ b/internal/ui/table_renderer.go
@@ -5,8 +5,47 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/logger"
 )
+
+// refreshTableContent re-renders the current result in the active output format
+// and sets the viewport content together with the row boundaries describing it.
+//
+// Paging snaps scroll offsets to tableRowBoundaries. Those are line numbers, so
+// they only mean anything for the layout that produced them and have to be
+// replaced whenever the content is. Leaving stale ones behind caps scrolling:
+// boundaries from the boxed table, where a record is one line, cannot reach past
+// the row count in expand format, where a record is as tall as the table is wide.
+//
+// The boxed renderer fills the boundaries in as it builds; the other formats
+// either report them or have none.
+func (m *MainModel) refreshTableContent(allData [][]string) {
+	var (
+		content    string
+		boundaries []int
+	)
+
+	format := config.OutputFormatTable
+	if m.sessionManager != nil {
+		format = m.sessionManager.GetOutputFormat()
+	}
+
+	switch format {
+	case config.OutputFormatASCII:
+		content = FormatASCIITable(allData)
+	case config.OutputFormatExpand:
+		content, boundaries = FormatExpandTableWithBoundaries(allData, m.styles)
+	case config.OutputFormatJSON:
+		content = m.formatTableAsJSON()
+	default:
+		content = m.formatTableForViewport(allData)
+		boundaries = m.tableRowBoundaries // filled in while rendering
+	}
+
+	m.tableRowBoundaries = boundaries
+	m.tableViewport.SetContent(content)
+}
 
 // formatTableForViewport formats a 2D array of strings as a table for the viewport
 func (m *MainModel) formatTableForViewport(data [][]string) string {


### PR DESCRIPTION
Closes #85. Two faults, and the first one hides the second.

## Fault 1: boundaries from the wrong layout

`tableRowBoundaries` records the line each record starts on, and paging snaps scroll offsets to it. Only the boxed table renderer ever filled it in - `buildFullTable` resets and populates it while rendering. Every other format set the viewport content and left whatever the last table render had put there.

So in EXPAND format the boundaries described a layout where a record is **one line**, while the content on screen had records **ten or more lines** tall. The paging code computes the right limit and then throws it away:

```go
maxOffset := m.tableViewport.TotalLineCount() - m.tableViewport.Height   // correct, ~570
newOffset := m.tableViewport.YOffset + scrollAmount

if len(m.tableRowBoundaries) > 0 {
    bestOffset := m.tableViewport.YOffset
    for _, boundary := range m.tableRowBoundaries {
        if boundary <= newOffset && boundary > bestOffset {
            bestOffset = boundary
        }
    }
    newOffset = bestOffset      // clamped to the largest stale boundary, ~55
}
```

With 52 rows the largest stale boundary is around line 55, so scrolling could never pass it - about row 9 of 52. The reporter called it exactly: *"appears to confuse output lines vs row lines"*.

It only shows after switching **from** TABLE **to** EXPAND, because that is what leaves the stale boundaries behind. Starting in EXPAND, the list is empty and the snap does nothing.

## Fault 2: the snap cannot advance

Fixing the boundaries alone made it **worse** - paging then stuck at line 1:

```
with correct boundaries paging reached line 1 of 555; with stale ones it stopped at 55
```

The snap took the last boundary at or before the target and nothing else. Half a page is 10 lines and expand records are 11 apart, so there was never a boundary in range, and it returned the offset it started from. One-line table boundaries had hidden this for years.

## The fix

- `FormatExpandTableWithBoundaries` reports where each record starts, plus a final boundary so the last record can be scrolled through
- `snapDownToBoundary` steps to the **next** record when nothing lies between the current offset and the target, rather than standing still
- `refreshTableContent` sets content and boundaries together, replacing three copies of the same output-format switch in the mouse handler, the pager and the navigation handler
- ASCII and JSON clear the boundaries instead of inheriting the table's

Net effect on the duplication: `keyboard_navtigation.go` loses 44 lines, `mouse_handler.go` 17, `keyboard_navigation_pager.go` shrinks despite gaining the helper.

## Tests

`internal/ui/expand_formatter_test.go`:

- boundaries land on the actual `@ Row N` lines of the rendered output, checked against the real text rather than assumed
- boundaries track rendered height: same row count, more columns, boundaries spread proportionally further down - the thing table-derived boundaries cannot express
- **the reported scenario**: 52 records, viewport of 20 lines. Paging now walks the entire result in 52 steps and lands on a record start every time
- `snapDownToBoundary` in isolation, including the wedge case: records 11 apart, scroll of 10, must still advance

## Verification note

I could not run the new tests against the previous commit, because they call a function that does not exist there. The pre-fix behaviour in the numbers above was measured during development, with the boundary fix in place and the snap fix not yet written.
