### PR TITLE
fix(schema): stop handing the AI an empty database

### DIFF
--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/session"
 )
 
@@ -97,12 +99,18 @@ func (s *Session) GetTableSchema(keyspace, table string) (*TableSchema, error) {
 		ClusteringKeys: []string{},
 	}
 
-	// Get columns
+	// Get columns.
+	//
+	// Deliberately no ORDER BY: system_schema.columns is clustered by
+	// column_name, and Cassandra rejects ordering by anything else with
+	// "Order by is currently only supported on the clustered columns of the
+	// PRIMARY KEY". Asking for ORDER BY position failed every call, and the
+	// caller swallowed the error, so no table was ever loaded. Sort in Go
+	// instead.
 	columnQuery := `
-		SELECT column_name, type, kind, position 
-		FROM system_schema.columns 
-		WHERE keyspace_name = ? AND table_name = ?
-		ORDER BY position`
+		SELECT column_name, type, kind, position
+		FROM system_schema.columns
+		WHERE keyspace_name = ? AND table_name = ?`
 
 	iter := s.Query(columnQuery, keyspace, table).Iter()
 
@@ -110,25 +118,39 @@ func (s *Session) GetTableSchema(keyspace, table string) (*TableSchema, error) {
 	var position int
 
 	for iter.Scan(&colName, &colType, &colKind, &position) {
-		col := ColumnSchema{
+		ts.Columns = append(ts.Columns, ColumnSchema{
 			Name:     colName,
 			Type:     colType,
 			Kind:     colKind,
 			Position: position,
-		}
-		ts.Columns = append(ts.Columns, col)
-
-		// Track partition and clustering keys
-		switch colKind {
-		case "partition_key":
-			ts.PartitionKeys = append(ts.PartitionKeys, colName)
-		case "clustering":
-			ts.ClusteringKeys = append(ts.ClusteringKeys, colName)
-		}
+		})
 	}
 
 	if err := iter.Close(); err != nil {
 		return nil, fmt.Errorf("failed to retrieve columns: %v", err)
+	}
+
+	// Partition keys first, then clustering keys, then the rest; within a kind,
+	// by position.
+	kindPriority := map[string]int{"partition_key": 0, "clustering": 1, "regular": 2}
+	sort.SliceStable(ts.Columns, func(i, j int) bool {
+		iPriority, jPriority := kindPriority[ts.Columns[i].Kind], kindPriority[ts.Columns[j].Kind]
+		if iPriority != jPriority {
+			return iPriority < jPriority
+		}
+		return ts.Columns[i].Position < ts.Columns[j].Position
+	})
+
+	// Collect the key names only once sorted. Taking them during the scan gives
+	// alphabetical order, which describes a different table: partition key
+	// order decides how rows are distributed, clustering order how they sort.
+	for _, col := range ts.Columns {
+		switch col.Kind {
+		case "partition_key":
+			ts.PartitionKeys = append(ts.PartitionKeys, col.Name)
+		case "clustering":
+			ts.ClusteringKeys = append(ts.ClusteringKeys, col.Name)
+		}
 	}
 
 	if len(ts.Columns) == 0 {
@@ -159,7 +181,10 @@ func (s *Session) loadTablesForKeyspace(ks *KeyspaceSchema) error {
 	for iter.Scan(&tableName) {
 		ts, err := s.GetTableSchema(ks.Name, tableName)
 		if err != nil {
-			continue // Skip tables we can't load
+			// Log rather than skip in silence. A whole schema disappearing
+			// with no message is why the broken query above went unnoticed.
+			logger.DebugfToFile("Schema", "Skipping table %s.%s: %v", ks.Name, tableName, err)
+			continue
 		}
 		ks.Tables[tableName] = ts
 	}

--- a/test/integration/ai_schema_context_test.go
+++ b/test/integration/ai_schema_context_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+// +build integration
+
+package integration_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaContextNamesTables covers #101.
+//
+// GetSchemaContext is what the AI is handed as its picture of the database
+// (internal/ui/ai_commands.go and internal/ai/client.go). It walks keyspaces and
+// loads each table's columns. Loading a table used to fail for every table,
+// because the query asked Cassandra to ORDER BY a column it cannot sort by, and
+// loadTablesForKeyspace discarded the error and moved on. The result was a
+// context listing keyspace names and nothing else - an AI asked to write CQL
+// against a database it believes has no tables will invent them.
+func TestSchemaContextNamesTables(t *testing.T) {
+	dbSession, _, cleanup := getTestSession(t)
+	defer cleanup()
+
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS ai_ctx (
+		a int, b int,
+		z int, y int,
+		note text,
+		PRIMARY KEY ((b, a), z, y)
+	)`).Exec())
+
+	ctx, err := dbSession.GetSchemaContext(50)
+	require.NoError(t, err)
+	require.NotEmpty(t, ctx)
+
+	assert.Contains(t, ctx, "Keyspace: test_roundtrip")
+	assert.Contains(t, ctx, "Table: ai_ctx",
+		"the AI must be told the table exists, not just the keyspace")
+
+	for _, col := range []string{"a", "b", "z", "y", "note"} {
+		assert.Contains(t, ctx, "- "+col+":",
+			"column %q is missing from the schema the AI is given", col)
+	}
+
+	assert.Contains(t, ctx, "(PK)", "partition keys must be marked")
+	assert.Contains(t, ctx, "(CK)", "clustering keys must be marked")
+}
+
+// TestTableSchemaKeyOrder guards the same trap that #84 was about. The columns
+// come back from system_schema.columns alphabetically, so the key order has to
+// be taken after sorting by position, or the AI is told this table is
+// partitioned by (a, b) when it is partitioned by (b, a).
+func TestTableSchemaKeyOrder(t *testing.T) {
+	dbSession, _, cleanup := getTestSession(t)
+	defer cleanup()
+
+	require.NoError(t, dbSession.Query(`CREATE TABLE IF NOT EXISTS ai_key_order (
+		a int, b int, c int,
+		x int, y int, z int,
+		v text,
+		PRIMARY KEY ((c, a, b), z, y, x)
+	)`).Exec())
+
+	ts, err := dbSession.GetTableSchema("test_roundtrip", "ai_key_order")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"c", "a", "b"}, ts.PartitionKeys,
+		"partition keys must follow schema position, not the alphabet")
+	assert.Equal(t, []string{"z", "y", "x"}, ts.ClusteringKeys,
+		"clustering keys must follow schema position, not the alphabet")
+
+	// Columns are ordered keys-first so the AI reads the primary key correctly.
+	var names []string
+	for _, c := range ts.Columns {
+		names = append(names, c.Name)
+	}
+	assert.Equal(t, []string{"c", "a", "b", "z", "y", "x", "v"}, names,
+		"columns should be ordered partition keys, clustering keys, then the rest")
+}
+
+// TestSchemaContextIsNotJustKeyspaces is the symptom in the issue, stated as a
+// measurement rather than a list of assertions.
+func TestSchemaContextIsNotJustKeyspaces(t *testing.T) {
+	dbSession, _, cleanup := getTestSession(t)
+	defer cleanup()
+
+	require.NoError(t, dbSession.Query(
+		`CREATE TABLE IF NOT EXISTS ai_present (id int PRIMARY KEY, v text)`).Exec())
+
+	ctx, err := dbSession.GetSchemaContext(50)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(ctx), "\n")
+	var keyspaceLines, otherLines int
+	for _, l := range lines {
+		if strings.HasPrefix(l, "Keyspace:") {
+			keyspaceLines++
+		} else if strings.TrimSpace(l) != "" {
+			otherLines++
+		}
+	}
+
+	assert.Greater(t, otherLines, 0,
+		"the schema context was %d keyspace lines and nothing else", keyspaceLines)
+}


### PR DESCRIPTION
Closes #101.

## The bug

`GetTableSchema` asked Cassandra to sort by a column it cannot sort by:

```sql
SELECT column_name, type, kind, position
FROM system_schema.columns
WHERE keyspace_name = ? AND table_name = ?
ORDER BY position
```

`system_schema.columns` is clustered by `column_name`, so the server rejects it:

```
Order by is currently only supported on the clustered columns of the PRIMARY KEY, got position
```

Every call failed. And `loadTablesForKeyspace` threw the error away:

```go
ts, err := s.GetTableSchema(ks.Name, tableName)
if err != nil {
    continue // Skip tables we can't load
}
```

So every table was skipped, silently, and each keyspace ended up with none.

## Why it matters

That path is `GetSchemaContext` - what the AI is handed as its picture of the database (`internal/ui/ai_commands.go:39`, `internal/ai/client.go:300`).

Measured against a live cluster, before:

```
Keyspace: hayato2
Keyspace: usb_mny_mvmnt_datastore
Keyspace: hayato
Keyspace: test_roundtrip
Keyspace: metrics_index
Keyspace: ks84
Keyspace: test
```

123 characters. Not one table.

After, on the same cluster - 8747 characters:

```
Keyspace: ks101
  Table: orders
    Columns:
      - region: text (PK)
      - cust_id: uuid (PK)
      - placed: timestamp (CK)
      - item: text
      - qty: int
```

An AI asked to write CQL against a database it believes is empty will invent tables and columns. That makes this a plausible cause of #44 (always wants to create a table), #43 (counting always incorrect) and #42 (ALLOW FILTERING). Worth re-testing those against this before touching any prompts.

## The fix

Drop the `ORDER BY` and sort in Go: partition keys first, then clustering, then the rest, by position within each kind.

Collect the key names **after** sorting, for the same reason as #84. Taking them during the scan gives alphabetical order, which describes a table partitioned by `(a, b)` when it is partitioned by `(b, a)`. Fixing the query without that would have quietly told the AI the wrong primary key for every table - worse than telling it nothing.

`loadTablesForKeyspace` now logs what it skips. A whole schema vanishing without a message is exactly why this went unnoticed.

## Tests

`test/integration/ai_schema_context_test.go`, run by the existing `cassandra-tests` job. All three were written first and **fail against `main`**:

- the context names a table that exists, its columns, and marks its keys
- key order follows schema position, not the alphabet, including column ordering
- the context is not just keyspace lines - stated as a measurement, which is the symptom in the issue

## Still worth deciding, not done here

There is a parallel implementation, `GetTableSchemaUsingMetadata` in `metadata.go`, which reads gocql's metadata and never had this problem. Two implementations of the same thing is how one of them ends up broken for this long. Worth choosing one.
