### PR TITLE
feat(ui): show the modes as clickable tabs at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,13 +312,18 @@ cqlai -e "SELECT * FROM large_table;" --page-size 50
 | `Ctrl+Y` | Paste previously cut text | Same |
 
 #### View Switching
-| Shortcut | Action |
-|----------|--------|
-| `F2` | Switch to query/history view |
-| `F3` | Switch to table view |
-| `F4` | Switch to trace view (when tracing enabled) |
-| `F5` | Switch to AI conversation view |
-| `F6` | Toggle column data types in table headers |
+
+The four views are shown as tabs along the top, so you can see which one you are
+in and what the others are. Click a tab, or use the key on it. A view with
+nothing to show yet is dimmed.
+
+| Shortcut | Tab | Shows |
+|----------|-----|-------|
+| `F2` | Console | The running transcript of commands and messages |
+| `F3` | Results | The last query's output, in whatever `OUTPUT` format is set |
+| `F4` | Trace | Query trace, when tracing is enabled |
+| `F5` | AI | The AI conversation |
+| `F6` | | Toggle column data types in table headers |
 
 #### Scrolling & Table Navigation
 | Shortcut | Action | macOS Alternative |

--- a/README.md
+++ b/README.md
@@ -345,9 +345,17 @@ Press `Esc` to toggle navigation mode when viewing tables or traces.
 
 #### Mouse Support
 
-cqlai leaves the mouse buttons to your terminal, so selecting text, right-click
-paste and middle-click paste all behave exactly as they do in any other program.
-No modifier key needed.
+By default cqlai asks the terminal for mouse events, so you can click the mode
+tabs at the top. The cost is that the terminal no longer handles the buttons
+itself: **selecting text needs Shift held down, and right-click paste does not
+work**.
+
+`MOUSE OFF` hands the buttons back, so selection and paste behave as they do in
+any other program, at the cost of the tabs no longer being clickable. `MOUSE ON`
+turns clicking back on, and `MOUSE` on its own says which is active. The status
+bar shows `[MOUSE]` or `[MOUSE OFF]`.
+
+The F-keys switch mode either way, so nothing forces you into mouse mode.
 
 It gets the scroll wheel through alternate scroll mode, where the terminal turns
 wheel spins into `↑`/`↓` key presses. That means the wheel scrolls whatever `↑`
@@ -357,8 +365,10 @@ conversation in the AI view.
 | Action | Function |
 |--------|----------|
 | Mouse Wheel | Scroll vertically with automatic data loading |
-| Click+Drag | Select text (your terminal's own selection) |
-| Right Click | Paste (if your terminal binds it that way) |
+| Click a tab | Switch mode, with `MOUSE` on (the default) |
+| Shift+Click+Drag | Select text, with `MOUSE` on |
+| Click+Drag | Select text with no modifier, after `MOUSE OFF` |
+| Right Click | Paste, after `MOUSE OFF` |
 | Middle Click | Paste from selection buffer (Linux/Unix) |
 
 Scroll wide tables sideways with `Alt+←`/`Alt+→`, or `<` and `>` in navigation

--- a/internal/ui/keyboard_handler_enter_special.go
+++ b/internal/ui/keyboard_handler_enter_special.go
@@ -16,6 +16,13 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 		return m, tea.Quit, true
 	}
 
+	// MOUSE is handled here rather than in the router because it is UI state:
+	// the mode is a field on the View returned each render, not something the
+	// session knows about.
+	if upperCommand == "MOUSE" || strings.HasPrefix(upperCommand, "MOUSE ") {
+		return m.handleMouseCommand(upperCommand)
+	}
+
 	if upperCommand == "CLEAR" || upperCommand == "CLS" {
 		m.fullHistoryContent = ""
 		m.updateHistoryWrapping()
@@ -34,4 +41,50 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 	}
 
 	return m, nil, false
+}
+
+// handleMouseCommand turns mouse reporting on or off.
+//
+// The two are exclusive at the terminal level, so this is a choice between
+// clicking the mode tabs and the terminal's own text selection. Saying which is
+// active matters: someone who has never heard of this command would otherwise
+// just find that selecting text stopped working, with no clue why.
+func (m *MainModel) handleMouseCommand(upperCommand string) (*MainModel, tea.Cmd, bool) {
+	arg := strings.TrimSpace(strings.TrimPrefix(upperCommand, "MOUSE"))
+
+	switch arg {
+	case "ON":
+		m.mouseEnabled = true
+	case "OFF":
+		m.mouseEnabled = false
+	case "":
+		// Report rather than change, the way SHOW does.
+		m.appendMouseStatus()
+		m.input.Reset()
+		return m, nil, true
+	default:
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render(
+			"Usage: MOUSE [ON|OFF]") + "\n"
+		m.updateHistoryWrapping()
+		m.historyViewport.GotoBottom()
+		m.input.Reset()
+		return m, nil, true
+	}
+
+	m.appendMouseStatus()
+	m.input.Reset()
+	return m, nil, true
+}
+
+// appendMouseStatus writes the current mouse mode and what it costs.
+func (m *MainModel) appendMouseStatus() {
+	if m.mouseEnabled {
+		m.fullHistoryContent += "\n" + m.styles.AccentText.Render("Mouse: ON") +
+			m.styles.MutedText.Render(" - tabs are clickable; hold Shift to select text") + "\n"
+	} else {
+		m.fullHistoryContent += "\n" + m.styles.AccentText.Render("Mouse: OFF") +
+			m.styles.MutedText.Render(" - select and paste as usual; tabs are not clickable") + "\n"
+	}
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -475,8 +475,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
 
-		headerHeight := 2 // mode tabs, then the top bar
-		footerHeight := 1 // status bar
+		headerHeight := 1 // mode tabs
+		footerHeight := 2 // query info, then the connection bar
 		inputHeight := 1  // text input
 		// Guard against a terminal that reports no size, or one too small to
 		// hold the chrome: v2's components size buffers from these and panic on

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -114,6 +114,7 @@ type MainModel struct {
 	hasTable                 bool              // Whether we're currently displaying a table
 	cachedTableLines         []string          // Cache rendered table lines for fast scrolling
 	navigationMode           bool              // Toggle between navigation keys and input mode
+	mouseEnabled             bool              // Whether to ask the terminal for mouse reporting
 	viewMode                 string            // "history", "table", "trace", or "ai_info"
 	showDataTypes            bool              // Whether to show column data types in table headers
 	columnTypes              []string          // Store column data types
@@ -415,29 +416,33 @@ func NewMainModelWithConnectionOptions(options ConnectionOptions) (*MainModel, e
 	statusBar.Consistency = dbSession.Consistency()
 
 	return &MainModel{
-		topBar:                    NewTopBarModel(),
-		statusBar:                 statusBar,
-		input:                     ti,
-		session:                   dbSession,
-		sessionManager:            sessionMgr,
-		config:                    cfg,
-		aiConfig:                  cfg.AI,
-		styles:                    styles,
-		commandHistory:            commandHistory,
-		historyIndex:              -1,
-		fullHistoryContent:        "", // Will be initialized with welcome message in Init()
-		completionEngine:          completionEngine,
-		completions:               []string{},
-		completionIndex:           -1,
-		showCompletions:           false,
-		completionScrollOffset:    0,
-		horizontalOffset:          0,
-		lastTableData:             nil,
-		tableWidth:                0,
-		tableHeaders:              nil,
-		columnWidths:              nil,
-		hasTable:                  false,
-		viewMode:                  "history",
+		topBar:                 NewTopBarModel(),
+		statusBar:              statusBar,
+		input:                  ti,
+		session:                dbSession,
+		sessionManager:         sessionMgr,
+		config:                 cfg,
+		aiConfig:               cfg.AI,
+		styles:                 styles,
+		commandHistory:         commandHistory,
+		historyIndex:           -1,
+		fullHistoryContent:     "", // Will be initialized with welcome message in Init()
+		completionEngine:       completionEngine,
+		completions:            []string{},
+		completionIndex:        -1,
+		showCompletions:        false,
+		completionScrollOffset: 0,
+		horizontalOffset:       0,
+		lastTableData:          nil,
+		tableWidth:             0,
+		tableHeaders:           nil,
+		columnWidths:           nil,
+		hasTable:               false,
+		viewMode:               "history",
+		// On by default so the mode tabs are clickable without anyone having to
+		// find a setting first. The cost is that selecting text needs Shift and
+		// right-click paste stops working, which MOUSE OFF gives back.
+		mouseEnabled:              true,
 		hasTrace:                  false,
 		traceData:                 nil,
 		traceHeaders:              nil,
@@ -470,7 +475,7 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
 
-		headerHeight := 1 // top bar
+		headerHeight := 2 // mode tabs, then the top bar
 		footerHeight := 1 // status bar
 		inputHeight := 1  // text input
 		// Guard against a terminal that reports no size, or one too small to

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -24,11 +24,20 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 	logger.DebugfToFile("Mouse", "MouseEvent: %T Button=%v X=%d Y=%d Mod=%v",
 		msg, mouse.Button, mouse.X, mouse.Y, mouse.Mod)
 
-	// Only wheel events matter here. v2 splits clicks, releases, motion and
-	// wheel into separate types, so anything else is simply not ours. Note that
-	// ignoring a click here is not what lets the terminal select text - by the
-	// time an event arrives the terminal has already given the button up.
-	// Leaving MouseMode off is what does that.
+	// A click on the tab line switches mode. Row 0 is the tabs; everything
+	// below belongs to the view.
+	if _, isClick := msg.(tea.MouseClickMsg); isClick {
+		if mouse.Button == tea.MouseLeft && mouse.Y == 0 {
+			return m.clickTab(mouse.X)
+		}
+		return m, nil
+	}
+
+	// Otherwise only wheel events matter. v2 splits clicks, releases, motion
+	// and wheel into separate types, so anything else is not ours. Note that
+	// ignoring an event here is not what lets the terminal select text - by the
+	// time one arrives the terminal has already given the button up. Leaving
+	// MouseMode off is what does that.
 	if _, isWheel := msg.(tea.MouseWheelMsg); !isWheel {
 		return m, nil
 	}
@@ -287,4 +296,30 @@ func (m *MainModel) formatTableAsJSON() string {
 		}
 	}
 	return jsonStr
+}
+
+// clickTab switches to whichever mode's tab covers a column.
+//
+// A tab with nothing to show is dimmed and reports itself unavailable, so
+// clicking it does nothing rather than dropping you on an empty screen. The
+// F-keys stay unconditional, matching what they did before there were tabs.
+func (m *MainModel) clickTab(col int) (*MainModel, tea.Cmd) {
+	mode, available := m.modeAt(m.windowWidth, col)
+	if !available || mode == m.viewMode {
+		return m, nil
+	}
+
+	logger.DebugfToFile("Mouse", "Tab clicked at column %d: switching to %s", col, mode)
+
+	switch mode {
+	case "history":
+		return m.handleF2()
+	case "table":
+		return m.handleF3()
+	case "trace":
+		return m.handleF4()
+	case "ai":
+		return m.handleF5()
+	}
+	return m, nil
 }

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -16,6 +16,7 @@ type StatusBarModel struct {
 	Consistency  string
 	PagingSize   int
 	Tracing      bool
+	AutoFetch    bool
 	HasTraceData bool // Whether trace data is available to view
 	Keyspace     string
 	Version      string
@@ -31,6 +32,7 @@ func NewStatusBarModel() StatusBarModel {
 		Consistency:  "LOCAL_ONE",
 		PagingSize:   100,
 		Tracing:      false,
+		AutoFetch:    false,
 		OutputFormat: "TABLE",
 	}
 }
@@ -82,12 +84,21 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 		tracingStyle = tracingOnStyle
 	}
 
+	autoFetchState := "OFF"
+	autoFetchStyle := tracingOffStyle
+	if m.AutoFetch {
+		autoFetchState = "ON"
+		autoFetchStyle = tracingOnStyle
+	}
+
 	// Version style
 	versionStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#B8B8B8"))
 
 	// Build the status text with colors in the requested order:
-	// Cassandra version, User, Host, KS, Cons, Pg, Trace
+	// Cassandra version, User, Host, KS, CL, Pg, Trace, Fetch.
+	// AutoFetch sits here with the other session settings rather than up with
+	// the query facts, since that is what it is.
 	statusText := ""
 
 	// Start with version if available
@@ -103,11 +114,13 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 		separatorStyle.Render(" │ ") +
 		labelStyle.Render("KS: ") + keyspaceStyle.Render(keyspaceDisplay) +
 		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Cons: ") + consistencyStyle.Render(m.Consistency) +
+		labelStyle.Render("CL: ") + consistencyStyle.Render(m.Consistency) +
 		separatorStyle.Render(" │ ") +
 		labelStyle.Render("Pg: ") + pageStyle.Render(fmt.Sprintf("%d", m.PagingSize)) +
 		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Trace: ") + tracingStyle.Render(tracingState)
+		labelStyle.Render("Trace: ") + tracingStyle.Render(tracingState) +
+		separatorStyle.Render(" │ ") +
+		labelStyle.Render("Fetch: ") + autoFetchStyle.Render(autoFetchState)
 
 	// Apply style to the entire bar without forced background
 	barStyle := lipgloss.NewStyle().

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -16,16 +16,23 @@ import (
 type modeTab struct {
 	mode  string // matches MainModel.viewMode
 	label string
+	short string // one or two letters for a terminal too narrow for the label
 	key   string
 }
 
 // modeTabs lists the tabs in display order. F6 is deliberately absent: it sits
 // next to these keys but toggles data types rather than switching mode.
 var modeTabs = []modeTab{
-	{mode: "history", label: "CQL", key: "F2"},
-	{mode: "table", label: "Table", key: "F3"},
-	{mode: "trace", label: "Trace", key: "F4"},
-	{mode: "ai", label: "AI", key: "F5"},
+	// "Console" rather than "History": Ctrl+R searches command history, which
+	// is a different thing, and this view is the running transcript of what you
+	// typed and what came back.
+	{mode: "history", label: "Console", short: "C", key: "F2"},
+	// "Results" rather than "Table": the same view shows EXPAND, ASCII and JSON
+	// output, none of which is a table, and "table" already means a schema
+	// object to anyone using this.
+	{mode: "table", label: "Results", short: "R", key: "F3"},
+	{mode: "trace", label: "Trace", short: "T", key: "F4"},
+	{mode: "ai", label: "AI", short: "A", key: "F5"},
 }
 
 // tabAvailable reports whether a tab has anything to show. An unavailable tab
@@ -52,7 +59,9 @@ func tabText(width int) []string {
 	for i, t := range modeTabs {
 		full[i] = t.label + " (" + t.key + ")"
 		plain[i] = t.label
-		short[i] = t.label[:1]
+		// Not label[:1]: two labels can share a first letter, and a bar of
+		// indistinguishable letters is worse than no bar.
+		short[i] = t.short
 	}
 
 	for _, candidate := range [][]string{full, plain, short} {

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -1,0 +1,180 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// The mode tabs across the top.
+//
+// The four modes used to be reachable only by F-key, with nothing on screen
+// saying so. The tabs put the choices and their keys in front of you, and mark
+// the ones that have nothing to show yet.
+
+// modeTab is one entry in the tab bar.
+type modeTab struct {
+	mode  string // matches MainModel.viewMode
+	label string
+	key   string
+}
+
+// modeTabs lists the tabs in display order. F6 is deliberately absent: it sits
+// next to these keys but toggles data types rather than switching mode.
+var modeTabs = []modeTab{
+	{mode: "history", label: "CQL", key: "F2"},
+	{mode: "table", label: "Table", key: "F3"},
+	{mode: "trace", label: "Trace", key: "F4"},
+	{mode: "ai", label: "AI", key: "F5"},
+}
+
+// tabAvailable reports whether a tab has anything to show. An unavailable tab
+// is dimmed and ignores clicks; the key still works, matching what F3 and F4
+// did before, so nobody loses a shortcut they were used to.
+func (m *MainModel) tabAvailable(mode string) bool {
+	switch mode {
+	case "table":
+		return m.hasTable
+	case "trace":
+		return m.hasTrace
+	default:
+		return true
+	}
+}
+
+// tabText renders the tab labels at one of three widths. The bar must never
+// wrap onto a second line, so it drops the key hints and then shortens the
+// names before anything is left out.
+func tabText(width int) []string {
+	full := make([]string, len(modeTabs))
+	plain := make([]string, len(modeTabs))
+	short := make([]string, len(modeTabs))
+	for i, t := range modeTabs {
+		full[i] = t.label + " (" + t.key + ")"
+		plain[i] = t.label
+		short[i] = t.label[:1]
+	}
+
+	for _, candidate := range [][]string{full, plain, short} {
+		if tabBarWidth(candidate) <= width {
+			return candidate
+		}
+	}
+	return short
+}
+
+// tabSeparator sits between tabs; the padding is part of each tab's click area.
+const tabSeparator = "  "
+
+func tabBarWidth(labels []string) int {
+	total := 0
+	for _, l := range labels {
+		total += len(l) + 2 // one space of padding each side
+	}
+	return total + len(tabSeparator)*(len(labels)-1)
+}
+
+// tabSpan is where a tab sits on the line, used to turn a click into a mode.
+type tabSpan struct {
+	mode       string
+	label      string
+	start, end int // column range, end exclusive
+	available  bool
+	active     bool
+}
+
+// layoutTabs decides what fits on the line and where each tab sits.
+//
+// Rendering and click handling both go through this, so a click always lands on
+// the tab that was actually drawn there. On a terminal too narrow even for
+// single letters, tabs are dropped from the right rather than wrapped: a second
+// line would push the viewport down and break the height arithmetic.
+func (m *MainModel) layoutTabs(width int) []tabSpan {
+	if width <= 0 {
+		return nil
+	}
+
+	labels := tabText(width)
+
+	spans := make([]tabSpan, 0, len(modeTabs))
+	col := 0
+	for i, t := range modeTabs {
+		next := col
+		if i > 0 {
+			next += len(tabSeparator)
+		}
+		end := next + len(labels[i]) + 2
+		if end > width {
+			break // no room left; leave the rest off rather than wrap
+		}
+
+		spans = append(spans, tabSpan{
+			mode:      t.mode,
+			label:     labels[i],
+			start:     next,
+			end:       end,
+			available: m.tabAvailable(t.mode),
+			active:    m.viewMode == t.mode,
+		})
+		col = end
+	}
+	return spans
+}
+
+// modeAt returns the mode whose tab covers a column, and whether it can be
+// switched to. An unavailable tab reports false so a click on it does nothing.
+func (m *MainModel) modeAt(width, col int) (string, bool) {
+	for _, span := range m.layoutTabs(width) {
+		if col >= span.start && col < span.end {
+			return span.mode, span.available
+		}
+	}
+	return "", false
+}
+
+// ViewTabBar renders the tab line.
+func (m *MainModel) ViewTabBar(width int) string {
+	spans := m.layoutTabs(width)
+	if len(spans) == 0 {
+		return strings.Repeat(" ", max(width, 0))
+	}
+
+	activeStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#1c1c1c")).
+		Background(lipgloss.Color("#87D7FF")).
+		Bold(true)
+
+	availableStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#87D7FF"))
+
+	unavailableStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#585858"))
+
+	separatorStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#3a3a3a"))
+
+	var b strings.Builder
+	for i, span := range spans {
+		if i > 0 {
+			b.WriteString(separatorStyle.Render(tabSeparator))
+		}
+
+		text := " " + span.label + " "
+		switch {
+		case span.active:
+			b.WriteString(activeStyle.Render(text))
+		case span.available:
+			b.WriteString(availableStyle.Render(text))
+		default:
+			b.WriteString(unavailableStyle.Render(text))
+		}
+	}
+
+	// Pad by hand rather than with lipgloss Width, which wraps instead of
+	// truncating when the content is wider than the line.
+	if pad := width - spans[len(spans)-1].end; pad > 0 {
+		b.WriteString(strings.Repeat(" ", pad))
+	}
+
+	return b.String()
+}

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -30,15 +30,49 @@ func TestTabBarShowsKeysWhenThereIsRoom(t *testing.T) {
 	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
 
 	wide := stripAnsiForTest(m.ViewTabBar(120))
-	for _, want := range []string{"CQL (F2)", "Table (F3)", "Trace (F4)", "AI (F5)"} {
+	for _, want := range []string{"Console (F2)", "Results (F3)", "Trace (F4)", "AI (F5)"} {
 		assert.Contains(t, wide, want)
 	}
 
 	// Narrower: names survive, key hints are dropped rather than wrapping.
-	medium := stripAnsiForTest(m.ViewTabBar(30))
-	assert.Contains(t, medium, "CQL")
-	assert.Contains(t, medium, "Table")
+	medium := stripAnsiForTest(m.ViewTabBar(40))
+	assert.Contains(t, medium, "Console")
+	assert.Contains(t, medium, "Results")
 	assert.NotContains(t, medium, "(F2)")
+}
+
+// TestShortLabelsAreDistinct guards the narrow-terminal fallback.
+//
+// Truncating to the first letter is the obvious approach and it is wrong: two
+// labels can share one. A bar reading "C T T A" tells you nothing about which
+// tab is which, so the short forms are chosen rather than derived.
+func TestShortLabelsAreDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for _, tab := range modeTabs {
+		require.NotEmpty(t, tab.short, "%q has no short label", tab.label)
+
+		if other, clash := seen[tab.short]; clash {
+			t.Errorf("%q and %q both shorten to %q, so they cannot be told apart on a narrow terminal",
+				other, tab.label, tab.short)
+		}
+		seen[tab.short] = tab.label
+	}
+}
+
+// TestNarrowBarStaysDistinct is the same guarantee through the rendered output,
+// so it holds for whatever the layout actually draws.
+func TestNarrowBarStaysDistinct(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	bar := stripAnsiForTest(m.ViewTabBar(20))
+	fields := strings.Fields(bar)
+	require.NotEmpty(t, fields)
+
+	seen := map[string]bool{}
+	for _, f := range fields {
+		assert.False(t, seen[f], "the narrow bar repeats %q, so two tabs look the same", f)
+		seen[f] = true
+	}
 }
 
 // TestTabBarMarksTheCurrentMode checks exactly one tab is the active one, and

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -1,0 +1,238 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTabBarNeverWraps(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	// Every width from unusable to generous.
+	for width := 1; width <= 200; width++ {
+		bar := m.ViewTabBar(width)
+		assert.NotContains(t, bar, "\n", "the tab bar wrapped at width %d", width)
+
+		plain := stripAnsiForTest(bar)
+		assert.LessOrEqual(t, len([]rune(strings.TrimRight(plain, " "))), width,
+			"tab bar overflowed at width %d: %q", width, plain)
+	}
+}
+
+func TestTabBarShowsKeysWhenThereIsRoom(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	wide := stripAnsiForTest(m.ViewTabBar(120))
+	for _, want := range []string{"CQL (F2)", "Table (F3)", "Trace (F4)", "AI (F5)"} {
+		assert.Contains(t, wide, want)
+	}
+
+	// Narrower: names survive, key hints are dropped rather than wrapping.
+	medium := stripAnsiForTest(m.ViewTabBar(30))
+	assert.Contains(t, medium, "CQL")
+	assert.Contains(t, medium, "Table")
+	assert.NotContains(t, medium, "(F2)")
+}
+
+// TestTabBarMarksTheCurrentMode checks exactly one tab is the active one, and
+// that it is the mode being viewed. Colour cannot be asserted here: lipgloss
+// emits no escape codes without a terminal, so the test looks at the layout.
+func TestTabBarMarksTheCurrentMode(t *testing.T) {
+	for _, mode := range []string{"history", "table", "trace", "ai"} {
+		t.Run(mode, func(t *testing.T) {
+			m := &MainModel{viewMode: mode, hasTable: true, hasTrace: true}
+
+			active := []string{}
+			for _, span := range m.layoutTabs(120) {
+				if span.active {
+					active = append(active, span.mode)
+				}
+			}
+
+			require.Len(t, active, 1, "exactly one tab should be active")
+			assert.Equal(t, mode, active[0])
+		})
+	}
+}
+
+// TestTabBarUnknownModeHighlightsNothing guards the edge where viewMode is
+// something the bar does not list, so it must not pick an arbitrary tab.
+func TestTabBarUnknownModeHighlightsNothing(t *testing.T) {
+	m := &MainModel{viewMode: "ai_info", hasTable: true, hasTrace: true}
+	for _, span := range m.layoutTabs(120) {
+		assert.False(t, span.active, "%q should not be marked active", span.mode)
+	}
+}
+
+// TestTabAvailability covers the "modes with no data look unavailable" rule.
+func TestTabAvailability(t *testing.T) {
+	empty := &MainModel{viewMode: "history"}
+	assert.True(t, empty.tabAvailable("history"))
+	assert.True(t, empty.tabAvailable("ai"))
+	assert.False(t, empty.tabAvailable("table"), "no results yet, so nothing to show")
+	assert.False(t, empty.tabAvailable("trace"), "no trace yet, so nothing to show")
+
+	loaded := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	assert.True(t, loaded.tabAvailable("table"))
+	assert.True(t, loaded.tabAvailable("trace"))
+}
+
+// TestModeAtMapsClicksToTabs is what makes the tabs clickable: a column on the
+// tab line has to resolve back to the mode drawn there.
+func TestModeAtMapsClicksToTabs(t *testing.T) {
+	const width = 120
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	spans := m.layoutTabs(width)
+	require.Len(t, spans, 4)
+
+	for _, span := range spans {
+		for _, col := range []int{span.start, (span.start + span.end) / 2, span.end - 1} {
+			mode, ok := m.modeAt(width, col)
+			assert.Equal(t, span.mode, mode, "column %d should belong to %q", col, span.mode)
+			assert.True(t, ok, "%q is available and should accept a click", span.mode)
+		}
+	}
+
+	// Past the last tab there is nothing to click.
+	_, ok := m.modeAt(width, spans[len(spans)-1].end+1)
+	assert.False(t, ok)
+
+	// Spans do not overlap and are in display order.
+	for i := 1; i < len(spans); i++ {
+		assert.GreaterOrEqual(t, spans[i].start, spans[i-1].end,
+			"tab %d overlaps the one before it", i)
+	}
+}
+
+// TestUnavailableTabsIgnoreClicks pairs with the dimming: a tab that looks
+// unavailable must not respond.
+func TestUnavailableTabsIgnoreClicks(t *testing.T) {
+	const width = 120
+	m := &MainModel{viewMode: "history"} // no results, no trace
+
+	for _, span := range m.layoutTabs(width) {
+		mode, ok := m.modeAt(width, (span.start+span.end)/2)
+		switch mode {
+		case "table", "trace":
+			assert.False(t, ok, "%q has nothing to show and must not be clickable", mode)
+		default:
+			assert.True(t, ok, "%q should be clickable", mode)
+		}
+	}
+}
+
+// TestClickingATabSwitchesMode covers the point of making the bar clickable.
+func TestClickingATabSwitchesMode(t *testing.T) {
+	const width = 120
+
+	newModel := func() *MainModel {
+		input := textinput.New()
+		input.SetWidth(width)
+		return &MainModel{
+			input:        input,
+			viewMode:     "history",
+			hasTable:     true,
+			hasTrace:     true,
+			mouseEnabled: true,
+			windowWidth:  width,
+			styles:       DefaultStyles(),
+		}
+	}
+
+	for _, want := range []string{"table", "trace"} {
+		t.Run(want, func(t *testing.T) {
+			m := newModel()
+
+			var col int
+			for _, span := range m.layoutTabs(width) {
+				if span.mode == want {
+					col = (span.start + span.end) / 2
+				}
+			}
+
+			m.clickTab(col)
+			assert.Equal(t, want, m.viewMode, "clicking the %s tab should switch to it", want)
+		})
+	}
+}
+
+// TestClickingAnUnavailableTabDoesNothing pairs with dimming: a tab with
+// nothing behind it must not drop you on an empty screen.
+func TestClickingAnUnavailableTabDoesNothing(t *testing.T) {
+	const width = 120
+
+	input := textinput.New()
+	m := &MainModel{
+		input:       input,
+		viewMode:    "history",
+		windowWidth: width,
+		styles:      DefaultStyles(),
+	} // no results, no trace
+
+	for _, span := range m.layoutTabs(width) {
+		if span.mode != "table" && span.mode != "trace" {
+			continue
+		}
+		m.clickTab((span.start + span.end) / 2)
+		assert.Equal(t, "history", m.viewMode,
+			"the %s tab has nothing to show and must not be clickable", span.mode)
+	}
+}
+
+// TestMouseCommandTogglesReporting covers MOUSE ON and MOUSE OFF, which is the
+// escape hatch for anyone who would rather have text selection than clicking.
+func TestMouseCommandTogglesReporting(t *testing.T) {
+	input := textinput.New()
+	m := &MainModel{
+		input:              input,
+		viewMode:           "history",
+		mouseEnabled:       true,
+		styles:             DefaultStyles(),
+		historyViewport:    viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		fullHistoryContent: "",
+	}
+
+	_, _, handled := m.handleSpecialCommands("MOUSE OFF")
+	assert.True(t, handled, "MOUSE OFF should be handled by the UI, not sent to Cassandra")
+	assert.False(t, m.mouseEnabled)
+	assert.Contains(t, m.fullHistoryContent, "Mouse: OFF")
+
+	_, _, handled = m.handleSpecialCommands("MOUSE ON")
+	assert.True(t, handled)
+	assert.True(t, m.mouseEnabled)
+	assert.Contains(t, m.fullHistoryContent, "Mouse: ON")
+
+	// Bare MOUSE reports without changing anything.
+	before := m.mouseEnabled
+	_, _, handled = m.handleSpecialCommands("MOUSE")
+	assert.True(t, handled)
+	assert.Equal(t, before, m.mouseEnabled, "bare MOUSE should report, not toggle")
+
+	// Anything else is a usage error rather than a silent no-op.
+	_, _, handled = m.handleSpecialCommands("MOUSE SIDEWAYS")
+	assert.True(t, handled)
+	assert.Contains(t, m.fullHistoryContent, "Usage: MOUSE")
+}
+
+// TestMouseModeFollowsTheSetting checks the View actually carries it, since
+// that is what the terminal acts on.
+func TestMouseModeFollowsTheSetting(t *testing.T) {
+	m := &MainModel{mouseEnabled: true}
+	assert.Equal(t, tea.MouseModeCellMotion, m.newView("").MouseMode,
+		"reporting must be on for the tabs to be clickable")
+
+	m.mouseEnabled = false
+	assert.Equal(t, tea.MouseModeNone, m.newView("").MouseMode,
+		"MOUSE OFF must hand the buttons back to the terminal")
+
+	// The alternate screen is asked for either way.
+	assert.True(t, m.newView("").AltScreen)
+}

--- a/internal/ui/topbar.go
+++ b/internal/ui/topbar.go
@@ -13,8 +13,11 @@ type TopBarModel struct {
 	QueryTime    time.Duration
 	RowCount     int
 	HasQueryData bool
-	AutoFetch    bool
-	HasMoreData  bool // Indicates if there's more data to fetch
+	// Not displayed here any more - the status bar shows it with the other
+	// session settings - but still needed to decide whether the row count is
+	// shown as "100+" with more to fetch.
+	AutoFetch   bool
+	HasMoreData bool // Indicates if there's more data to fetch
 }
 
 // NewTopBarModel creates a new TopBarModel.
@@ -41,26 +44,9 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	separatorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#555555"))
 
-	// AutoFetch styles
-	autoFetchOnStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#87FFD7")).
-		Bold(true)
-
-	autoFetchOffStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#5F5F5F"))
-
 	// The mode used to be named here. The tab line above shows it now, and
 	// highlights it, so repeating it would only take up room.
 	content := ""
-
-	// Add AutoFetch status
-	autoFetchState := "OFF"
-	autoFetchStyle := autoFetchOffStyle
-	if m.AutoFetch {
-		autoFetchState = "ON"
-		autoFetchStyle = autoFetchOnStyle
-	}
-	content += labelStyle.Render("AutoFetch: ") + autoFetchStyle.Render(autoFetchState)
 
 	// Add command information if available
 	if m.LastCommand != "" {

--- a/internal/ui/topbar.go
+++ b/internal/ui/topbar.go
@@ -41,10 +41,6 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	separatorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#555555"))
 
-	modeStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FF87FF")).
-		Bold(true)
-
 	// AutoFetch styles
 	autoFetchOnStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#87FFD7")).
@@ -53,19 +49,9 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	autoFetchOffStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#5F5F5F"))
 
-	// Start with the mode
-	var modeText string
-	switch viewMode {
-	case "ai":
-		modeText = "AI"
-	case "table":
-		modeText = "TABLE"
-	case "trace":
-		modeText = "TRACE"
-	default:
-		modeText = "CQL"
-	}
-	content := labelStyle.Render("Mode: ") + modeStyle.Render(modeText)
+	// The mode used to be named here. The tab line above shows it now, and
+	// highlights it, so repeating it would only take up room.
+	content := ""
 
 	// Add AutoFetch status
 	autoFetchState := "OFF"
@@ -74,8 +60,7 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 		autoFetchState = "ON"
 		autoFetchStyle = autoFetchOnStyle
 	}
-	content += separatorStyle.Render(" │ ") +
-		labelStyle.Render("AutoFetch: ") + autoFetchStyle.Render(autoFetchState)
+	content += labelStyle.Render("AutoFetch: ") + autoFetchStyle.Render(autoFetchState)
 
 	// Add command information if available
 	if m.LastCommand != "" {

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -15,15 +15,22 @@ import (
 // commands, the alternate screen and mouse mode are fields recomputed on every
 // render, so they cannot drift out of step with what is on screen.
 //
-// MouseMode stays None deliberately. Asking for mouse reporting takes the
-// buttons away from the terminal, which is what stopped text selection and
-// right-click paste working before #86. The wheel arrives as Up/Down key
-// presses through alternate scroll mode instead, which v2 does not manage and
-// mouse_mode.go still sets up.
+// MouseMode is a trade rather than a setting with a right answer. Asking for
+// mouse reporting is what makes the tabs clickable, and it is also what takes
+// the buttons away from the terminal, so text selection needs Shift and
+// right-click paste stops working - the behaviour #86 was about. MOUSE OFF
+// gives those back at the cost of clicking.
+//
+// Either way the wheel still scrolls, through alternate scroll mode, which v2
+// does not manage and mouse_mode.go sets up.
 func (m *MainModel) newView(content string) tea.View {
 	v := tea.NewView(content)
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeNone
+	if m.mouseEnabled {
+		v.MouseMode = tea.MouseModeCellMotion
+	} else {
+		v.MouseMode = tea.MouseModeNone
+	}
 	return v
 }
 
@@ -178,6 +185,17 @@ func (m *MainModel) View() tea.View {
 		}
 	}
 
+	// Say which way the mouse is set. Without this, someone who has never heard
+	// of the MOUSE command just finds that selecting text needs Shift, with
+	// nothing on screen explaining why.
+	if m.mouseEnabled {
+		mouseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF"))
+		scrollInfo += " " + mouseStyle.Render("[MOUSE]")
+	} else {
+		mouseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#5F5F5F"))
+		scrollInfo += " " + mouseStyle.Render("[MOUSE OFF]")
+	}
+
 	// Build the input section
 	var inputSection string
 	if m.viewMode == "ai" && m.aiConversationActive {
@@ -284,8 +302,11 @@ func (m *MainModel) View() tea.View {
 		viewportSection = viewportContent
 	}
 
-	// Build the final view
+	// Build the final view. The tabs get their own line above the status bar so
+	// the modes and their keys are always on screen, rather than something you
+	// have to have read the README to know about.
 	finalView = lipgloss.JoinVertical(lipgloss.Left,
+		m.ViewTabBar(viewportWidth),
 		topBar,
 		viewportSection,
 		inputSection,

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -271,11 +271,13 @@ func (m *MainModel) View() tea.View {
 	// Build the main view with proper sticky header overlay
 	var finalView string
 
-	// Always show the top bar
-	topBar := m.topBar.View(viewportWidth, m.styles, m.viewMode)
-	if topBar == "" {
-		// Ensure top bar is never empty
-		topBar = " " // At least one space to maintain layout
+	// Query facts - AutoFetch, the last command, timing, row count. These sit at
+	// the bottom now, just above the connection bar, so the top of the screen is
+	// only the tabs and the result starts a line higher.
+	infoBar := m.topBar.View(viewportWidth, m.styles, m.viewMode)
+	if infoBar == "" {
+		// Never empty, or the row collapses and the layout shifts
+		infoBar = " "
 	}
 
 	// Build the viewport section with sticky header for tables
@@ -307,9 +309,9 @@ func (m *MainModel) View() tea.View {
 	// have to have read the README to know about.
 	finalView = lipgloss.JoinVertical(lipgloss.Left,
 		m.ViewTabBar(viewportWidth),
-		topBar,
 		viewportSection,
 		inputSection,
+		infoBar,
 		m.statusBar.View(viewportWidth, m.styles, m.viewMode)+scrollInfo,
 	)
 

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -42,7 +42,9 @@ func (m *MainModel) View() tea.View {
 
 	m.topBar.LastCommand = m.lastCommand
 	if m.session != nil {
-		m.topBar.AutoFetch = m.session.AutoFetch()
+		autoFetch := m.session.AutoFetch()
+		m.statusBar.AutoFetch = autoFetch
+		m.topBar.AutoFetch = autoFetch // drives the "+" on the row count
 	}
 	if m.slidingWindow != nil {
 		m.topBar.HasMoreData = m.slidingWindow.hasMoreData

--- a/internal/validation/command.go
+++ b/internal/validation/command.go
@@ -31,7 +31,7 @@ func ValidateCommandSyntax(command string) error {
 		"DESCRIBE", "DESC", "CONSISTENCY", "OUTPUT",
 		"PAGING", "AUTOFETCH", "TRACING", "SOURCE",
 		"COPY", "SHOW", "EXPAND", "CAPTURE",
-		"HELP", "SAVE",
+		"HELP", "SAVE", "MOUSE",
 	}
 
 	// Check if command starts with any valid keyword


### PR DESCRIPTION
Closes #93. **Please try this one before merging** - the visual result is a matter of taste and I cannot see it.

## What it does

The four modes now sit on their own line at the top, with their keys, the current one highlighted, and any mode with nothing to show dimmed:

```
  Console (F2)    Results (F3)    Trace (F4)    AI (F5)
  ... results ...
> your query here
 Last: SELECT * FROM users │ Query: 12ms │ Rows: 100
 v5.0.9 │ User: … │ Host: … │ KS: … │ CL: LOCAL_ONE │ Pg: 100 │ Trace: OFF │ Fetch: ON  [MOUSE]
```

The tabs are alone at the top. The query facts - AutoFetch, last command, timing, row count - moved to the bottom, just above the connection bar.

`Mode: TABLE` comes out of that bar entirely: the tabs say the same thing and highlight it, so keeping both would be repetition.

## Clicking, and what it costs

Clicking a tab needs mouse reporting, and that is exclusive with the terminal's own text selection. With it on, **selecting text needs Shift and right-click paste stops working** - the behaviour #86 was filed about.

As decided on the issue, reporting is **on by default** so the tabs work out of the box:

- `MOUSE OFF` hands the buttons back: selection and paste as normal, tabs not clickable
- `MOUSE ON` turns clicking back on
- `MOUSE` on its own reports which is active
- The status bar shows `[MOUSE]` or `[MOUSE OFF]`

That indicator is not decoration. Without it the only symptom of the default is that selecting text quietly stops working, with nothing on screen explaining why.

The F-keys are unconditional either way, so nobody has to enable the mouse to change tab. A dimmed tab ignores clicks rather than dropping you on an empty screen.

## Two details

**The viewport keeps its height.** Moving the info bar down means the header goes back to one row and the footer to two, which cancel out, so the tabs cost nothing. That removes the one real objection raised on the issue.

**Names.** "CQL" said nothing, since everything here is CQL, and "Table" was wrong twice: the same view shows EXPAND, ASCII and JSON output, none of which is a table, and "table" already means a schema object to anyone using this. Not "History" for the first one, even though the code calls it that, because Ctrl+R searches command history and that is a different thing.

Renaming also surfaced a real defect. The narrow-terminal fallback truncated to the first letter, so Table and Trace both became "T" and the bar read `C T T A`. Short forms are now chosen per tab rather than derived, with a test that fails if any two ever collide.

**Also moved.** `Mode: TABLE` is gone from the info bar, since the tabs say it and highlight it. `AutoFetch` became `Fetch` on the bottom line next to `CL`, `Pg` and `Trace`, being a session setting rather than a fact about the last query. `Cons:` became `CL:`, which is what Cassandra calls it.

**The bar never wraps.** It degrades in stages, tested at every width from 1 to 200:

```
w=120  | Console (F2)    Results (F3)    Trace (F4)    AI (F5)
w=40   | Console    Results    Trace    AI
w=26   | C    R    T    A
w=14   | C    R    T
```

Labels with keys, then labels, then distinct letters, then tabs dropped from the right - never a second line, which would push everything down and break the height arithmetic.

## v2 made this easier

Worth noting since it justifies doing #104 first: mouse mode is a field on the `View` returned each render, so toggling it is

```go
if m.mouseEnabled {
    v.MouseMode = tea.MouseModeCellMotion
} else {
    v.MouseMode = tea.MouseModeNone
}
```

On v1 this would have been raw escape sequences and teardown bookkeeping across every quit path, which is exactly the shape of thing #87 had to do by hand.

## Tests

Layout at every width from 1 to 200 with no wrapping or overflow; key hints dropped before names; exactly one tab active and only for a mode the bar lists; clicks mapping back to the tab drawn at that column; unavailable tabs ignoring clicks; `MOUSE` in all four forms; and that the `View` actually carries the mouse mode, since that is what the terminal acts on.

## What I cannot check

How it looks, and whether clicking feels right in a real terminal. Also whether the info bar reads better below the input line, where it is now, or above it - I was not certain which you meant, and it is a one-line change either way.

