### PR TITLE
feat(ui): click the settings on the bottom line, and drag to select text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,14 +78,3 @@ Thumbs.db
 ehthumbs.db
 
 plan/
-
-### BROKK'S CONFIGURATION ###
-.brokk/**
-/.brokk/workspace.properties
-/.brokk/sessions/
-/.brokk/dependencies/
-/.brokk/history.zip
-!AGENTS.md
-!.brokk/style.md
-!.brokk/review.md
-!.brokk/project.properties

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ We encourage you to **try CQLAI today** and help shape its development! Your fee
     - A multi-layer, full-screen terminal application with alternate screen buffer (preserves terminal history).
     - Virtualized, scrollable table for results with automatic data loading, preventing memory overload from large queries.
     - Advanced navigation modes with vim-style keyboard shortcuts.
-    - Full mouse support including wheel scrolling and text selection.
+    - Full mouse support: clickable tabs and settings, click-and-drag text selection with no modifier key, and wheel scrolling.
     - Sticky footer/status bar showing connection details, query latency, and session status (consistency, tracing).
     - Modal overlays for history, help, and command completion.
 - **Apache Parquet Support:**
@@ -350,31 +350,49 @@ Press `Esc` to toggle navigation mode when viewing tables or traces.
 
 #### Mouse Support
 
-By default cqlai asks the terminal for mouse events, so you can click the mode
-tabs at the top. The cost is that the terminal no longer handles the buttons
-itself: **selecting text needs Shift held down, and right-click paste does not
-work**.
+The mouse is on by default. Click the mode tabs at the top, click `KS`, `CL`,
+`Pg`, `Trace` or `Fetch` on the bottom line to change them, and click and drag
+anywhere in the output to select text. No modifier key for any of it.
 
-`MOUSE OFF` hands the buttons back, so selection and paste behave as they do in
-any other program, at the cost of the tabs no longer being clickable. `MOUSE ON`
-turns clicking back on, and `MOUSE` on its own says which is active. The status
-bar shows `[MOUSE]` or `[MOUSE OFF]`.
+Releasing a drag copies the selection to your system clipboard. Double-click
+selects a word, triple-click selects a line, and dragging past the top or bottom
+edge scrolls, so a selection can run further than one screen. `Esc`, or a click
+somewhere else, clears it.
 
-The F-keys switch mode either way, so nothing forces you into mouse mode.
+The copy goes out as OSC 52, the escape sequence a terminal program uses to
+write the clipboard. That works through `ssh` and through `tmux`, where shelling
+out to `xclip` or `pbcopy` would put the text on the wrong machine.
 
-It gets the scroll wheel through alternate scroll mode, where the terminal turns
-wheel spins into `↑`/`↓` key presses. That means the wheel scrolls whatever `↑`
-and `↓` scroll: results in the table view, the trace in the trace view, and the
-conversation in the AI view.
+**There is no right-click paste.** Reading the clipboard needs OSC 52 *read*,
+which iTerm2, kitty, foot and WezTerm all refuse by default, for good reason -
+any program on the far end of an ssh session could otherwise help itself to
+whatever you last copied. Whatever your terminal binds paste to, usually
+`Shift`+right-click or `Ctrl+Shift+V`, still works.
+
+`MOUSE OFF` hands the mouse back to the terminal, so its own selection, its
+right-click paste and its middle-click paste behave as they do in any other
+program - at the cost of the tabs and the settings no longer being clickable.
+`MOUSE ON` takes it back, and `MOUSE` on its own says which is active. The
+status bar shows `[MOUSE]` or `[MOUSE OFF]`.
+
+The F-keys switch view either way, and every setting on the bottom line has a
+command, so nothing is only reachable with the mouse.
+
+The wheel scrolls in both modes. With the mouse on it arrives as a wheel event;
+with it off, alternate scroll mode has the terminal turn wheel spins into
+`↑`/`↓` key presses, which scroll whatever `↑` and `↓` scroll: results in the
+table view, the trace in the trace view, the conversation in the AI view.
 
 | Action | Function |
 |--------|----------|
 | Mouse Wheel | Scroll vertically with automatic data loading |
-| Click a tab | Switch mode, with `MOUSE` on (the default) |
-| Shift+Click+Drag | Select text, with `MOUSE` on |
-| Click+Drag | Select text with no modifier, after `MOUSE OFF` |
-| Right Click | Paste, after `MOUSE OFF` |
-| Middle Click | Paste from selection buffer (Linux/Unix) |
+| Click+Drag | Select text; releasing copies it to the clipboard |
+| Double Click | Select a word |
+| Triple Click | Select a line |
+| Click a tab | Switch view |
+| Click a setting | Change KS, CL, Pg, Trace or Fetch; KS lists the cluster's keyspaces |
+| Right Click | Nothing; use whatever your terminal binds paste to |
+| `Esc` | Clear the selection |
 
 Scroll wide tables sideways with `Alt+←`/`Alt+→`, or `<` and `>` in navigation
 mode. Horizontal scrolling with the wheel is not available, because the terminal

--- a/cmd/cqlai/main.go
+++ b/cmd/cqlai/main.go
@@ -356,6 +356,7 @@ func runInteractive(m tea.Model) error {
 	// Give the wheel back to the terminal however we leave. Bubble Tea already
 	// restores the alternate screen and mouse state itself.
 	defer ui.DisableAlternateScroll()
+	defer ui.ResetMouseReporting()
 
 	_, err := p.Run()
 	return err

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.30.0
 	github.com/apache/arrow-go/v18 v18.7.0
 	github.com/apache/cassandra-gocql-driver/v2 v2.1.2
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0
 	github.com/lithammer/fuzzysearch v1.1.8
@@ -25,7 +26,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
-	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -9,6 +9,23 @@ import (
 
 // handleKeyboardInput handles keyboard input events
 func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
+	// Any keypress drops the mouse selection: whatever happens next is likely
+	// to move or replace the text under it, and a highlight left behind on
+	// different text is worse than no highlight. Escape does nothing else, so
+	// it is the way to take one down deliberately.
+	if m.selection.active {
+		m.clearSelection()
+		if msg.String() == "esc" {
+			return m, nil
+		}
+	}
+
+	// The settings chooser takes keys while it is open: it was opened by a
+	// click a moment ago, so it is what the next keypress is aimed at.
+	if m.chooser.active {
+		return m.handleSettingChooserKey(msg)
+	}
+
 	// Check for save modal first (highest priority)
 	if m.saveModalActive {
 		return m.handleSaveModalKeyboard(msg)

--- a/internal/ui/keyboard_handler_control.go
+++ b/internal/ui/keyboard_handler_control.go
@@ -59,8 +59,9 @@ func (m *MainModel) handleCtrlC() (*MainModel, tea.Cmd) {
 
 	// If already confirming, exit. Otherwise show confirmation.
 	if m.confirmExit {
-		// Give the wheel back to the terminal on exit.
+		// Give the wheel and the buttons back to the terminal on exit.
 		DisableAlternateScroll()
+		ResetMouseReporting()
 		return m, tea.Quit
 	}
 	m.confirmExit = true
@@ -73,8 +74,9 @@ func (m *MainModel) handleCtrlC() (*MainModel, tea.Cmd) {
 func (m *MainModel) handleCtrlD() (*MainModel, tea.Cmd) {
 	// If confirming exit, quit. Otherwise show confirmation.
 	if m.confirmExit {
-		// Give the wheel back to the terminal on exit.
+		// Give the wheel and the buttons back to the terminal on exit.
 		DisableAlternateScroll()
+		ResetMouseReporting()
 		return m, tea.Quit
 	}
 	m.confirmExit = true

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -644,28 +644,42 @@ func (m *MainModel) processTableResult(command string, v [][]string) (*MainModel
 	return m, nil
 }
 
-// processStringResult handles string type results
-func (m *MainModel) processStringResult(command string, v string) (*MainModel, tea.Cmd) {
-	// Check if this is a USE command result
-	if strings.HasPrefix(v, "Now using keyspace ") {
-		// Extract keyspace name and update session manager
-		keyspace := strings.TrimPrefix(v, "Now using keyspace ")
-		keyspace = strings.TrimSpace(keyspace)
-		if m.sessionManager != nil {
-			if err := m.sessionManager.SetKeyspace(keyspace); err != nil {
-				logger.DebugfToFile("keyboard_handler_enter", "Failed to update session manager keyspace: %v", err)
-			}
-			// Update the status bar
-			m.statusBar.Keyspace = keyspace
+// adoptKeyspace records a keyspace change the server has already accepted.
+//
+// The change is done by the time this runs; what is left is bookkeeping, and
+// there are three places that track the current keyspace separately - the
+// session manager, the gocql session, and the status line. Missing one leaves
+// the bottom line claiming a keyspace the queries are not going to.
+//
+// It takes the result string rather than a name because that is what says the
+// USE succeeded. Both routes to a USE - typing it, and picking a keyspace from
+// the status line - come through here, so neither can drift from the other.
+func (m *MainModel) adoptKeyspace(result string) {
+	const prefix = "Now using keyspace "
+	if !strings.HasPrefix(result, prefix) {
+		return
+	}
+	keyspace := strings.TrimSpace(strings.TrimPrefix(result, prefix))
+
+	if m.sessionManager != nil {
+		if err := m.sessionManager.SetKeyspace(keyspace); err != nil {
+			logger.DebugfToFile("keyboard_handler_enter", "Failed to update session manager keyspace: %v", err)
 		}
-		// Update the database session's keyspace
-		if m.session != nil {
-			if err := m.session.SetKeyspace(keyspace); err != nil {
-				// Log error but don't fail - the keyspace change was already successful on the server
-				logger.DebugfToFile("keyboard_handler_enter", "Failed to update session keyspace: %v", err)
-			}
+		m.statusBar.Keyspace = keyspace
+	}
+	if m.session != nil {
+		if err := m.session.SetKeyspace(keyspace); err != nil {
+			// Log it but carry on: the server has already switched, so
+			// refusing here would only make the two disagree.
+			logger.DebugfToFile("keyboard_handler_enter", "Failed to update session keyspace: %v", err)
 		}
 	}
+}
+
+// processStringResult handles string type results
+func (m *MainModel) processStringResult(command string, v string) (*MainModel, tea.Cmd) {
+	m.adoptKeyspace(v)
+
 	// Text result - add to history
 	m.tableHeaders = nil
 	m.columnWidths = nil

--- a/internal/ui/keyboard_handler_enter_special.go
+++ b/internal/ui/keyboard_handler_enter_special.go
@@ -11,8 +11,9 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 	upperCommand := strings.ToUpper(command)
 
 	if upperCommand == "EXIT" || upperCommand == "QUIT" {
-		// Give the wheel back to the terminal on exit.
+		// Give the wheel and the buttons back to the terminal on exit.
 		DisableAlternateScroll()
+		ResetMouseReporting()
 		return m, tea.Quit, true
 	}
 
@@ -45,10 +46,15 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 
 // handleMouseCommand turns mouse reporting on or off.
 //
-// The two are exclusive at the terminal level, so this is a choice between
-// clicking the mode tabs and the terminal's own text selection. Saying which is
-// active matters: someone who has never heard of this command would otherwise
-// just find that selecting text stopped working, with no clue why.
+// On, which is the default, cqlai has the mouse: the tabs and the settings on
+// the bottom line are clickable and dragging selects text, because cqlai draws
+// the selection itself. Off hands the mouse back to the terminal, for anyone
+// who would rather have its selection, its right-click paste and its own idea
+// of what a double click means.
+//
+// Nothing is written to the terminal here. MouseMode is a field on the View, so
+// the next render carries the change; writing escape sequences from under the
+// renderer fights it for the screen.
 func (m *MainModel) handleMouseCommand(upperCommand string) (*MainModel, tea.Cmd, bool) {
 	arg := strings.TrimSpace(strings.TrimPrefix(upperCommand, "MOUSE"))
 
@@ -57,6 +63,7 @@ func (m *MainModel) handleMouseCommand(upperCommand string) (*MainModel, tea.Cmd
 		m.mouseEnabled = true
 	case "OFF":
 		m.mouseEnabled = false
+		m.clearSelection()
 	case "":
 		// Report rather than change, the way SHOW does.
 		m.appendMouseStatus()
@@ -76,14 +83,14 @@ func (m *MainModel) handleMouseCommand(upperCommand string) (*MainModel, tea.Cmd
 	return m, nil, true
 }
 
-// appendMouseStatus writes the current mouse mode and what it costs.
+// appendMouseStatus writes which mode the mouse is in and what each one does.
 func (m *MainModel) appendMouseStatus() {
 	if m.mouseEnabled {
 		m.fullHistoryContent += "\n" + m.styles.AccentText.Render("Mouse: ON") +
-			m.styles.MutedText.Render(" - tabs are clickable; hold Shift to select text") + "\n"
+			m.styles.MutedText.Render(" - click the tabs and the settings on the bottom line; drag to select, and the text goes to the clipboard") + "\n"
 	} else {
 		m.fullHistoryContent += "\n" + m.styles.AccentText.Render("Mouse: OFF") +
-			m.styles.MutedText.Render(" - select and paste as usual; tabs are not clickable") + "\n"
+			m.styles.MutedText.Render(" - the terminal handles selection and paste; the tabs and settings are not clickable") + "\n"
 	}
 	m.updateHistoryWrapping()
 	m.historyViewport.GotoBottom()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -115,6 +115,8 @@ type MainModel struct {
 	cachedTableLines         []string          // Cache rendered table lines for fast scrolling
 	navigationMode           bool              // Toggle between navigation keys and input mode
 	mouseEnabled             bool              // Whether to ask the terminal for mouse reporting
+	chooser                  settingChooser    // Open list of values for a status bar setting
+	selection                textSelection     // Text being dragged out with the mouse, if any
 	viewMode                 string            // "history", "table", "trace", or "ai_info"
 	showDataTypes            bool              // Whether to show column data types in table headers
 	columnTypes              []string          // Store column data types
@@ -439,10 +441,13 @@ func NewMainModelWithConnectionOptions(options ConnectionOptions) (*MainModel, e
 		columnWidths:           nil,
 		hasTable:               false,
 		viewMode:               "history",
-		// On by default so the mode tabs are clickable without anyone having to
-		// find a setting first. The cost is that selecting text needs Shift and
-		// right-click paste stops working, which MOUSE OFF gives back.
-		mouseEnabled:              true,
+		// Off by default. Asking the terminal for clicks costs its own text
+		// selection and right-click paste, and no mouse mode avoids that:
+		// mode 1000 requests clicks without drag events and the terminal
+		// still gives up selection. Losing selection is a cost paid
+		// constantly; clicking a tab or a setting is an occasional
+		// convenience, and everything it reaches has a key or a command.
+		mouseEnabled:              defaultMouseEnabled,
 		hasTrace:                  false,
 		traceData:                 nil,
 		traceHeaders:              nil,
@@ -460,9 +465,9 @@ func NewMainModelWithConnectionOptions(options ConnectionOptions) (*MainModel, e
 
 // Init initializes the main model.
 func (m *MainModel) Init() tea.Cmd {
-	// Take the wheel without taking the mouse buttons, so the terminal keeps
-	// its own text selection and right-click paste. Wheel events arrive as
-	// Up/Down key presses instead of mouse events.
+	// Alternate scroll mode, so the wheel still scrolls with MOUSE OFF, when
+	// mouse reporting is not asked for and wheel events would not arrive.
+	// Bubble Tea does not manage this mode; the rest is a field on the View.
 	EnableAlternateScroll()
 	return textinput.Blink
 }
@@ -475,9 +480,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
 
-		headerHeight := 1 // mode tabs
-		footerHeight := 2 // query info, then the connection bar
-		inputHeight := 1  // text input
+		headerHeight := tabBarHeight // mode tabs
+		footerHeight := 2            // query info, then the connection bar
+		inputHeight := 1             // text input
 		// Guard against a terminal that reports no size, or one too small to
 		// hold the chrome: v2's components size buffers from these and panic on
 		// a negative value where v1 quietly carried on.

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -10,38 +10,73 @@ import (
 
 // handleMouseInput handles mouse events.
 //
-// Nothing reaches this today: cqlai no longer turns on mouse reporting, because
-// doing so takes the buttons away from the terminal and breaks its text
-// selection and right-click paste. The wheel arrives as Up/Down key presses via
-// alternate scroll mode instead - see mouse_mode.go.
-//
-// It is kept for the day something clickable needs mouse reporting switched on
-// while it is on screen, which is the point at which wheel events start
-// arriving here again.
+// cqlai owns the mouse while reporting is on, which is what makes the tabs and
+// the settings on the bottom line clickable. It also means the terminal will
+// not select text for us any more, so we do that ourselves - see selection.go.
+// MOUSE OFF hands the mouse back and the terminal behaves as it always did.
 func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 	mouse := msg.Mouse()
 
-	logger.DebugfToFile("Mouse", "MouseEvent: %T Button=%v X=%d Y=%d Mod=%v",
-		msg, mouse.Button, mouse.X, mouse.Y, mouse.Mod)
-
-	// A click on the tab line switches mode. Row 0 is the tabs; everything
-	// below belongs to the view.
-	if _, isClick := msg.(tea.MouseClickMsg); isClick {
-		if mouse.Button == tea.MouseLeft && mouse.Y == 0 {
-			return m.clickTab(mouse.X)
+	switch msg.(type) {
+	case tea.MouseClickMsg:
+		logger.DebugfToFile("Mouse", "Press Button=%v X=%d Y=%d Mod=%v",
+			mouse.Button, mouse.X, mouse.Y, mouse.Mod)
+		// Only the left button does anything. A right click is left alone so
+		// the terminal's own context menu, and whatever it binds paste to,
+		// still work.
+		if mouse.Button != tea.MouseLeft {
+			return m, nil
 		}
-		return m, nil
+		return m.handleMousePress(mouse)
+
+	case tea.MouseMotionMsg:
+		// Motion only arrives with a button held, and only matters mid-drag;
+		// extendSelection returns straight away otherwise.
+		return m.extendSelection(mouse.X, mouse.Y)
+
+	case tea.MouseReleaseMsg:
+		return m.endSelection()
+
+	case tea.MouseWheelMsg:
+		return m.handleMouseWheel(mouse)
 	}
 
-	// Otherwise only wheel events matter. v2 splits clicks, releases, motion
-	// and wheel into separate types, so anything else is not ours. Note that
-	// ignoring an event here is not what lets the terminal select text - by the
-	// time one arrives the terminal has already given the button up. Leaving
-	// MouseMode off is what does that.
-	if _, isWheel := msg.(tea.MouseWheelMsg); !isWheel {
-		return m, nil
+	return m, nil
+}
+
+// handleMousePress routes a left button press: the controls first, then the
+// viewport, where a press starts a selection.
+func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
+	// A press anywhere drops whatever was selected.
+	m.clearSelection()
+
+	// A press inside the open list picks that value.
+	if m.chooser.active {
+		if choice, inside := m.choiceAt(m.windowWidth, m.windowHeight, mouse.X, mouse.Y); inside {
+			return m.applySettingChoice(choice)
+		}
+		// Anywhere else closes it. Clicking the status line again may then
+		// open a different one, which is what the switch below decides.
+		m.closeSettingChooser()
+		if mouse.Y != m.windowHeight-1 && mouse.Y != 0 {
+			return m, nil
+		}
 	}
 
+	// Row 0 is the tabs and the last row is the connection bar; everything
+	// between them is content, and a press there starts a selection.
+	switch mouse.Y {
+	case 0:
+		return m.clickTab(mouse.X)
+	case m.windowHeight - 1:
+		return m.clickStatusSetting(mouse.X)
+	}
+
+	return m.beginSelection(mouse.X, mouse.Y)
+}
+
+// handleMouseWheel scrolls the view under the pointer.
+func (m *MainModel) handleMouseWheel(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 	// Any modifier plus a vertical wheel means horizontal scrolling.
 	modified := mouse.Mod.Contains(tea.ModShift) ||
 		mouse.Mod.Contains(tea.ModAlt) ||
@@ -49,36 +84,21 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 
 	switch mouse.Button {
 	case tea.MouseWheelUp:
-		// Check for horizontal scrolling modes
 		if modified && m.viewMode == "table" && m.hasTable {
-			// Any modifier + WheelUp = Scroll left
-			logger.DebugfToFile("Mouse", "Modified WheelUp detected (Mod=%v) - scrolling left",
-				mouse.Mod)
 			return m.handleMouseWheelLeft()
 		}
-		// Regular scroll up
 		return m.handleMouseWheelUp()
 	case tea.MouseWheelDown:
-		// Check for horizontal scrolling modes
 		if modified && m.viewMode == "table" && m.hasTable {
-			// Any modifier + WheelDown = Scroll right
-			logger.DebugfToFile("Mouse", "Modified WheelDown detected (Mod=%v) - scrolling right",
-				mouse.Mod)
 			return m.handleMouseWheelRight()
 		}
-		// Regular scroll down
 		return m.handleMouseWheelDown()
 	case tea.MouseWheelLeft:
-		// Native horizontal scroll left (for mice/trackpads that support it)
+		// Native horizontal scroll, for mice and trackpads that report it.
 		return m.handleMouseWheelLeft()
 	case tea.MouseWheelRight:
-		// Native horizontal scroll right (for mice/trackpads that support it)
 		return m.handleMouseWheelRight()
 	default:
-		// Ignore left, middle and right clicks. Note that ignoring them here is
-		// not what lets the terminal select text - by the time an event reaches
-		// this function the terminal has already given the button up. Leaving
-		// mouse reporting off is what does that.
 		return m, nil
 	}
 }
@@ -322,4 +342,65 @@ func (m *MainModel) clickTab(col int) (*MainModel, tea.Cmd) {
 		return m.handleF5()
 	}
 	return m, nil
+}
+
+// clickStatusSetting opens the list of values for a setting on the status line.
+func (m *MainModel) clickStatusSetting(col int) (*MainModel, tea.Cmd) {
+	setting, anchorX, ok := m.statusBar.settingAt(col)
+	if !ok {
+		return m, nil
+	}
+
+	current := m.currentSettingValue(setting)
+
+	// Every setting but KS has a fixed set of values. Keyspaces come from the
+	// cluster, so they are fetched here rather than listed in settingChoices.
+	var choices []string
+	if setting == settingKeyspace {
+		choices = m.keyspaceChoices()
+	} else {
+		choices, _ = settingChoices(setting, current)
+	}
+	if len(choices) == 0 {
+		return m, nil
+	}
+
+	logger.DebugfToFile("Mouse", "Status setting %q clicked at column %d, current %q", setting, col, current)
+	m.openSettingChooser(setting, anchorX, choices, current)
+	return m, nil
+}
+
+// keyspaceChoices lists the keyspaces to offer for KS.
+//
+// Asked for on each click rather than cached, because keyspaces are created and
+// dropped while cqlai is running and a list that quietly goes stale is worse
+// than one small query against a system table. System keyspaces are included:
+// USE system_schema is a reasonable thing to want.
+func (m *MainModel) keyspaceChoices() []string {
+	if m.session == nil {
+		return nil
+	}
+
+	keyspaces, err := m.session.DescribeKeyspacesQuery()
+	if err != nil {
+		logger.DebugfToFile("Mouse", "Listing keyspaces for the KS chooser: %v", err)
+		return nil
+	}
+
+	names := make([]string, 0, len(keyspaces))
+	for _, ks := range keyspaces {
+		names = append(names, ks.Name)
+	}
+	return names
+}
+
+// currentSettingValue reads a setting as it is displayed, so the chooser can
+// mark it and open on it.
+func (m *MainModel) currentSettingValue(setting string) string {
+	for _, seg := range m.statusBar.segments() {
+		if seg.setting == setting {
+			return seg.value
+		}
+	}
+	return ""
 }

--- a/internal/ui/mouse_mode.go
+++ b/internal/ui/mouse_mode.go
@@ -1,30 +1,24 @@
 package ui
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Alternate scroll mode (DECSET 1007).
 //
-// cqlai runs on the alternate screen and only ever wanted the scroll wheel.
-// Asking for that with mouse reporting (DECSET 1000) is too blunt: the terminal
-// then hands us every click, so its own text selection and right-click paste
-// stop working and users have to hold Shift to select anything.
+// This is the one terminal mode Bubble Tea does not manage for us. The rest -
+// the alternate screen, and whether the mouse is reported at all - are fields
+// on the View returned each render; see newView.
 //
-// Alternate scroll mode gets the wheel without the buttons. While the alternate
-// screen is active and mouse reporting is off, the terminal turns wheel events
-// into Up/Down key presses and sends those instead, so it keeps the buttons and
-// we still get to scroll. See handleUpArrow/handleDownArrow for the receiving
-// end.
+// It matters only while mouse reporting is off, which MOUSE OFF does. With no
+// mouse events arriving, alternate scroll mode is what still lets the wheel
+// scroll: on the alternate screen the terminal turns a wheel spin into Up and
+// Down key presses and sends those instead. See handleUpArrow/handleDownArrow
+// for the receiving end.
 const (
 	seqEnableAlternateScroll  = "\x1b[?1007h"
 	seqDisableAlternateScroll = "\x1b[?1007l"
 )
 
 // EnableAlternateScroll turns on alternate scroll mode.
-//
-// Bubble Tea has no command for this mode, so it is written straight to stdout
-// the same way the mouse sequences used to be.
 func EnableAlternateScroll() {
 	fmt.Print(seqEnableAlternateScroll)
 }
@@ -32,6 +26,16 @@ func EnableAlternateScroll() {
 // DisableAlternateScroll gives the wheel back to the terminal.
 func DisableAlternateScroll() {
 	fmt.Print(seqDisableAlternateScroll)
+}
+
+// ResetMouseReporting turns every mouse reporting mode off.
+//
+// Bubble Tea already does this as it tears the screen down, so this is
+// insurance for the paths that leave without it - a panic, or a signal - where
+// the alternative is a terminal that keeps printing escape sequences at the
+// shell every time the mouse moves.
+func ResetMouseReporting() {
+	fmt.Print("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
 }
 
 // viewportOwnsArrows reports whether a bare Up/Down should scroll the current

--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -1,0 +1,431 @@
+package ui
+
+import (
+	"strings"
+	"time"
+	"unicode"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Text selection drawn by cqlai rather than by the terminal.
+//
+// Asking the terminal for mouse events takes its own click-and-drag selection
+// away, and there is no mode that gives you both. The way out is to stop
+// relying on the terminal for selection at all: take the mouse, follow the drag
+// ourselves, paint the highlight into what we render, and hand the text to the
+// system clipboard on release. Terminal applications that manage clicking and
+// selecting at the same time all do it this way.
+//
+// The span is stored against the active viewport's content, by line and column,
+// not by screen row. Scrolling then moves the text under the highlight without
+// moving the highlight off it, which matters because dragging past an edge
+// scrolls on purpose.
+
+const (
+	// tabBarHeight is how many rows the mode tabs take, and so the first row
+	// the viewport occupies. WindowSizeMsg reserves the same figure.
+	tabBarHeight = 1
+
+	// stickyHeaderHeight is how many rows the frozen table header covers when a
+	// table is scrolled: top border, column names, separator.
+	stickyHeaderHeight = 3
+
+	// multiClickInterval is how close together presses have to be to count as a
+	// double or triple click.
+	multiClickInterval = 400 * time.Millisecond
+)
+
+// selectionStyle is what a selected run of text looks like. It matches the
+// active tab, so the two highlights on screen are the same colour.
+var selectionStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("#1c1c1c")).
+	Background(lipgloss.Color("#87D7FF"))
+
+// textSelection is the span being dragged out, or the one just dragged.
+type textSelection struct {
+	active   bool
+	dragging bool
+
+	// view names the viewport the coordinates belong to, so switching mode
+	// drops the selection instead of painting it onto different content.
+	view string
+
+	anchorLine, anchorCol int
+	headLine, headCol     int
+
+	// Press tracking, for double and triple clicks.
+	lastPress time.Time
+	lastLine  int
+	lastCol   int
+	presses   int
+}
+
+// span returns the selection in reading order, whichever way it was dragged.
+func (s textSelection) span() (startLine, startCol, endLine, endCol int) {
+	if s.anchorLine < s.headLine || (s.anchorLine == s.headLine && s.anchorCol <= s.headCol) {
+		return s.anchorLine, s.anchorCol, s.headLine, s.headCol
+	}
+	return s.headLine, s.headCol, s.anchorLine, s.anchorCol
+}
+
+// empty reports whether the span covers no characters, which is what a plain
+// click leaves behind.
+func (s textSelection) empty() bool {
+	return s.anchorLine == s.headLine && s.anchorCol == s.headCol
+}
+
+// selectionTarget returns the viewport a selection applies to and a name for
+// it, matching the viewport View draws. Both come from here so a selection
+// cannot end up recorded against one view and painted onto another.
+//
+// It returns nil where the view has nothing to select: the "no table data" and
+// "no trace data" messages are drawn through a throwaway viewport, so there is
+// no content to anchor to.
+func (m *MainModel) selectionTarget() (*viewport.Model, string) {
+	switch {
+	case m.viewMode == "ai" && m.aiConversationActive:
+		return &m.aiConversationViewport, "ai"
+	case m.viewMode == "trace" && m.hasTrace:
+		return &m.traceViewport, "trace"
+	case m.viewMode == "table" && m.hasTable:
+		return &m.tableViewport, "table"
+	case m.viewMode == "trace" || m.viewMode == "table":
+		return nil, ""
+	default:
+		return &m.historyViewport, "history"
+	}
+}
+
+// stickyHeaderRows is how many rows at the top of the viewport show the frozen
+// table header rather than the lines the viewport is scrolled to.
+//
+// Those rows are outside the selection: they show the top of the table, not the
+// content at that scroll position, so a selection anchored there would copy
+// something other than what is under the pointer. View draws the header only
+// when this is non-zero, so the two agree by construction.
+func (m *MainModel) stickyHeaderRows() int {
+	if m.viewMode == "table" && m.hasTable && m.tableViewport.YOffset() > 0 &&
+		len(m.tableHeaders) > 0 && m.lastTableData != nil && m.columnWidths != nil {
+		return stickyHeaderHeight
+	}
+	return 0
+}
+
+// docPosition converts a screen position into a line and column of the active
+// viewport's content.
+func (m *MainModel) docPosition(col, row int) (line, column int, ok bool) {
+	vp, _ := m.selectionTarget()
+	if vp == nil || col < 0 {
+		return 0, 0, false
+	}
+
+	top := tabBarHeight + m.stickyHeaderRows()
+	bottom := tabBarHeight + vp.Height()
+	if row < top || row >= bottom {
+		return 0, 0, false
+	}
+
+	return vp.YOffset() + row - tabBarHeight, col, true
+}
+
+// beginSelection starts a drag, or picks out a word or a line if this press
+// follows others on the same spot.
+func (m *MainModel) beginSelection(col, row int) (*MainModel, tea.Cmd) {
+	line, column, ok := m.docPosition(col, row)
+	if !ok {
+		m.clearSelection()
+		return m, nil
+	}
+	_, view := m.selectionTarget()
+
+	// A press soon after one on the same cell counts up: two for a word, three
+	// for a line, and a fourth starts over.
+	presses := 1
+	if m.selection.view == view && m.selection.lastLine == line &&
+		m.selection.lastCol == column && time.Since(m.selection.lastPress) < multiClickInterval {
+		presses = m.selection.presses%3 + 1
+	}
+
+	m.selection = textSelection{
+		active:     true,
+		dragging:   true,
+		view:       view,
+		anchorLine: line,
+		anchorCol:  column,
+		headLine:   line,
+		headCol:    column,
+		lastPress:  time.Now(),
+		lastLine:   line,
+		lastCol:    column,
+		presses:    presses,
+	}
+
+	switch presses {
+	case 2:
+		m.selectWord(line, column)
+	case 3:
+		m.selectLine(line)
+	}
+	return m, nil
+}
+
+// extendSelection moves the far end of the selection to follow the pointer.
+//
+// Dragging past the top or bottom edge scrolls a line at a time, so a selection
+// can run further than one screen. Because the span is held in content
+// coordinates, the scroll moves the text and the highlight together.
+func (m *MainModel) extendSelection(col, row int) (*MainModel, tea.Cmd) {
+	if !m.selection.dragging {
+		return m, nil
+	}
+	vp, view := m.selectionTarget()
+	if vp == nil || view != m.selection.view {
+		return m, nil
+	}
+
+	top := tabBarHeight + m.stickyHeaderRows()
+	bottom := tabBarHeight + vp.Height()
+	switch {
+	case row < top:
+		vp.SetYOffset(max(0, vp.YOffset()-1))
+		row = top
+	case row >= bottom:
+		vp.SetYOffset(min(max(0, vp.TotalLineCount()-vp.Height()), vp.YOffset()+1))
+		row = bottom - 1
+	}
+
+	line, column, ok := m.docPosition(col, row)
+	if !ok {
+		return m, nil
+	}
+	m.selection.headLine, m.selection.headCol = line, column
+	return m, nil
+}
+
+// endSelection finishes a drag and puts the text on the system clipboard.
+//
+// Bubble Tea writes it with OSC 52, which is the one way a terminal application
+// can reach the clipboard of whatever machine the terminal is on - it works
+// through ssh and through tmux, where shelling out to xclip does not. Reading
+// the clipboard back is a different matter and most terminals refuse it, which
+// is why there is still no right-click paste.
+//
+// The highlight stays up until the next click or keypress, so you can see what
+// you got.
+func (m *MainModel) endSelection() (*MainModel, tea.Cmd) {
+	if !m.selection.dragging {
+		return m, nil
+	}
+	m.selection.dragging = false
+
+	text := m.selectedText()
+	if text == "" {
+		m.selection.active = false
+		return m, nil
+	}
+	return m, tea.SetClipboard(text)
+}
+
+// clearSelection takes the highlight down.
+//
+// The press bookkeeping is left alone: it is keyed on position and time, so a
+// stale entry cannot turn an unrelated later click into a double click.
+func (m *MainModel) clearSelection() {
+	m.selection.active = false
+	m.selection.dragging = false
+}
+
+// selectWord grows the selection to the word under a position.
+//
+// Underscores and digits count as part of a word, because the words worth
+// double-clicking here are keyspace, table and column names.
+func (m *MainModel) selectWord(line, col int) {
+	cells, ok := m.documentCells(line)
+	if !ok || col >= len(cells) || !wordCell(cells[col]) {
+		return
+	}
+
+	start, end := col, col+1
+	for start > 0 && wordCell(cells[start-1]) {
+		start--
+	}
+	for end < len(cells) && wordCell(cells[end]) {
+		end++
+	}
+
+	m.selection.anchorLine, m.selection.anchorCol = line, start
+	m.selection.headLine, m.selection.headCol = line, end
+}
+
+// selectLine takes the whole line.
+func (m *MainModel) selectLine(line int) {
+	cells, ok := m.documentCells(line)
+	if !ok {
+		return
+	}
+	m.selection.anchorLine, m.selection.anchorCol = line, 0
+	m.selection.headLine, m.selection.headCol = line, len(cells)
+}
+
+// wordCell reports whether a character belongs to a word.
+func wordCell(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// documentLines splits the active viewport's content into lines.
+func (m *MainModel) documentLines() ([]string, bool) {
+	vp, view := m.selectionTarget()
+	if vp == nil || view != m.selection.view {
+		return nil, false
+	}
+	return strings.Split(vp.GetContent(), "\n"), true
+}
+
+// documentCells returns one line of content as one rune per column.
+func (m *MainModel) documentCells(line int) ([]rune, bool) {
+	lines, ok := m.documentLines()
+	if !ok || line < 0 || line >= len(lines) {
+		return nil, false
+	}
+	return lineCells(ansi.Strip(lines[line])), true
+}
+
+// lineCells lays a string out one rune per column, so a column index can be
+// used as a slice index.
+//
+// A double-width character fills two columns; the second holds a zero rune,
+// which is how the terminal shows it - one character, two cells.
+func lineCells(s string) []rune {
+	var cells []rune
+	for _, r := range s {
+		w := ansi.StringWidth(string(r))
+		if w <= 0 {
+			// A combining mark sits on the character before it and takes no
+			// column of its own.
+			continue
+		}
+		cells = append(cells, r)
+		for range w - 1 {
+			cells = append(cells, 0)
+		}
+	}
+	return cells
+}
+
+// selectedText is the selection as plain text, the way a terminal hands it
+// over: styling removed and trailing spaces dropped, so a selection dragged
+// across a padded table does not paste as a field of blanks.
+func (m *MainModel) selectedText() string {
+	if !m.selection.active || m.selection.empty() {
+		return ""
+	}
+	lines, ok := m.documentLines()
+	if !ok {
+		return ""
+	}
+
+	startLine, startCol, endLine, endCol := m.selection.span()
+	if startLine < 0 {
+		startLine = 0
+	}
+	if endLine >= len(lines) {
+		endLine = len(lines) - 1
+	}
+	if startLine > endLine {
+		return ""
+	}
+
+	out := make([]string, 0, endLine-startLine+1)
+	for line := startLine; line <= endLine; line++ {
+		text := ansi.Strip(lines[line])
+		from, to := 0, ansi.StringWidth(text)
+		if line == startLine {
+			from = startCol
+		}
+		if line == endLine && endCol < to {
+			to = endCol
+		}
+		if to <= from {
+			out = append(out, "")
+			continue
+		}
+		out = append(out, strings.TrimRight(ansi.Cut(text, from, to), " "))
+	}
+	return strings.Join(out, "\n")
+}
+
+// highlightSelection paints the selection onto the rendered viewport.
+//
+// Row i of the rendered viewport is content line YOffset+i, the same mapping
+// docPosition recorded the span through, so the highlight stays on the
+// characters the pointer covered however far the view has scrolled since.
+func (m *MainModel) highlightSelection(section string) string {
+	if !m.selection.active || m.selection.empty() {
+		return section
+	}
+	vp, view := m.selectionTarget()
+	if vp == nil || view != m.selection.view {
+		return section
+	}
+
+	startLine, startCol, endLine, endCol := m.selection.span()
+	offset := vp.YOffset()
+	sticky := m.stickyHeaderRows()
+
+	rows := strings.Split(section, "\n")
+	for i := range rows {
+		if i < sticky {
+			continue
+		}
+		line := offset + i
+		if line < startLine || line > endLine {
+			continue
+		}
+
+		from, to := 0, ansi.StringWidth(rows[i])
+		if line == startLine {
+			from = startCol
+		}
+		if line == endLine && endCol < to {
+			to = endCol
+		}
+		rows[i] = highlightColumns(rows[i], from, to)
+	}
+	return strings.Join(rows, "\n")
+}
+
+// highlightColumns marks a range of columns of an already styled line.
+//
+// The selected run loses its own colours first. A solid block is what a
+// terminal's own selection looks like, and layering a highlight over the
+// greens and blues already in a result set gives neither.
+func highlightColumns(line string, from, to int) string {
+	width := ansi.StringWidth(line)
+	if from < 0 {
+		from = 0
+	}
+	if to > width {
+		to = width
+	}
+	if to <= from {
+		return line
+	}
+
+	// The resets keep the styling either side of the highlight from leaking
+	// into it, or the highlight's own colours from running on past it.
+	return ansi.Cut(line, 0, from) + "\x1b[0m" +
+		selectionStyle.Render(ansi.Strip(ansi.Cut(line, from, to))) + "\x1b[0m" +
+		ansi.Cut(line, to, width)
+}
+
+// defaultMouseEnabled says whether a new session takes the mouse.
+//
+// It does. The tabs and the settings on the bottom line are no use behind a
+// command nobody has heard of, and taking the mouse no longer costs the user
+// their text selection now that cqlai draws that itself. MOUSE OFF is there for
+// anyone who wants the terminal's own behaviour back.
+const defaultMouseEnabled = true

--- a/internal/ui/selection_test.go
+++ b/internal/ui/selection_test.go
@@ -1,0 +1,359 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestInput() textinput.Model {
+	in := textinput.New()
+	in.SetWidth(40)
+	return in
+}
+
+// selectionModel builds a history view holding the given lines, in a viewport
+// tall enough to show height of them.
+func selectionModel(height int, lines ...string) *MainModel {
+	vp := viewport.New(viewport.WithWidth(80), viewport.WithHeight(height))
+	vp.SetContent(strings.Join(lines, "\n"))
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		mouseEnabled:    true,
+		windowWidth:     80,
+		windowHeight:    height + 4, // tabs, input, info bar, status bar
+		viewMode:        "history",
+		historyViewport: vp,
+	}
+}
+
+// drag runs a whole press-move-release, the way the terminal delivers one.
+func drag(m *MainModel, fromCol, fromRow, toCol, toRow int) tea.Cmd {
+	m.beginSelection(fromCol, fromRow)
+	m.extendSelection(toCol, toRow)
+	_, cmd := m.endSelection()
+	return cmd
+}
+
+// clipboardText runs the command endSelection returned and reads the text back
+// out, which is what would reach the terminal as OSC 52.
+//
+// Bubble Tea keeps the message type unexported, so this goes by its name and
+// its contents rather than a type assertion.
+func clipboardText(t *testing.T, cmd tea.Cmd) string {
+	t.Helper()
+	require.NotNil(t, cmd, "releasing a drag should have produced a clipboard command")
+
+	msg := cmd()
+	require.Contains(t, fmt.Sprintf("%T", msg), "lipboard",
+		"expected a clipboard command, got %T", msg)
+	return fmt.Sprintf("%s", msg)
+}
+
+// TestDragSelectsAndCopies is the point of the feature: no modifier key, and
+// the text ends up on the clipboard.
+func TestDragSelectsAndCopies(t *testing.T) {
+	m := selectionModel(5, "first line", "second line", "third line")
+
+	// Row 0 is the tab bar, so the first content line is row 1.
+	cmd := drag(m, 0, 1, 5, 2)
+
+	assert.Equal(t, "first line\nsecon", clipboardText(t, cmd))
+	assert.True(t, m.selection.active, "the highlight should stay up after release")
+	assert.False(t, m.selection.dragging)
+}
+
+// TestDragBackwardsSelectsTheSameText: a selection dragged right to left is
+// the same span, and span() is what puts it in reading order.
+func TestDragBackwardsSelectsTheSameText(t *testing.T) {
+	forwards := selectionModel(5, "first line", "second line")
+	backwards := selectionModel(5, "first line", "second line")
+
+	assert.Equal(t,
+		clipboardText(t, drag(forwards, 2, 1, 6, 2)),
+		clipboardText(t, drag(backwards, 6, 2, 2, 1)))
+}
+
+// TestClickWithoutDraggingCopiesNothing guards against a stray click wiping
+// whatever the user had on their clipboard.
+func TestClickWithoutDraggingCopiesNothing(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+
+	m.beginSelection(4, 1)
+	_, cmd := m.endSelection()
+
+	assert.Nil(t, cmd, "a click that selected nothing should not touch the clipboard")
+	assert.False(t, m.selection.active)
+}
+
+// TestSelectionSurvivesScrolling is why the span is stored against the content
+// rather than against screen rows: dragging past the bottom edge scrolls, and
+// the selection has to keep meaning the same characters.
+func TestSelectionSurvivesScrolling(t *testing.T) {
+	m := selectionModel(3, "one", "two", "three", "four", "five", "six")
+
+	// Start on the top visible line, then drag below the bottom edge twice.
+	m.beginSelection(0, 1)
+	m.extendSelection(0, 4)
+	m.extendSelection(3, 4)
+
+	assert.Equal(t, 2, m.historyViewport.YOffset(), "dragging past the edge should scroll")
+
+	// Two lines scrolled past, so the head sits on "five" rather than on the
+	// row it was dragged to.
+	_, cmd := m.endSelection()
+	assert.Equal(t, "one\ntwo\nthree\nfour\nfiv", clipboardText(t, cmd))
+}
+
+// TestScrollingAfterReleaseKeepsTheHighlightOnItsText checks the same thing
+// from the other side: the highlight follows the text up the screen.
+func TestScrollingAfterReleaseKeepsTheHighlightOnItsText(t *testing.T) {
+	m := selectionModel(3, "alpha", "bravo", "charlie", "delta", "echo")
+
+	drag(m, 0, 2, 5, 2) // all of "bravo", the second line
+
+	before := m.highlightSelection(m.historyViewport.View())
+	m.historyViewport.SetYOffset(1)
+	after := m.highlightSelection(m.historyViewport.View())
+
+	// Second row before the scroll, first row after it, and marked both times.
+	marked := selectionStyle.Render("bravo")
+	assert.Contains(t, strings.Split(before, "\n")[1], marked,
+		"bravo should be highlighted before scrolling")
+	assert.Contains(t, strings.Split(after, "\n")[0], marked,
+		"bravo should still be highlighted after scrolling")
+	assert.NotContains(t, strings.Split(after, "\n")[1], selectionStyle.Render("charlie"),
+		"charlie was never selected")
+}
+
+func TestDoubleClickSelectsAWord(t *testing.T) {
+	m := selectionModel(5, "SELECT id FROM system_schema.tables")
+
+	m.beginSelection(12, 1) // inside "FROM"
+	m.endSelection()
+	m.beginSelection(12, 1)
+	_, cmd := m.endSelection()
+
+	assert.Equal(t, "FROM", clipboardText(t, cmd))
+}
+
+// TestDoubleClickTakesAWholeIdentifier: underscores and digits are part of a
+// word here, because the words worth double-clicking are schema names.
+func TestDoubleClickTakesAWholeIdentifier(t *testing.T) {
+	m := selectionModel(5, "keyspace system_schema_2 ok")
+
+	for range 2 {
+		m.beginSelection(12, 1) // inside "system_schema_2"
+		m.endSelection()
+	}
+
+	assert.Equal(t, "system_schema_2", m.selectedText())
+}
+
+func TestTripleClickSelectsTheLine(t *testing.T) {
+	m := selectionModel(5, "first line", "second line here", "third")
+
+	for range 3 {
+		m.beginSelection(4, 2)
+		m.endSelection()
+	}
+
+	assert.Equal(t, "second line here", m.selectedText())
+}
+
+// TestSlowClicksDoNotCountAsADoubleClick: the count is on time as well as
+// position, or every second click on the same spot would grab a word.
+func TestSlowClicksDoNotCountAsADoubleClick(t *testing.T) {
+	m := selectionModel(5, "SELECT id FROM tables")
+
+	m.beginSelection(12, 1)
+	m.endSelection()
+	m.selection.lastPress = time.Now().Add(-2 * time.Second)
+	m.beginSelection(12, 1)
+
+	assert.True(t, m.selection.empty(), "a click long after the last one starts a fresh selection")
+}
+
+// TestPressOnTheTabBarStartsNoSelection: the rows outside the viewport belong
+// to the controls, and a press there must not leave a selection behind.
+func TestPressOnTheTabBarStartsNoSelection(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+	m.selection.active = true
+
+	m.beginSelection(3, 0)
+
+	assert.False(t, m.selection.active)
+}
+
+// TestPressBelowTheViewportStartsNoSelection covers the input line and the
+// bars under it.
+func TestPressBelowTheViewportStartsNoSelection(t *testing.T) {
+	m := selectionModel(3, "first line", "second line")
+
+	m.beginSelection(3, 1+3) // one row past the last content row
+
+	assert.False(t, m.selection.active)
+}
+
+// TestAnyKeyDropsTheSelection stops a highlight sitting over text that has
+// since moved or changed.
+func TestAnyKeyDropsTheSelection(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+	m.input = newTestInput()
+
+	drag(m, 0, 1, 5, 1)
+	require.True(t, m.selection.active)
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	assert.False(t, m.selection.active)
+}
+
+// TestEscapeOnlyDropsTheSelection: with a selection up, Escape takes it down
+// and does nothing else.
+func TestEscapeOnlyDropsTheSelection(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+	m.input = newTestInput()
+	m.input.SetValue("SELECT 1")
+
+	drag(m, 0, 1, 5, 1)
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	assert.False(t, m.selection.active)
+	assert.Equal(t, "SELECT 1", m.input.Value(), "Escape should not have cleared the prompt as well")
+}
+
+// TestSwitchingViewDropsTheSelection: the span belongs to one viewport's
+// content, so it must not be painted onto another's.
+func TestSwitchingViewDropsTheSelection(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+	drag(m, 0, 1, 5, 1)
+
+	m.viewMode = "trace"
+	m.hasTrace = true
+	m.traceViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(5))
+	m.traceViewport.SetContent("trace line\nanother")
+
+	assert.Equal(t, "", m.selectedText(), "the selection belongs to the console view")
+	assert.Equal(t, m.traceViewport.View(), m.highlightSelection(m.traceViewport.View()))
+}
+
+// TestCopiedLinesLoseTrailingSpaces: a table pads every cell, and pasting a
+// column of blanks into an editor is not what anyone wanted.
+func TestCopiedLinesLoseTrailingSpaces(t *testing.T) {
+	m := selectionModel(5, "id    ", "1     ", "2     ")
+
+	cmd := drag(m, 0, 1, 6, 3)
+
+	assert.Equal(t, "id\n1\n2", clipboardText(t, cmd))
+}
+
+// TestHighlightKeepsTheLineIntact guards the ANSI arithmetic: the visible
+// characters must survive being cut into three and put back together.
+func TestHighlightKeepsTheLineIntact(t *testing.T) {
+	styled := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Render("hello") + " world"
+
+	for from := range 11 {
+		for to := from; to <= 11; to++ {
+			got := stripAnsiForTest(highlightColumns(styled, from, to))
+			assert.Equal(t, "hello world", got, "columns %d..%d lost characters", from, to)
+		}
+	}
+}
+
+// TestHighlightMarksOnlyTheSelectedColumns.
+func TestHighlightMarksOnlyTheSelectedColumns(t *testing.T) {
+	line := "hello world"
+
+	marked := highlightColumns(line, 6, 11)
+
+	assert.Contains(t, marked, selectionStyle.Render("world"))
+	assert.False(t, strings.Contains(marked, selectionStyle.Render("hello")))
+}
+
+// TestColumnsAreCellsNotBytes: a column is a cell on screen. Counting bytes
+// puts the highlight in the wrong place the moment a name is not ASCII.
+func TestColumnsAreCellsNotBytes(t *testing.T) {
+	m := selectionModel(5, "id | naïve café")
+
+	cmd := drag(m, 5, 1, 15, 1)
+
+	assert.Equal(t, "naïve café", clipboardText(t, cmd))
+}
+
+// TestWideCharactersFillTwoColumns.
+func TestWideCharactersFillTwoColumns(t *testing.T) {
+	cells := lineCells("a世b")
+
+	require.Len(t, cells, 4, "a wide character takes two columns")
+	assert.Equal(t, 'a', cells[0])
+	assert.Equal(t, '世', cells[1])
+	assert.Equal(t, rune(0), cells[2], "the second column of a wide character holds nothing of its own")
+	assert.Equal(t, 'b', cells[3])
+}
+
+// TestStickyHeaderRowsAreNotSelectable: while a table is scrolled the top
+// three rows show the top of the table, not the lines at that scroll position,
+// so a selection anchored there would copy something else entirely.
+func TestStickyHeaderRowsAreNotSelectable(t *testing.T) {
+	vp := viewport.New(viewport.WithWidth(80), viewport.WithHeight(6))
+	vp.SetContent(strings.Join([]string{"top", "head", "sep", "r1", "r2", "r3", "r4", "r5"}, "\n"))
+	vp.SetYOffset(2)
+
+	m := &MainModel{
+		styles:        DefaultStyles(),
+		viewMode:      "table",
+		hasTable:      true,
+		tableViewport: vp,
+		tableHeaders:  []string{"id"},
+		lastTableData: [][]string{{"id"}},
+		columnWidths:  []int{4},
+		windowWidth:   80,
+		windowHeight:  10,
+	}
+
+	require.Equal(t, stickyHeaderHeight, m.stickyHeaderRows())
+
+	for row := tabBarHeight; row < tabBarHeight+stickyHeaderHeight; row++ {
+		_, _, ok := m.docPosition(0, row)
+		assert.False(t, ok, "row %d is the frozen header", row)
+	}
+
+	line, _, ok := m.docPosition(0, tabBarHeight+stickyHeaderHeight)
+	require.True(t, ok)
+	assert.Equal(t, 5, line, "the first selectable row is the content at the scroll offset")
+}
+
+// TestSelectionIsOffWhenThereIsNothingToSelect: the empty-view messages are
+// drawn through a throwaway viewport, with no content to anchor to.
+func TestSelectionIsOffWithoutContent(t *testing.T) {
+	m := &MainModel{styles: DefaultStyles(), viewMode: "table", hasTable: false}
+
+	vp, name := m.selectionTarget()
+	assert.Nil(t, vp)
+	assert.Equal(t, "", name)
+
+	m.beginSelection(2, 2)
+	assert.False(t, m.selection.active)
+}
+
+// TestMouseOffDropsTheSelection: with the mouse handed back there is nothing
+// keeping the highlight up to date.
+func TestMouseOffDropsTheSelection(t *testing.T) {
+	m := selectionModel(5, "first line", "second line")
+	m.input = newTestInput()
+	drag(m, 0, 1, 5, 1)
+
+	m.handleMouseCommand("MOUSE OFF")
+
+	assert.False(t, m.mouseEnabled)
+	assert.False(t, m.selection.active)
+}

--- a/internal/ui/setting_chooser.go
+++ b/internal/ui/setting_chooser.go
@@ -1,0 +1,303 @@
+package ui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/router"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The list that opens when you click a setting on the status line.
+//
+// The status line is the last row, so the list opens upward, anchored to the
+// column of the field it belongs to. Anywhere else on screen and it would be
+// unclear which setting it was offering.
+
+// settingChooser is the open list, if any.
+type settingChooser struct {
+	active   bool
+	setting  string // which status field this belongs to
+	label    string // shown above the list, e.g. "CL"
+	choices  []string
+	selected int    // only used to centre the scroll window on the current value
+	current  string // marked in the list
+	anchorX  int    // column the field starts at
+}
+
+// chooserMaxHeight caps the list so it cannot cover the whole screen. Anything
+// longer scrolls.
+const chooserMaxHeight = 10
+
+// openSettingChooser opens the list for a status field.
+func (m *MainModel) openSettingChooser(setting string, anchorX int, choices []string, current string) {
+	if len(choices) == 0 {
+		return
+	}
+
+	selected := 0
+	for i, c := range choices {
+		if c == current {
+			selected = i
+		}
+	}
+
+	m.chooser = settingChooser{
+		active:   true,
+		setting:  setting,
+		label:    setting,
+		choices:  choices,
+		selected: selected,
+		current:  current,
+		anchorX:  anchorX,
+	}
+}
+
+// closeSettingChooser dismisses the list without changing anything.
+func (m *MainModel) closeSettingChooser() {
+	m.chooser = settingChooser{}
+}
+
+// chooserWindow returns the slice of choices to draw, and where the selection
+// sits within it, so a list longer than the space available scrolls.
+func (c settingChooser) window(height int) (start, end int) {
+	if height <= 0 || height >= len(c.choices) {
+		return 0, len(c.choices)
+	}
+
+	// Keep the current value in view, roughly centred, so a long list opens
+	// showing where you already are.
+	start = c.selected - height/2
+	if start < 0 {
+		start = 0
+	}
+	if start+height > len(c.choices) {
+		start = len(c.choices) - height
+	}
+	return start, start + height
+}
+
+// chooserGeometry works out where the list sits and which choices it shows.
+//
+// Drawing and clicking both go through this. Working the position out twice is
+// how a click ends up applying the row above the one you pointed at.
+type chooserGeometry struct {
+	x, y          int // top-left of the box, including its border
+	width, height int
+	first, last   int // range of choices drawn, last exclusive
+	innerWidth    int
+}
+
+func (m *MainModel) chooserGeometry(screenWidth, screenHeight int) (chooserGeometry, bool) {
+	c := m.chooser
+	if !c.active || len(c.choices) == 0 {
+		return chooserGeometry{}, false
+	}
+
+	// Rows above the status line, less the box's own border.
+	available := screenHeight - 1 - 2
+	rows := min(len(c.choices), min(chooserMaxHeight, available))
+	if rows <= 0 {
+		return chooserGeometry{}, false
+	}
+
+	first, last := c.window(rows)
+
+	inner := lipgloss.Width(c.label)
+	for _, choice := range c.choices {
+		if w := lipgloss.Width(choice); w > inner {
+			inner = w
+		}
+	}
+	// A leading space, a gap, and the current-value marker.
+	inner += 3
+
+	// A keyspace name can be long enough to push the box off the screen, so the
+	// box is capped and the names inside it are truncated to fit.
+	if inner > screenWidth-2 {
+		inner = max(screenWidth-2, 0)
+	}
+
+	width := inner + 2 // borders
+	height := rows + 2
+
+	x := c.anchorX
+	if x+width > screenWidth {
+		x = screenWidth - width
+	}
+	if x < 0 {
+		x = 0
+	}
+
+	y := screenHeight - 1 - height
+	if y < 0 {
+		y = 0
+	}
+
+	return chooserGeometry{
+		x: x, y: y, width: width, height: height,
+		first: first, last: last, innerWidth: inner,
+	}, true
+}
+
+// choiceAt returns the choice under a screen position, if the click is inside
+// the list.
+func (m *MainModel) choiceAt(screenWidth, screenHeight, col, row int) (string, bool) {
+	g, ok := m.chooserGeometry(screenWidth, screenHeight)
+	if !ok {
+		return "", false
+	}
+
+	// Inside the border, not on it.
+	if col <= g.x || col >= g.x+g.width-1 {
+		return "", false
+	}
+	if row <= g.y || row >= g.y+g.height-1 {
+		return "", false
+	}
+
+	idx := g.first + (row - g.y - 1)
+	if idx < g.first || idx >= g.last || idx >= len(m.chooser.choices) {
+		return "", false
+	}
+	return m.chooser.choices[idx], true
+}
+
+// viewSettingChooser renders the list and says where to put it.
+//
+// screenHeight is the full screen; the list sits directly above the status
+// line, growing upward, and is clamped to the screen if there is not room.
+func (m *MainModel) viewSettingChooser(screenWidth, screenHeight int) (Layer, bool) {
+	g, ok := m.chooserGeometry(screenWidth, screenHeight)
+	if !ok {
+		return Layer{}, false
+	}
+	c := m.chooser
+
+	choiceStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#D0D0D0"))
+	currentStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#87FFD7")).
+		Bold(true)
+
+	var b strings.Builder
+	for i := g.first; i < g.last; i++ {
+		choice := c.choices[i]
+
+		marker := " "
+		style := choiceStyle
+		if choice == c.current {
+			marker = "\u25cf"
+			style = currentStyle
+		}
+
+		// Exactly innerWidth columns: a leading space, the name padded out,
+		// then the marker. Anything else and the box's borders do not line up
+		// with the width chooserGeometry reports, which is what choiceAt tests
+		// clicks against.
+		text := ansi.Truncate(choice, max(g.innerWidth-2, 0), "…")
+		fill := max(g.innerWidth-lipgloss.Width(text)-2, 0)
+		line := " " + text + strings.Repeat(" ", fill) + marker
+		b.WriteString(style.Render(line))
+		if i < g.last-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#87D7FF")).
+		Render(b.String())
+
+	return Layer{
+		Content: box,
+		X:       g.x,
+		Y:       g.y,
+		Width:   g.width,
+		Height:  g.height,
+		ZIndex:  200, // above the other overlays; it is the thing just clicked
+	}, true
+}
+
+// handleSettingChooserKey dismisses the list on any keypress.
+//
+// There is deliberately no keyboard navigation. Anyone at the keyboard can type
+// CONSISTENCY LOCAL_QUORUM directly, which is fewer keystrokes than arrowing
+// through a list, so the list is for the mouse and gets out of the way as soon
+// as you start typing.
+func (m *MainModel) handleSettingChooserKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
+	m.closeSettingChooser()
+
+	// Escape means "just close it". Anything else was aimed at the prompt, so
+	// pass it on rather than swallowing a keystroke.
+	if msg.String() == "esc" {
+		return m, nil
+	}
+	return m.handleKeyboardInput(msg)
+}
+
+// applySettingChoice runs the command the chosen value corresponds to.
+//
+// It goes through the same meta-command path as typing it, so everything that
+// normally follows - the confirmation in the transcript, the status line
+// updating - happens the same way. Duplicating the effects here is how the two
+// routes end up behaving differently.
+func (m *MainModel) applySettingChoice(choice string) (*MainModel, tea.Cmd) {
+	c := m.chooser
+	m.closeSettingChooser()
+
+	if choice == "" {
+		return m, nil
+	}
+
+	if choice == c.current {
+		// Picking what is already set should do nothing at all, rather than
+		// logging a change that did not happen.
+		return m, nil
+	}
+
+	command := settingCommand(c.setting, choice)
+	if command == "" {
+		return m, nil
+	}
+
+	// Same path as typing it, so the transcript shows what changed and the
+	// status line updates the way it always has.
+	result := router.ProcessCommand(command, m.session, m.sessionManager)
+
+	m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
+	if text, ok := result.(string); ok && text != "" {
+		m.fullHistoryContent += "\n" + text
+
+		// A USE leaves three places tracking the keyspace to be told, the same
+		// as when one is typed at the prompt. Not switching to the console
+		// view, though: you clicked a setting, so whatever you were reading
+		// should still be in front of you.
+		m.adoptKeyspace(text)
+	}
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
+
+	return m, nil
+}
+
+// settingCommand returns the meta-command that sets a value.
+func settingCommand(setting, choice string) string {
+	switch setting {
+	case settingConsistency:
+		return "CONSISTENCY " + choice
+	case settingPaging:
+		return "PAGING " + choice
+	case settingTracing:
+		return "TRACING " + choice
+	case settingAutoFetch:
+		return "AUTOFETCH " + choice
+	case settingKeyspace:
+		// Quoted, so a keyspace created with a mixed-case name works. The USE
+		// handler strips the quotes before looking the name up, so this is
+		// harmless for the ordinary lowercase ones.
+		return `USE "` + choice + `"`
+	}
+	return ""
+}

--- a/internal/ui/setting_chooser_test.go
+++ b/internal/ui/setting_chooser_test.go
@@ -1,0 +1,320 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func chooserModel() *MainModel {
+	return &MainModel{
+		styles:       DefaultStyles(),
+		mouseEnabled: true,
+		windowWidth:  120,
+		windowHeight: 30,
+		statusBar:    testStatusBar(),
+	}
+}
+
+// TestClickingASettingOpensItsChoices is the point of the feature.
+func TestClickingASettingOpensItsChoices(t *testing.T) {
+	m := chooserModel()
+
+	var col int
+	for _, seg := range m.statusBar.segments() {
+		if seg.setting == settingConsistency {
+			col = (seg.start + seg.end) / 2
+		}
+	}
+
+	m.clickStatusSetting(col)
+
+	require.True(t, m.chooser.active, "clicking CL should open its list")
+	assert.Equal(t, settingConsistency, m.chooser.setting)
+	assert.Contains(t, m.chooser.choices, "LOCAL_QUORUM")
+	assert.Equal(t, "LOCAL_ONE", m.chooser.choices[m.chooser.selected],
+		"the list should open on the value already set")
+}
+
+func TestClickingAConnectionFactOpensNothing(t *testing.T) {
+	m := chooserModel()
+
+	for _, seg := range m.statusBar.segments() {
+		if seg.clickable() {
+			continue
+		}
+		m.clickStatusSetting((seg.start + seg.end) / 2)
+		assert.False(t, m.chooser.active, "%q is not a setting", seg.label)
+	}
+}
+
+// TestChooserDismissedByAnyKey: there is no keyboard navigation, so a keypress
+// means you have gone back to typing and the list should get out of the way.
+func TestChooserDismissedByAnyKey(t *testing.T) {
+	for _, key := range []tea.KeyPressMsg{
+		{Code: tea.KeyEscape},
+		{Code: 'x'},
+		{Code: tea.KeyDown},
+	} {
+		m := chooserModel()
+		m.openSettingChooser(settingConsistency, 10,
+			[]string{"ANY", "ONE", "QUORUM"}, "ONE")
+
+		m.handleSettingChooserKey(key)
+
+		assert.False(t, m.chooser.active, "%v should dismiss the list", key.String())
+		assert.Empty(t, m.fullHistoryContent, "dismissing must not change a setting")
+	}
+}
+
+// TestClickingAChoiceAppliesIt is how a value gets picked, now that there is no
+// keyboard navigation.
+func TestClickingAChoiceAppliesIt(t *testing.T) {
+	const w, h = 120, 30
+
+	m := chooserModel()
+	m.openSettingChooser(settingConsistency, 40,
+		[]string{"ANY", "ONE", "QUORUM", "ALL"}, "ONE")
+
+	g, ok := m.chooserGeometry(w, h)
+	require.True(t, ok)
+
+	// The third row inside the border is "QUORUM".
+	choice, inside := m.choiceAt(w, h, g.x+2, g.y+1+2)
+	require.True(t, inside, "a click inside the list should land on a choice")
+	assert.Equal(t, "QUORUM", choice)
+}
+
+// TestClicksOutsideTheListMissIt covers the border and the surrounding screen,
+// so clicking away closes rather than picking something by accident.
+func TestClicksOutsideTheListMissIt(t *testing.T) {
+	const w, h = 120, 30
+
+	m := chooserModel()
+	m.openSettingChooser(settingConsistency, 40,
+		[]string{"ANY", "ONE", "QUORUM", "ALL"}, "ONE")
+
+	g, ok := m.chooserGeometry(w, h)
+	require.True(t, ok)
+
+	outside := []struct {
+		name     string
+		col, row int
+	}{
+		{"top border", g.x + 2, g.y},
+		{"bottom border", g.x + 2, g.y + g.height - 1},
+		{"left border", g.x, g.y + 2},
+		{"right border", g.x + g.width - 1, g.y + 2},
+		{"left of the box", g.x - 1, g.y + 2},
+		{"above the box", g.x + 2, g.y - 1},
+		{"the status line itself", g.x + 2, h - 1},
+	}
+
+	for _, tt := range outside {
+		_, inside := m.choiceAt(w, h, tt.col, tt.row)
+		assert.False(t, inside, "a click on the %s is not a choice", tt.name)
+	}
+}
+
+// TestEveryDrawnRowIsClickable walks the whole list, so no row is unreachable.
+func TestEveryDrawnRowIsClickable(t *testing.T) {
+	const w, h = 120, 30
+
+	choices := []string{"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL"}
+	m := chooserModel()
+	m.openSettingChooser(settingConsistency, 20, choices, "ONE")
+
+	g, ok := m.chooserGeometry(w, h)
+	require.True(t, ok)
+	require.Equal(t, len(choices), g.last-g.first, "the whole list should fit here")
+
+	layer, ok := m.viewSettingChooser(w, h)
+	require.True(t, ok)
+	rows := strings.Split(layer.Content, "\n")
+
+	for i := g.first; i < g.last; i++ {
+		got, inside := m.choiceAt(w, h, g.x+1, g.y+1+(i-g.first))
+		require.True(t, inside, "row %d should be clickable", i)
+		assert.Equal(t, choices[i], got, "row %d should be %q", i, choices[i])
+
+		// The row that answers the click has to be the row showing that
+		// choice, or the list is off by one and nobody notices until they pick
+		// the wrong consistency level.
+		assert.Contains(t, stripAnsiForTest(rows[1+(i-g.first)]), choices[i])
+	}
+}
+
+// TestChoosingTheCurrentValueDoesNothing: picking what is already set should be
+// a no-op, not a logged change.
+func TestChoosingTheCurrentValueDoesNothing(t *testing.T) {
+	m := chooserModel()
+	m.openSettingChooser(settingTracing, 10, []string{"ON", "OFF"}, "OFF")
+
+	m.applySettingChoice("OFF")
+
+	assert.False(t, m.chooser.active)
+	assert.Empty(t, m.fullHistoryContent, "re-picking the current value should change nothing")
+}
+
+// TestSettingCommandMatchesTheTypedForm: applying must go through the same
+// command a user would type, or the two routes drift apart.
+func TestSettingCommandMatchesTheTypedForm(t *testing.T) {
+	tests := []struct {
+		setting, choice, want string
+	}{
+		{settingConsistency, "QUORUM", "CONSISTENCY QUORUM"},
+		{settingPaging, "500", "PAGING 500"},
+		{settingTracing, "ON", "TRACING ON"},
+		{settingAutoFetch, "OFF", "AUTOFETCH OFF"},
+		// Quoted, so a mixed-case keyspace name survives. The USE handler
+		// strips the quotes again before looking it up.
+		{settingKeyspace, "system", `USE "system"`},
+		{settingKeyspace, "MyKeyspace", `USE "MyKeyspace"`},
+		{"nonsense", "x", ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, settingCommand(tt.setting, tt.choice))
+	}
+}
+
+// TestChooserSitsAboveTheStatusLine: the field is on the last row, so the list
+// has to grow upward or it would be off screen.
+func TestChooserSitsAboveTheStatusLine(t *testing.T) {
+	const screenHeight = 30
+
+	m := chooserModel()
+	m.openSettingChooser(settingConsistency, 40,
+		[]string{"ANY", "ONE", "QUORUM", "ALL"}, "ONE")
+
+	layer, ok := m.viewSettingChooser(120, screenHeight)
+	require.True(t, ok)
+
+	assert.Equal(t, screenHeight-1, layer.Y+layer.Height,
+		"the list should finish directly above the status line")
+	assert.Equal(t, 40, layer.X, "and be anchored to the field it belongs to")
+	assert.Greater(t, layer.ZIndex, 100, "it is the thing just clicked, so it goes on top")
+}
+
+// TestChooserNudgedLeftAtTheEdge: a field near the right edge must not push the
+// list off screen.
+func TestChooserNudgedLeftAtTheEdge(t *testing.T) {
+	m := chooserModel()
+	m.openSettingChooser(settingConsistency, 118,
+		[]string{"LOCAL_QUORUM", "EACH_QUORUM"}, "LOCAL_QUORUM")
+
+	layer, ok := m.viewSettingChooser(120, 30)
+	require.True(t, ok)
+
+	assert.GreaterOrEqual(t, layer.X, 0)
+	assert.LessOrEqual(t, layer.X+layer.Width, 120,
+		"the list must stay on screen")
+}
+
+// TestChooserScrollsWhenTooTall keeps a long list usable on a short screen.
+func TestChooserScrollsWhenTooTall(t *testing.T) {
+	long := make([]string, 40)
+	for i := range long {
+		long[i] = string(rune('a' + i%26))
+	}
+
+	c := settingChooser{choices: long, selected: 30}
+	start, end := c.window(10)
+
+	assert.Equal(t, 10, end-start, "the window should be the height asked for")
+	assert.LessOrEqual(t, start, 30)
+	assert.Greater(t, end, 30, "the selection has to be inside the window")
+
+	// And it must not run past either end.
+	c.selected = 0
+	start, _ = c.window(10)
+	assert.Equal(t, 0, start, "at the top the window should start at the top")
+
+	c.selected = len(long) - 1
+	_, end = c.window(10)
+	assert.Equal(t, len(long), end, "at the bottom it should reach the last choice")
+}
+
+func TestChooserHiddenWhenClosed(t *testing.T) {
+	m := chooserModel()
+	_, ok := m.viewSettingChooser(120, 30)
+	assert.False(t, ok, "nothing to draw when nothing is open")
+}
+
+// TestLongChoicesStayOnScreen: keyspace names are the one setting whose values
+// are not short and known in advance, so the box has to be capped and the names
+// truncated rather than pushed off the side.
+func TestLongChoicesStayOnScreen(t *testing.T) {
+	const screenWidth = 40
+
+	m := chooserModel()
+	m.windowWidth = screenWidth
+	m.openSettingChooser(settingKeyspace, 4, []string{
+		"short",
+		"a_keyspace_name_far_longer_than_this_terminal_is_wide",
+	}, "short")
+
+	layer, ok := m.viewSettingChooser(screenWidth, 30)
+	require.True(t, ok)
+
+	assert.LessOrEqual(t, layer.X+layer.Width, screenWidth, "the box ran off the screen")
+	for _, line := range strings.Split(layer.Content, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), screenWidth,
+			"a row of the box is wider than the screen: %q", line)
+	}
+}
+
+// TestChooserGeometryMatchesWhatItDraws is the invariant behind every click on
+// the list: choiceAt tests a position against chooserGeometry, so if the box
+// renders even a column wider than the geometry says, the last column of it
+// stops responding.
+func TestChooserGeometryMatchesWhatItDraws(t *testing.T) {
+	cases := [][]string{
+		{"ON", "OFF"},
+		{"ANY", "ONE", "TWO", "THREE", "QUORUM", "LOCAL_QUORUM", "EACH_QUORUM"},
+		{"a", "a_much_longer_keyspace_name_here"},
+	}
+
+	for _, choices := range cases {
+		m := chooserModel()
+		m.openSettingChooser(settingKeyspace, 4, choices, choices[0])
+
+		g, ok := m.chooserGeometry(m.windowWidth, m.windowHeight)
+		require.True(t, ok)
+
+		layer, ok := m.viewSettingChooser(m.windowWidth, m.windowHeight)
+		require.True(t, ok)
+
+		rows := strings.Split(layer.Content, "\n")
+		assert.Len(t, rows, g.height, "%v: drew a different number of rows than the geometry claims", choices)
+		for _, row := range rows {
+			assert.Equal(t, g.width, lipgloss.Width(row),
+				"%v: row %q is not the width the geometry claims", choices, row)
+		}
+	}
+}
+
+// TestKeyspacesAreNotAConstantList: they come from the cluster, so
+// settingChoices must not pretend to know them.
+func TestKeyspacesAreNotAConstantList(t *testing.T) {
+	choices, _ := settingChoices(settingKeyspace, "system")
+	assert.Empty(t, choices)
+}
+
+// TestClickingKSWithNoConnectionOpensNothing: an empty list would be a box
+// with nothing in it.
+func TestClickingKSWithNoConnectionOpensNothing(t *testing.T) {
+	m := chooserModel()
+
+	for _, seg := range m.statusBar.segments() {
+		if seg.setting == settingKeyspace {
+			m.clickStatusSetting((seg.start + seg.end) / 2)
+		}
+	}
+
+	assert.False(t, m.chooser.active)
+}

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"fmt"
-
 	"charm.land/lipgloss/v2"
 )
 
@@ -66,65 +64,39 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 	separatorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#555555"))
 
-	// Format values
-	keyspaceDisplay := m.Keyspace
-	if keyspaceDisplay == "" {
-		keyspaceDisplay = "(none)"
+	// Render from the same segment list that hit testing uses, so a click can
+	// never land on a different field from the one drawn there.
+	styleFor := func(seg statusSegment) lipgloss.Style {
+		switch seg.setting {
+		case settingKeyspace:
+			return keyspaceStyle
+		case settingConsistency:
+			return consistencyStyle
+		case settingPaging:
+			return pageStyle
+		case settingTracing, settingAutoFetch:
+			if seg.value == "ON" {
+				return tracingOnStyle
+			}
+			return tracingOffStyle
+		}
+		if seg.label == "v" {
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("#B8B8B8"))
+		}
+		return hostStyle
 	}
 
-	usernameDisplay := m.Username
-	if usernameDisplay == "" {
-		usernameDisplay = "(anonymous)"
-	}
-
-	tracingState := "OFF"
-	tracingStyle := tracingOffStyle
-	if m.Tracing {
-		tracingState = "ON"
-		tracingStyle = tracingOnStyle
-	}
-
-	autoFetchState := "OFF"
-	autoFetchStyle := tracingOffStyle
-	if m.AutoFetch {
-		autoFetchState = "ON"
-		autoFetchStyle = tracingOnStyle
-	}
-
-	// Version style
-	versionStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#B8B8B8"))
-
-	// Build the status text with colors in the requested order:
-	// Cassandra version, User, Host, KS, CL, Pg, Trace, Fetch.
-	// AutoFetch sits here with the other session settings rather than up with
-	// the query facts, since that is what it is.
 	statusText := ""
-
-	// Start with version if available
-	if m.Version != "" {
-		statusText = labelStyle.Render("v") + versionStyle.Render(m.Version) +
-			separatorStyle.Render(" │ ")
+	for i, seg := range m.segments() {
+		if i > 0 {
+			statusText += separatorStyle.Render(statusSeparator)
+		}
+		statusText += labelStyle.Render(seg.label) + styleFor(seg).Render(seg.value)
 	}
-
-	// Then add the rest in order
-	statusText += labelStyle.Render("User: ") + hostStyle.Render(usernameDisplay) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Host: ") + hostStyle.Render(m.Host) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("KS: ") + keyspaceStyle.Render(keyspaceDisplay) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("CL: ") + consistencyStyle.Render(m.Consistency) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Pg: ") + pageStyle.Render(fmt.Sprintf("%d", m.PagingSize)) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Trace: ") + tracingStyle.Render(tracingState) +
-		separatorStyle.Render(" │ ") +
-		labelStyle.Render("Fetch: ") + autoFetchStyle.Render(autoFetchState)
 
 	// Apply style to the entire bar without forced background
 	barStyle := lipgloss.NewStyle().
-		Padding(0, 1).
+		Padding(0, statusBarPadding).
 		Width(width)
 
 	return barStyle.Render(statusText)

--- a/internal/ui/statusbar_fields.go
+++ b/internal/ui/statusbar_fields.go
@@ -1,0 +1,135 @@
+package ui
+
+import (
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Clickable settings on the status line.
+//
+// The line is built from segments so that rendering and hit testing come from
+// one description of the layout. Working the columns out separately from the
+// drawing is how a click ends up opening the wrong thing the moment either side
+// changes - the same trap the tab bar avoids by sharing layoutTabs.
+
+// Setting keys, used to tie a click to what it changes.
+const (
+	settingKeyspace    = "KS"
+	settingConsistency = "CL"
+	settingPaging      = "Pg"
+	settingTracing     = "Trace"
+	settingAutoFetch   = "Fetch"
+)
+
+// statusSegment is one "Label: value" pair on the status line.
+//
+// A segment with an empty setting is information rather than a control - the
+// server version, the user, the host - and ignores clicks.
+type statusSegment struct {
+	setting    string // one of the setting constants, or "" if not clickable
+	label      string
+	value      string
+	start, end int // column range covering label and value, end exclusive
+}
+
+// clickable reports whether this segment changes something.
+func (s statusSegment) clickable() bool { return s.setting != "" }
+
+// statusBarPadding is the left padding lipgloss adds when rendering the line.
+// Click columns are screen columns, so they have to account for it.
+const statusBarPadding = 1
+
+// statusSeparator sits between segments.
+const statusSeparator = " │ "
+
+// segments describes the status line in order, with the column each piece
+// occupies. Rendering walks the same list, so the two cannot disagree.
+func (m StatusBarModel) segments() []statusSegment {
+	keyspace := m.Keyspace
+	if keyspace == "" {
+		keyspace = "(none)"
+	}
+
+	username := m.Username
+	if username == "" {
+		username = "(anonymous)"
+	}
+
+	onOff := func(b bool) string {
+		if b {
+			return "ON"
+		}
+		return "OFF"
+	}
+
+	var segs []statusSegment
+	if m.Version != "" {
+		segs = append(segs, statusSegment{label: "v", value: m.Version})
+	}
+	segs = append(segs,
+		statusSegment{label: "User: ", value: username},
+		statusSegment{label: "Host: ", value: m.Host},
+		statusSegment{setting: settingKeyspace, label: "KS: ", value: keyspace},
+		statusSegment{setting: settingConsistency, label: "CL: ", value: m.Consistency},
+		statusSegment{setting: settingPaging, label: "Pg: ", value: fmt.Sprintf("%d", m.PagingSize)},
+		statusSegment{setting: settingTracing, label: "Trace: ", value: onOff(m.Tracing)},
+		statusSegment{setting: settingAutoFetch, label: "Fetch: ", value: onOff(m.AutoFetch)},
+	)
+
+	// Columns, not bytes. The separator is three columns wide but five bytes,
+	// because of the box-drawing character, and lipgloss.Width also gets
+	// double-width characters right, which a keyspace name can contain.
+	col := statusBarPadding
+	for i := range segs {
+		if i > 0 {
+			col += lipgloss.Width(statusSeparator)
+		}
+		segs[i].start = col
+		col += lipgloss.Width(segs[i].label) + lipgloss.Width(segs[i].value)
+		segs[i].end = col
+	}
+	return segs
+}
+
+// settingAt returns the setting whose segment covers a column, and where that
+// segment starts, so a chooser can be anchored to it.
+func (m StatusBarModel) settingAt(col int) (setting string, at int, ok bool) {
+	for _, seg := range m.segments() {
+		if col >= seg.start && col < seg.end {
+			if !seg.clickable() {
+				return "", 0, false
+			}
+			return seg.setting, seg.start, true
+		}
+	}
+	return "", 0, false
+}
+
+// settingChoices lists the values a setting can take, and which is current.
+//
+// Keyspaces are not here: they come from the cluster, so the caller supplies
+// them.
+func settingChoices(setting string, current string) (choices []string, selected int) {
+	switch setting {
+	case settingConsistency:
+		choices = []string{
+			"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL",
+			"LOCAL_QUORUM", "EACH_QUORUM", "LOCAL_ONE", "SERIAL", "LOCAL_SERIAL",
+		}
+	case settingPaging:
+		// The values PAGING accepts, plus OFF, which is how it is turned off.
+		choices = []string{"OFF", "50", "100", "500", "1000", "5000"}
+	case settingTracing, settingAutoFetch:
+		choices = []string{"ON", "OFF"}
+	default:
+		return nil, 0
+	}
+
+	for i, c := range choices {
+		if c == current {
+			return choices, i
+		}
+	}
+	return choices, 0
+}

--- a/internal/ui/statusbar_fields_test.go
+++ b/internal/ui/statusbar_fields_test.go
@@ -1,0 +1,135 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testStatusBar() StatusBarModel {
+	return StatusBarModel{
+		Username:    "cassandra",
+		Host:        "127.0.0.1",
+		Keyspace:    "system",
+		Consistency: "LOCAL_ONE",
+		PagingSize:  100,
+		Tracing:     false,
+		AutoFetch:   true,
+		Version:     "5.0.9",
+	}
+}
+
+// TestSegmentsMatchTheRenderedLine is the property everything else rests on:
+// the columns used for hit testing have to describe the text actually drawn.
+// Checking the two against each other, rather than against the same
+// arithmetic, is what catches them drifting apart.
+func TestSegmentsMatchTheRenderedLine(t *testing.T) {
+	m := testStatusBar()
+
+	rendered := []rune(stripAnsiForTest(m.View(140, DefaultStyles(), "history")))
+
+	for _, seg := range m.segments() {
+		require.LessOrEqual(t, seg.end, len(rendered),
+			"segment %q runs past the end of the line", seg.label)
+
+		got := string(rendered[seg.start:seg.end])
+		assert.Equal(t, seg.label+seg.value, got,
+			"columns %d..%d should hold %q but the line has %q",
+			seg.start, seg.end, seg.label+seg.value, got)
+	}
+}
+
+// TestSettingAtResolvesClicks covers turning a column into a setting.
+func TestSettingAtResolvesClicks(t *testing.T) {
+	m := testStatusBar()
+
+	for _, seg := range m.segments() {
+		if !seg.clickable() {
+			continue
+		}
+		for _, col := range []int{seg.start, (seg.start + seg.end) / 2, seg.end - 1} {
+			setting, at, ok := m.settingAt(col)
+			assert.True(t, ok, "column %d is inside %q and should be clickable", col, seg.setting)
+			assert.Equal(t, seg.setting, setting)
+			assert.Equal(t, seg.start, at, "the chooser anchors to the start of the field")
+		}
+	}
+}
+
+// TestConnectionFactsAreNotClickable: version, user and host describe the
+// connection rather than settings, so clicking them must do nothing rather than
+// open an empty list.
+func TestConnectionFactsAreNotClickable(t *testing.T) {
+	m := testStatusBar()
+
+	for _, seg := range m.segments() {
+		if seg.clickable() {
+			continue
+		}
+		_, _, ok := m.settingAt((seg.start + seg.end) / 2)
+		assert.False(t, ok, "%q is a fact, not a setting", seg.label)
+	}
+}
+
+func TestSettingAtOutsideAnyField(t *testing.T) {
+	m := testStatusBar()
+
+	_, _, ok := m.settingAt(0) // the padding column
+	assert.False(t, ok)
+
+	_, _, ok = m.settingAt(10000) // past the end
+	assert.False(t, ok)
+}
+
+// TestSegmentsDoNotOverlap: overlapping ranges would make a click ambiguous.
+func TestSegmentsDoNotOverlap(t *testing.T) {
+	segs := testStatusBar().segments()
+	require.NotEmpty(t, segs)
+
+	for i := 1; i < len(segs); i++ {
+		assert.GreaterOrEqual(t, segs[i].start, segs[i-1].end,
+			"%q overlaps %q", segs[i].label, segs[i-1].label)
+	}
+}
+
+// TestSettingChoicesMarkTheCurrentValue: the list should open on what is
+// already set, so picking the current value is a no-op rather than a surprise.
+func TestSettingChoicesMarkTheCurrentValue(t *testing.T) {
+	tests := []struct {
+		setting string
+		current string
+		want    string
+	}{
+		{settingConsistency, "LOCAL_QUORUM", "LOCAL_QUORUM"},
+		{settingConsistency, "ONE", "ONE"},
+		{settingPaging, "100", "100"},
+		{settingTracing, "OFF", "OFF"},
+		{settingAutoFetch, "ON", "ON"},
+	}
+
+	for _, tt := range tests {
+		choices, selected := settingChoices(tt.setting, tt.current)
+		require.NotEmpty(t, choices, "%s should offer choices", tt.setting)
+		require.Less(t, selected, len(choices))
+		assert.Equal(t, tt.want, choices[selected],
+			"%s should open on its current value", tt.setting)
+	}
+}
+
+// TestSettingChoicesFallBackToTheFirst covers a current value that is not in
+// the list, which happens for a consistency level we do not offer.
+func TestSettingChoicesFallBackToTheFirst(t *testing.T) {
+	choices, selected := settingChoices(settingConsistency, "SOMETHING_ELSE")
+	require.NotEmpty(t, choices)
+	assert.Equal(t, 0, selected)
+}
+
+func TestSettingChoicesUnknownSetting(t *testing.T) {
+	choices, _ := settingChoices("nonsense", "")
+	assert.Nil(t, choices)
+
+	// Keyspaces come from the cluster, so they are not baked in here.
+	choices, _ = settingChoices(settingKeyspace, "system")
+	assert.Nil(t, choices)
+}

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -256,17 +256,56 @@ func TestMouseCommandTogglesReporting(t *testing.T) {
 	assert.Contains(t, m.fullHistoryContent, "Usage: MOUSE")
 }
 
-// TestMouseModeFollowsTheSetting checks the View actually carries it, since
-// that is what the terminal acts on.
-func TestMouseModeFollowsTheSetting(t *testing.T) {
-	m := &MainModel{mouseEnabled: true}
-	assert.Equal(t, tea.MouseModeCellMotion, m.newView("").MouseMode,
-		"reporting must be on for the tabs to be clickable")
+// TestMouseReportingFollowsTheSetting checks what the terminal is actually
+// asked for, which is where the behaviour lives.
+//
+// CellMotion is DECSET 1002: presses, releases, the wheel and motion while a
+// button is held. The drag events are the point - cqlai draws its own text
+// selection, which is what lets the tabs be clickable and text still be
+// selectable at the same time.
+func TestMouseReportingFollowsTheSetting(t *testing.T) {
+	input := textinput.New()
+	m := &MainModel{
+		input:           input,
+		styles:          DefaultStyles(),
+		historyViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+	}
 
-	m.mouseEnabled = false
+	on := captureStdout(t, func() { m.handleSpecialCommands("MOUSE ON") })
+	assert.True(t, m.mouseEnabled)
+	assert.Equal(t, tea.MouseModeCellMotion, m.newView("").MouseMode)
+	assert.Empty(t, on, "the mode is a field on the View, not something written by hand")
+
+	off := captureStdout(t, func() { m.handleSpecialCommands("MOUSE OFF") })
+	assert.False(t, m.mouseEnabled)
 	assert.Equal(t, tea.MouseModeNone, m.newView("").MouseMode,
-		"MOUSE OFF must hand the buttons back to the terminal")
+		"MOUSE OFF must hand the mouse back to the terminal")
+	assert.Empty(t, off)
 
-	// The alternate screen is asked for either way.
 	assert.True(t, m.newView("").AltScreen)
+}
+
+// TestMouseIsOnByDefault: it has to be, or the tabs and the settings on the
+// bottom line do nothing until you have found a command nobody knows about.
+// It costs nothing now that selection is drawn rather than left to the
+// terminal.
+func TestMouseIsOnByDefault(t *testing.T) {
+	m := &MainModel{}
+	assert.False(t, m.mouseEnabled, "the zero value is not the default")
+
+	assert.True(t, defaultMouseEnabled,
+		"new sessions start with the mouse on")
+}
+
+// TestRenderDoesNotTouchTheTerminal: escape sequences written from View fight
+// the renderer for the screen, so the mouse mode is set from the command
+// handler instead.
+func TestRenderDoesNotTouchTheTerminal(t *testing.T) {
+	m := &MainModel{mouseEnabled: true}
+
+	out := captureStdout(t, func() {
+		m.newView("")
+		m.newView("")
+	})
+	assert.Empty(t, out, "rendering should write nothing directly to the terminal")
 }

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -15,22 +15,28 @@ import (
 // commands, the alternate screen and mouse mode are fields recomputed on every
 // render, so they cannot drift out of step with what is on screen.
 //
-// MouseMode is a trade rather than a setting with a right answer. Asking for
-// mouse reporting is what makes the tabs clickable, and it is also what takes
-// the buttons away from the terminal, so text selection needs Shift and
-// right-click paste stops working - the behaviour #86 was about. MOUSE OFF
-// gives those back at the cost of clicking.
+// Taking the mouse means the terminal stops selecting text for us, so cqlai
+// draws the selection itself instead - see selection.go. That is what lets the
+// tabs and the bottom line be clickable and text still be selectable, which no
+// choice of DECSET mode gives you on its own. MOUSE OFF hands the mouse back
+// for anyone who would rather have the terminal do it.
 //
-// Either way the wheel still scrolls, through alternate scroll mode, which v2
-// does not manage and mouse_mode.go sets up.
+// Either way the wheel still scrolls: with reporting on it arrives as a wheel
+// event, and with it off, through alternate scroll mode, which v2 does not
+// manage and mouse_mode.go sets up.
 func (m *MainModel) newView(content string) tea.View {
 	v := tea.NewView(content)
 	v.AltScreen = true
+
+	// CellMotion is DECSET 1002: presses, releases, the wheel, and motion while
+	// a button is held, which is what following a drag needs. AllMotion adds
+	// motion with no button down, and nothing here tracks the pointer at rest.
 	if m.mouseEnabled {
 		v.MouseMode = tea.MouseModeCellMotion
 	} else {
 		v.MouseMode = tea.MouseModeNone
 	}
+
 	return v
 }
 
@@ -187,9 +193,9 @@ func (m *MainModel) View() tea.View {
 		}
 	}
 
-	// Say which way the mouse is set. Without this, someone who has never heard
-	// of the MOUSE command just finds that selecting text needs Shift, with
-	// nothing on screen explaining why.
+	// Say which way the mouse is set. Without this, someone who has turned it
+	// off, or run into a terminal that will not report it, just finds that
+	// clicking the tabs does nothing, with nothing on screen explaining why.
 	if m.mouseEnabled {
 		mouseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF"))
 		scrollInfo += " " + mouseStyle.Render("[MOUSE]")
@@ -282,29 +288,25 @@ func (m *MainModel) View() tea.View {
 		infoBar = " "
 	}
 
-	// Build the viewport section with sticky header for tables
-	var viewportSection string
-	if m.viewMode == "table" && m.hasTable && m.tableViewport.YOffset() > 0 {
-		// When table is scrolled, prepend the header
+	// Build the viewport section with sticky header for tables.
+	//
+	// stickyHeaderRows decides whether the header is drawn, and the selection
+	// reads the same function to know which rows are showing the top of the
+	// table rather than the lines the viewport is scrolled to.
+	viewportSection := viewportContent
+	if headerLineCount := m.stickyHeaderRows(); headerLineCount > 0 {
 		header := m.buildTableStickyHeader()
-		if header != "" {
-			// Get viewport lines and remove the top lines that would duplicate the header
-			lines := strings.Split(viewportContent, "\n")
-
-			// Skip the lines that would be covered by the sticky header (3 lines: border, header, separator)
-			headerLineCount := 3
-			if len(lines) > headerLineCount {
-				remainingLines := lines[headerLineCount:]
-				viewportSection = header + "\n" + strings.Join(remainingLines, "\n")
-			} else {
-				viewportSection = header + "\n" + viewportContent
-			}
+		lines := strings.Split(viewportContent, "\n")
+		if len(lines) > headerLineCount {
+			viewportSection = header + "\n" + strings.Join(lines[headerLineCount:], "\n")
 		} else {
-			viewportSection = viewportContent
+			viewportSection = header + "\n" + viewportContent
 		}
-	} else {
-		viewportSection = viewportContent
 	}
+
+	// Paint the mouse selection on last, so it covers whatever styling the
+	// content already had.
+	viewportSection = m.highlightSelection(viewportSection)
 
 	// Build the final view. The tabs get their own line above the status bar so
 	// the modes and their keys are always on screen, rather than something you
@@ -413,6 +415,11 @@ func (m *MainModel) View() tea.View {
 	}
 
 	// Apply all layers to the final view
+	// The settings chooser sits above everything: it is the thing just clicked.
+	if layer, ok := m.viewSettingChooser(screenWidth, screenHeight); ok {
+		layerManager.AddLayer(layer)
+	}
+
 	finalView = layerManager.Render(finalView)
 
 	// If modal is showing, render it as an overlay


### PR DESCRIPTION
Two changes that only make sense together, so they are here as one PR.

## Clicking the settings on the bottom line

`KS`, `CL`, `Pg`, `Trace` and `Fetch` open a list of their values when you click them. The list opens upward, anchored to the field, because the field is on the last row.

Picking a value runs the same meta-command you would have typed, so the transcript records it and the status line updates the way it always has. `KS` asks the cluster for its keyspaces on each click rather than caching them, since keyspaces come and go while cqlai is running.

There is deliberately no keyboard navigation in the list. Anyone at the keyboard can type `CONSISTENCY LOCAL_QUORUM`, which is fewer keystrokes than arrowing through a list, so the list is for the mouse and gets out of the way as soon as you type.

## Drawing our own text selection

Asking the terminal for mouse events takes away its own click-and-drag selection. That looked like a hard limit: the mode tabs (#93) and these settings both sat behind `MOUSE ON`, and turning it on meant holding Shift to select anything.

It is not a limit. A `script` capture of another terminal application that manages both showed it enabling the full set - `?1000h ?1002h ?1003h ?1006h` - and then writing the clipboard with OSC 52. One of the decoded fragments was cut across column boundaries, which only an app-drawn selection produces, not a terminal's own.

So owning the mouse is not what loses you selection. It is what lets you keep it, provided you then draw the selection yourself.

- Press, drag and release selects a span. No modifier key, in every view.
- The highlight follows the drag.
- Releasing copies through `tea.SetClipboard`, which is OSC 52 - it works through ssh and inside tmux, where shelling out to `xclip` would put the text on the wrong machine.
- Double-click takes a word, triple-click takes a line.
- Dragging past the top or bottom edge scrolls, so a selection can run past one screen.
- Escape, any keypress, or a click elsewhere clears it.

The span is held as a line and column in the active viewport's **content**, not as screen rows. Scrolling - which dragging past an edge does on purpose - then moves the text under the highlight without moving the highlight off it.

## The mouse is on by default now

It costs nothing any more, so the tabs and the settings work without first finding a command nobody has heard of. `MOUSE OFF` still hands everything back to the terminal for anyone who wants its own selection and paste.

Mouse mode is now a field on the `View` (`CellMotion`) rather than escape sequences written by hand, which was the last item outstanding from the v2 upgrade (#104). Only alternate scroll, 1007, is still written directly, because Bubble Tea does not manage it.

## Fixed on the way through

- The chooser box rendered one column wider than its geometry reported, so the rightmost column of it took no clicks. There is now a test asserting every drawn row is exactly the width the geometry claims.
- The bookkeeping after a `USE` - the session manager, the gocql session and the status line each track the current keyspace separately - lived only on the Enter-key path. Picking a keyspace from the chooser would have switched the server and left all three stale. It is now one function called from both routes.
- Status line columns are counted in cells, not bytes. The separator is three columns wide and five bytes, so every field after the first was off by two per separator and clicking `CL` would have opened the paging list.

## What this does not fix

**Right-click paste.** Reading the clipboard needs OSC 52 *read*, which iTerm2, kitty, foot and WezTerm all refuse by default, and rightly - otherwise any program at the far end of an ssh session could help itself to whatever you last copied. Whatever your terminal binds paste to still works.

## Testing

`go build`, `go vet`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover the selection coordinate arithmetic, the ANSI-aware column slicing, copy text including trailing-space trimming, drag-past-edge scrolling, double and triple click, and the chooser geometry invariant.

Tests drive the model directly, so the parts they cannot reach - whether a real terminal delivers drag events and honours the OSC 52 write - were checked by hand against a build.

Closes #107
Closes #108
