### PR TITLE
feat(ui): rework the status line, and fix what clicking it did

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,20 +397,36 @@ func OverrideWithEnvVars(config *Config) {
 	}
 }
 
+// outputFormats are the formats OUTPUT accepts, in the order to offer them.
+var outputFormats = []OutputFormat{
+	OutputFormatTable,
+	OutputFormatASCII,
+	OutputFormatExpand,
+	OutputFormatJSON,
+}
+
+// OutputFormats names every format ParseOutputFormat accepts.
+//
+// Anything that offers a choice of format, or lists the valid ones in an error,
+// reads this rather than writing the four out again - the consistency levels
+// were spelled out in five places and had drifted in three of them.
+func OutputFormats() []string {
+	names := make([]string, 0, len(outputFormats))
+	for _, f := range outputFormats {
+		names = append(names, string(f))
+	}
+	return names
+}
+
 // ParseOutputFormat converts a string to OutputFormat
 func ParseOutputFormat(format string) (OutputFormat, error) {
-	switch strings.ToUpper(format) {
-	case "TABLE":
-		return OutputFormatTable, nil
-	case "ASCII":
-		return OutputFormatASCII, nil
-	case "EXPAND":
-		return OutputFormatExpand, nil
-	case "JSON":
-		return OutputFormatJSON, nil
-	default:
-		return "", fmt.Errorf("unknown output format: %s", format)
+	want := strings.ToUpper(format)
+	for _, f := range outputFormats {
+		if string(f) == want {
+			return f, nil
+		}
 	}
+	return "", fmt.Errorf("unknown output format: %s", format)
 }
 
 // loadCQLSHRC loads configuration from a CQLSHRC file

--- a/internal/db/connection_info.go
+++ b/internal/db/connection_info.go
@@ -1,0 +1,61 @@
+package db
+
+// ConnectionInfo describes the connection, for the panel behind Connection on
+// the status line.
+//
+// The version, the user and the host used to sit on the status line as three
+// separate fields, which took a third of it to say things that rarely change.
+// They are one field now, and this is what opens behind it - with the
+// encryption settings, which were not shown anywhere at all.
+type ConnectionInfo struct {
+	Version  string // Cassandra release version
+	Protocol int    // native protocol version negotiated
+	Username string
+	Host     string // host and port, as connected
+
+	// Encryption. The rest are meaningless unless Encrypted is set.
+	Encrypted         bool
+	HostVerified      bool // the server's certificate is checked against its name
+	ClientCertificate bool // we present one of our own
+	CustomCA          bool // the server's certificate is checked against a CA we were given
+}
+
+// ConnectionInfo reports how this session is connected.
+//
+// It reads the cluster configuration rather than the wire, so it says what was
+// asked for. For TLS that is the same thing: gocql fails the connection if the
+// handshake does not meet the configuration, so a session that exists is one
+// where these held.
+func (s *Session) ConnectionInfo() ConnectionInfo {
+	info := ConnectionInfo{
+		Version:  s.CassandraVersion(),
+		Username: s.username,
+	}
+	if info.Username == "" {
+		info.Username = "(anonymous)"
+	}
+
+	if s.cluster == nil {
+		return info
+	}
+
+	info.Protocol = s.cluster.ProtoVersion
+	if len(s.cluster.Hosts) > 0 {
+		info.Host = s.cluster.Hosts[0]
+	}
+
+	if s.cluster.SslOpts == nil {
+		return info
+	}
+	info.Encrypted = true
+
+	if c := s.cluster.SslOpts.Config; c != nil {
+		// InsecureSkipVerify is the switch that turns certificate checking
+		// off, so saying it plainly is the point: an encrypted connection that
+		// verifies nothing is not the same as one that does.
+		info.HostVerified = !c.InsecureSkipVerify
+		info.ClientCertificate = len(c.Certificates) > 0
+		info.CustomCA = c.RootCAs != nil
+	}
+	return info
+}

--- a/internal/db/consistency.go
+++ b/internal/db/consistency.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"fmt"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+)
+
+// The consistency levels CONSISTENCY accepts.
+//
+// One table, because there were five hand-written copies of this list and they
+// disagreed. Three offered SERIAL and LOCAL_SERIAL and SetConsistency did not
+// accept them, so picking one from the status line, or completing one with Tab,
+// produced "invalid consistency level" rather than a change.
+//
+// SERIAL and LOCAL_SERIAL belong here. They are consistency levels like the
+// rest - the driver has them as Consistency values, 0x08 and 0x09, and cqlsh
+// takes them for CONSISTENCY too. A read at SERIAL goes through Paxos and sees
+// any in-flight lightweight transaction, which is the point of them.
+//
+// In protocol order, which is also the order cqlsh lists them in.
+var consistencyLevels = []struct {
+	name  string
+	level gocql.Consistency
+}{
+	{"ANY", gocql.Any},
+	{"ONE", gocql.One},
+	{"TWO", gocql.Two},
+	{"THREE", gocql.Three},
+	{"QUORUM", gocql.Quorum},
+	{"ALL", gocql.All},
+	{"LOCAL_QUORUM", gocql.LocalQuorum},
+	{"EACH_QUORUM", gocql.EachQuorum},
+	{"SERIAL", gocql.Serial},
+	{"LOCAL_SERIAL", gocql.LocalSerial},
+	{"LOCAL_ONE", gocql.LocalOne},
+}
+
+// ConsistencyLevels names every level SetConsistency accepts.
+//
+// Everything that offers the user a choice of level reads this - the status
+// line chooser, tab completion, the CONSISTENCY usage message - so nothing can
+// offer a level that then fails to apply.
+func ConsistencyLevels() []string {
+	names := make([]string, 0, len(consistencyLevels))
+	for _, c := range consistencyLevels {
+		names = append(names, c.name)
+	}
+	return names
+}
+
+// Consistency returns the current consistency level.
+func (s *Session) Consistency() string {
+	for _, c := range consistencyLevels {
+		if c.level == s.consistency {
+			return c.name
+		}
+	}
+	return "UNKNOWN"
+}
+
+// SetConsistency sets the consistency level.
+func (s *Session) SetConsistency(level string) error {
+	for _, c := range consistencyLevels {
+		if c.name == level {
+			s.consistency = c.level
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid consistency level: %s", level)
+}

--- a/internal/db/consistency_test.go
+++ b/internal/db/consistency_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"testing"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryOfferedLevelCanBeSet is the guard the hand-written lists did not
+// have. Three of them offered SERIAL and LOCAL_SERIAL while SetConsistency
+// rejected them, so picking one printed an error instead of changing anything.
+func TestEveryOfferedLevelCanBeSet(t *testing.T) {
+	levels := ConsistencyLevels()
+	require.NotEmpty(t, levels)
+
+	s := &Session{}
+	for _, level := range levels {
+		require.NoError(t, s.SetConsistency(level), "%s is offered but cannot be set", level)
+		assert.Equal(t, level, s.Consistency(), "%s did not read back as itself", level)
+	}
+}
+
+// TestSerialLevelsAreAccepted is the bug from #110. They are consistency levels
+// like the rest, and cqlsh takes them for CONSISTENCY, so cqlai must too.
+func TestSerialLevelsAreAccepted(t *testing.T) {
+	for level, want := range map[string]gocql.Consistency{
+		"SERIAL":       gocql.Serial,
+		"LOCAL_SERIAL": gocql.LocalSerial,
+	} {
+		assert.Contains(t, ConsistencyLevels(), level)
+
+		s := &Session{}
+		require.NoError(t, s.SetConsistency(level))
+		assert.Equal(t, want, s.consistency)
+		assert.Equal(t, level, s.Consistency())
+	}
+}
+
+// TestEveryDriverLevelIsCovered: the driver's own list is the authority on what
+// a consistency level is, so anything it has and this table does not is a level
+// nobody can select.
+func TestEveryDriverLevelIsCovered(t *testing.T) {
+	all := []gocql.Consistency{
+		gocql.Any, gocql.One, gocql.Two, gocql.Three, gocql.Quorum, gocql.All,
+		gocql.LocalQuorum, gocql.EachQuorum, gocql.Serial, gocql.LocalSerial, gocql.LocalOne,
+	}
+
+	require.Len(t, consistencyLevels, len(all))
+	for _, level := range all {
+		s := &Session{consistency: level}
+		assert.NotEqual(t, "UNKNOWN", s.Consistency(), "%v has no name in the table", level)
+	}
+}
+
+func TestUnknownLevelIsRejected(t *testing.T) {
+	err := (&Session{}).SetConsistency("SIDEWAYS")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid consistency level: SIDEWAYS")
+}
+
+// TestChangingTheListDoesNotChangeTheTable: ConsistencyLevels builds a new
+// slice each time, so a caller that sorts or trims what it gets back cannot
+// reach into the table behind it.
+func TestChangingTheListDoesNotChangeTheTable(t *testing.T) {
+	first := ConsistencyLevels()
+	first[0] = "TAMPERED"
+
+	assert.Equal(t, "ANY", ConsistencyLevels()[0])
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -299,61 +299,6 @@ func loadConfig(customConfigPath string) (*config.Config, error) {
 	return conf, nil
 }
 
-// Consistency returns the current consistency level
-func (s *Session) Consistency() string {
-	switch s.consistency {
-	case gocql.Any:
-		return "ANY"
-	case gocql.One:
-		return "ONE"
-	case gocql.Two:
-		return "TWO"
-	case gocql.Three:
-		return "THREE"
-	case gocql.Quorum:
-		return "QUORUM"
-	case gocql.All:
-		return "ALL"
-	case gocql.LocalQuorum:
-		return "LOCAL_QUORUM"
-	case gocql.EachQuorum:
-		return "EACH_QUORUM"
-	case gocql.LocalOne:
-		return "LOCAL_ONE"
-	default:
-		return "UNKNOWN"
-	}
-}
-
-// SetConsistency sets the consistency level
-func (s *Session) SetConsistency(level string) error {
-	var consistency gocql.Consistency
-	switch level {
-	case "ANY":
-		consistency = gocql.Any
-	case "ONE":
-		consistency = gocql.One
-	case "TWO":
-		consistency = gocql.Two
-	case "THREE":
-		consistency = gocql.Three
-	case "QUORUM":
-		consistency = gocql.Quorum
-	case "ALL":
-		consistency = gocql.All
-	case "LOCAL_QUORUM":
-		consistency = gocql.LocalQuorum
-	case "EACH_QUORUM":
-		consistency = gocql.EachQuorum
-	case "LOCAL_ONE":
-		consistency = gocql.LocalOne
-	default:
-		return fmt.Errorf("invalid consistency level: %s", level)
-	}
-	s.consistency = consistency
-	return nil
-}
-
 // PageSize returns the current page size
 func (s *Session) PageSize() int {
 	return s.pageSize

--- a/internal/router/meta_commands.go
+++ b/internal/router/meta_commands.go
@@ -104,7 +104,7 @@ func (h *MetaCommandHandler) handleConsistency(command string) interface{} {
 		return fmt.Sprintf("Consistency level set to %s", level)
 	}
 
-	return "Usage: CONSISTENCY [level]\nValid levels: ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, LOCAL_ONE"
+	return "Usage: CONSISTENCY [level]\nValid levels: " + strings.Join(db.ConsistencyLevels(), ", ")
 }
 
 // handleShow handles SHOW commands

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -318,7 +318,8 @@ func handleOutputCommand(command string, session *db.Session) interface{} {
 		formatStr := parts[1]
 		format, err := config.ParseOutputFormat(formatStr)
 		if err != nil {
-			return fmt.Sprintf("Invalid output format '%s'. Valid formats are: TABLE, ASCII, EXPAND, JSON", formatStr)
+			return fmt.Sprintf("Invalid output format '%s'. Valid formats are: %s",
+				formatStr, strings.Join(config.OutputFormats(), ", "))
 		}
 		if err := sessionManager.SetOutputFormat(format); err != nil {
 			return fmt.Sprintf("Failed to set output format: %v", err)
@@ -326,7 +327,7 @@ func handleOutputCommand(command string, session *db.Session) interface{} {
 		return fmt.Sprintf("Now using %s output format", formatStr)
 	}
 
-	return "Usage: OUTPUT [TABLE|ASCII|EXPAND|JSON]"
+	return "Usage: OUTPUT [" + strings.Join(config.OutputFormats(), "|") + "]"
 }
 
 // IsDangerousCommand checks if a command requires confirmation

--- a/internal/ui/completion/constants.go
+++ b/internal/ui/completion/constants.go
@@ -1,5 +1,7 @@
 package completion
 
+import "github.com/axonops/cqlai/internal/db"
+
 // CQL Keywords and Constants used across completion files
 // This file centralizes all keyword lists to avoid duplication
 
@@ -32,19 +34,10 @@ var LogicalOperators = []string{"AND", "OR"}
 var SortOrders = []string{"ASC", "DESC"}
 
 // Consistency levels
-var ConsistencyLevels = []string{
-	"ALL",
-	"EACH_QUORUM",
-	"QUORUM",
-	"LOCAL_QUORUM",
-	"ONE",
-	"TWO",
-	"THREE",
-	"LOCAL_ONE",
-	"ANY",
-	"SERIAL",
-	"LOCAL_SERIAL",
-}
+// ConsistencyLevels are the levels CONSISTENCY accepts. Completing a level that
+// cannot then be set is worse than not completing it at all, so this comes from
+// the same table that applies them.
+var ConsistencyLevels = db.ConsistencyLevels()
 
 // Data types for CREATE TABLE
 var CQLDataTypes = []string{

--- a/internal/ui/completion/constants_test.go
+++ b/internal/ui/completion/constants_test.go
@@ -1,0 +1,24 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCompletionOffersOnlyLevelsThatCanBeSet: Tab suggested SERIAL and
+// LOCAL_SERIAL while CONSISTENCY rejected them, so accepting the suggestion
+// printed an error. Both completion paths now read the same list as the code
+// that applies a level.
+func TestCompletionOffersOnlyLevelsThatCanBeSet(t *testing.T) {
+	assert.Equal(t, db.ConsistencyLevels(), ConsistencyLevels)
+
+	sce := &SimpleCompletionEngine{}
+	assert.Equal(t, db.ConsistencyLevels(), sce.getConsistencyLevels())
+
+	for _, level := range ConsistencyLevels {
+		assert.NoError(t, (&db.Session{}).SetConsistency(level),
+			"%s is completed but cannot be set", level)
+	}
+}

--- a/internal/ui/completion/simple_parser.go
+++ b/internal/ui/completion/simple_parser.go
@@ -630,8 +630,5 @@ func (sce *SimpleCompletionEngine) getTopLevelKeywords() []string {
 
 // getConsistencyLevels returns valid consistency levels
 func (sce *SimpleCompletionEngine) getConsistencyLevels() []string {
-	return []string{
-		"ALL", "EACH_QUORUM", "QUORUM", "LOCAL_QUORUM", "ONE", "TWO", "THREE",
-		"LOCAL_ONE", "ANY", "SERIAL", "LOCAL_SERIAL",
-	}
+	return ConsistencyLevels
 }

--- a/internal/ui/connection_panel.go
+++ b/internal/ui/connection_panel.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/db"
+)
+
+// The panel behind Connection on the status line.
+//
+// It opens through the same machinery as the settings lists: same anchoring
+// above the field, same geometry, same dismissal. The difference is that its
+// rows are facts rather than values, so nothing is marked as current and
+// clicking a row only closes the panel - settingCommand has nothing to return
+// for Connection, so applySettingChoice does nothing else.
+
+// connectionRows lays the connection facts out as one row per fact, with the
+// values lined up.
+func connectionRows(info db.ConnectionInfo) []string {
+	type row struct{ label, value string }
+
+	rows := []row{
+		{"Cassandra", info.Version},
+		{"Protocol", protocolVersion(info.Protocol)},
+		{"User", info.Username},
+		{"Host", info.Host},
+		{"Encryption", encryptionSummary(info)},
+	}
+
+	width := 0
+	for _, r := range rows {
+		if w := lipgloss.Width(r.label); w > width {
+			width = w
+		}
+	}
+
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		value := r.value
+		if value == "" {
+			value = "unknown"
+		}
+		out = append(out, r.label+strings.Repeat(" ", width-lipgloss.Width(r.label)+2)+value)
+	}
+	return out
+}
+
+// protocolVersion renders the native protocol version the way the servers and
+// cqlsh both write it.
+func protocolVersion(v int) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("v%d", v)
+}
+
+// encryptionSummary says whether the connection is encrypted and what is
+// actually being checked.
+//
+// "TLS" on its own is not the useful fact. A connection with certificate
+// verification turned off is encrypted and still wide open to anything sitting
+// in the middle of it, so that is said plainly rather than left to be inferred
+// from the absence of a note.
+func encryptionSummary(info db.ConnectionInfo) string {
+	if !info.Encrypted {
+		return "none"
+	}
+
+	parts := []string{"TLS"}
+	if info.HostVerified {
+		parts = append(parts, "certificate verified")
+	} else {
+		parts = append(parts, "certificate NOT verified")
+	}
+	if info.CustomCA {
+		parts = append(parts, "own CA")
+	}
+	if info.ClientCertificate {
+		parts = append(parts, "client certificate")
+	}
+	return strings.Join(parts, ", ")
+}
+
+// openConnectionPanel shows the connection facts above the status line.
+func (m *MainModel) openConnectionPanel(anchorX int) {
+	if m.session == nil {
+		return
+	}
+	// No current value: these are facts, so nothing in the panel is marked and
+	// nothing can be applied.
+	m.openSettingChooser(settingConnection, anchorX, connectionRows(m.session.ConnectionInfo()), "")
+}

--- a/internal/ui/connection_panel_test.go
+++ b/internal/ui/connection_panel_test.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionRowsShowEveryFact(t *testing.T) {
+	rows := connectionRows(db.ConnectionInfo{
+		Version:  "5.0.9",
+		Protocol: 5,
+		Username: "cassandra",
+		Host:     "10.0.0.4:9042",
+	})
+
+	joined := strings.Join(rows, "\n")
+	for _, want := range []string{"Cassandra", "5.0.9", "Protocol", "v5", "User", "cassandra", "Host", "10.0.0.4:9042", "Encryption"} {
+		assert.Contains(t, joined, want)
+	}
+}
+
+// TestConnectionRowsLineUp: the values are in a column, so the panel reads as a
+// table rather than as ragged text.
+func TestConnectionRowsLineUp(t *testing.T) {
+	rows := connectionRows(db.ConnectionInfo{Version: "5.0.9", Protocol: 5, Username: "u", Host: "h"})
+
+	// The value starts after the run of spaces that follows the label.
+	var at []int
+	for _, row := range rows {
+		i := strings.Index(row, "  ")
+		for i < len(row) && row[i] == ' ' {
+			i++
+		}
+		at = append(at, i)
+	}
+	for i := range at {
+		assert.Equal(t, at[0], at[i], "row %d starts its value in a different column: %q", i, rows[i])
+	}
+}
+
+// TestUnencryptedSaysSo rather than leaving the row blank, which reads as a
+// missing fact instead of an answer.
+func TestUnencryptedSaysSo(t *testing.T) {
+	assert.Equal(t, "none", encryptionSummary(db.ConnectionInfo{}))
+}
+
+// TestUnverifiedEncryptionIsCalledOut is the point of showing this at all. TLS
+// with certificate checking turned off is encrypted and still open to anything
+// in the middle of the connection, so the panel has to say which it is.
+func TestUnverifiedEncryptionIsCalledOut(t *testing.T) {
+	verified := encryptionSummary(db.ConnectionInfo{Encrypted: true, HostVerified: true})
+	assert.Contains(t, verified, "TLS")
+	assert.Contains(t, verified, "certificate verified")
+	assert.NotContains(t, verified, "NOT")
+
+	unverified := encryptionSummary(db.ConnectionInfo{Encrypted: true})
+	assert.Contains(t, unverified, "NOT verified")
+}
+
+func TestEncryptionExtrasAreListed(t *testing.T) {
+	summary := encryptionSummary(db.ConnectionInfo{
+		Encrypted:         true,
+		HostVerified:      true,
+		CustomCA:          true,
+		ClientCertificate: true,
+	})
+
+	assert.Contains(t, summary, "own CA")
+	assert.Contains(t, summary, "client certificate")
+}
+
+// TestMissingFactsSayUnknown: an empty value would leave a row that looks
+// truncated.
+func TestMissingFactsSayUnknown(t *testing.T) {
+	rows := connectionRows(db.ConnectionInfo{})
+
+	for _, row := range rows {
+		assert.NotRegexp(t, `\s+$`, row, "row has no value at all: %q", row)
+	}
+	assert.Contains(t, strings.Join(rows, "\n"), "unknown")
+}
+
+// TestConnectionIsClickable: it replaced three fields that were not, so the
+// facts they carried have to be reachable.
+func TestConnectionIsClickable(t *testing.T) {
+	m := testStatusBar()
+
+	var found bool
+	for _, seg := range m.segments() {
+		if seg.setting == settingConnection {
+			found = true
+			setting, _, ok := m.settingAt((seg.start + seg.end) / 2)
+			require.True(t, ok)
+			assert.Equal(t, settingConnection, setting)
+		}
+		assert.NotEqual(t, "User: ", seg.label, "the user moved into the panel")
+		assert.NotEqual(t, "Host: ", seg.label, "the host moved into the panel")
+		assert.NotEqual(t, "v", seg.label, "the version moved into the panel")
+	}
+	require.True(t, found, "there is no Connection field on the status line")
+}
+
+// TestConnectionPanelPicksNothing: its rows are facts, so clicking one closes
+// the panel and changes nothing.
+func TestConnectionPanelPicksNothing(t *testing.T) {
+	assert.Equal(t, "", settingCommand(settingConnection, "Cassandra   5.0.9"))
+}
+
+// TestConnectionPanelNeedsASession: with nothing connected there is nothing to
+// report, and an empty box would be worse than none.
+func TestConnectionPanelNeedsASession(t *testing.T) {
+	m := chooserModel()
+	m.openConnectionPanel(4)
+
+	assert.False(t, m.chooser.active)
+}

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -38,6 +38,18 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 		return m.endSelection()
 
 	case tea.MouseWheelMsg:
+		// While the list is open the wheel belongs to it rather than to the
+		// view behind it, or the choices past the first screenful cannot be
+		// reached at all.
+		if m.chooser.active {
+			switch mouse.Button {
+			case tea.MouseWheelUp:
+				return m.scrollChooser(-chooserScrollStep)
+			case tea.MouseWheelDown:
+				return m.scrollChooser(chooserScrollStep)
+			}
+			return m, nil
+		}
 		return m.handleMouseWheel(mouse)
 	}
 
@@ -55,10 +67,12 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 		if choice, inside := m.choiceAt(m.windowWidth, m.windowHeight, mouse.X, mouse.Y); inside {
 			return m.applySettingChoice(choice)
 		}
-		// Anywhere else closes it. Clicking the status line again may then
-		// open a different one, which is what the switch below decides.
-		m.closeSettingChooser()
-		if mouse.Y != m.windowHeight-1 && mouse.Y != 0 {
+		// Anywhere else dismisses it, except on the tabs and the status line,
+		// which still act on the click. The status line is left to close the
+		// list itself, because it has to see which field the list belongs to
+		// before it can tell a close from a reopen.
+		if mouse.Y != 0 && mouse.Y != m.windowHeight-1 {
+			m.closeSettingChooser()
 			return m, nil
 		}
 	}
@@ -67,6 +81,7 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 	// between them is content, and a press there starts a selection.
 	switch mouse.Y {
 	case 0:
+		m.closeSettingChooser()
 		return m.clickTab(mouse.X)
 	case m.windowHeight - 1:
 		return m.clickStatusSetting(mouse.X)
@@ -344,10 +359,29 @@ func (m *MainModel) clickTab(col int) (*MainModel, tea.Cmd) {
 	return m, nil
 }
 
-// clickStatusSetting opens the list of values for a setting on the status line.
+// clickStatusSetting opens the list of values for a setting on the status line,
+// or closes the one already open.
 func (m *MainModel) clickStatusSetting(col int) (*MainModel, tea.Cmd) {
+	wasOpen, openSetting := m.chooser.active, m.chooser.setting
+	m.closeSettingChooser()
+
 	setting, anchorX, ok := m.statusBar.settingAt(col)
 	if !ok {
+		return m, nil
+	}
+
+	// Clicking the field whose list is already open closes it. Without this the
+	// press closed the list and reopened it in the same breath, so the list
+	// never appeared to go away and the only way to dismiss it was to click
+	// somewhere else entirely.
+	if wasOpen && openSetting == setting {
+		return m, nil
+	}
+
+	// Connection is not a setting: it opens a panel of facts about how we are
+	// connected, with nothing to pick.
+	if setting == settingConnection {
+		m.openConnectionPanel(anchorX)
 		return m, nil
 	}
 

--- a/internal/ui/setting_chooser.go
+++ b/internal/ui/setting_chooser.go
@@ -21,14 +21,16 @@ type settingChooser struct {
 	setting  string // which status field this belongs to
 	label    string // shown above the list, e.g. "CL"
 	choices  []string
-	selected int    // only used to centre the scroll window on the current value
+	selected int    // the value already set, which the list opens centred on
 	current  string // marked in the list
 	anchorX  int    // column the field starts at
-}
 
-// chooserMaxHeight caps the list so it cannot cover the whole screen. Anything
-// longer scrolls.
-const chooserMaxHeight = 10
+	// Where the visible window starts, once the wheel has moved it. Until then
+	// window() centres on selected instead, so a long list opens showing where
+	// you already are rather than its alphabetical start.
+	scroll   int
+	scrolled bool
+}
 
 // openSettingChooser opens the list for a status field.
 func (m *MainModel) openSettingChooser(setting string, anchorX int, choices []string, current string) {
@@ -54,28 +56,81 @@ func (m *MainModel) openSettingChooser(setting string, anchorX int, choices []st
 	}
 }
 
+const (
+	// chooserMinHeight keeps the list usable on a terminal too short for half
+	// of it to be worth having.
+	chooserMinHeight = 5
+
+	// chooserScrollStep is how far one wheel notch moves the list. The same as
+	// the viewports scroll by, so the wheel feels the same wherever it is.
+	chooserScrollStep = 3
+)
+
 // closeSettingChooser dismisses the list without changing anything.
 func (m *MainModel) closeSettingChooser() {
 	m.chooser = settingChooser{}
 }
 
-// chooserWindow returns the slice of choices to draw, and where the selection
-// sits within it, so a list longer than the space available scrolls.
+// window returns the slice of choices to draw, so a list longer than there is
+// room for scrolls rather than losing its tail.
 func (c settingChooser) window(height int) (start, end int) {
 	if height <= 0 || height >= len(c.choices) {
 		return 0, len(c.choices)
 	}
 
-	// Keep the current value in view, roughly centred, so a long list opens
-	// showing where you already are.
-	start = c.selected - height/2
-	if start < 0 {
-		start = 0
+	start = c.scroll
+	if !c.scrolled {
+		// Roughly centred on the value already set.
+		start = c.selected - height/2
 	}
-	if start+height > len(c.choices) {
-		start = len(c.choices) - height
-	}
+	start = min(max(start, 0), len(c.choices)-height)
 	return start, start + height
+}
+
+// scrollChooser moves the open list by n rows.
+//
+// Without this the wheel went to the view behind the list, so on a cluster with
+// more keyspaces than the box has rows the rest of them could not be reached at
+// all: there is no keyboard navigation here by design, and nothing else moved
+// the window.
+func (m *MainModel) scrollChooser(n int) (*MainModel, tea.Cmd) {
+	g, ok := m.chooserGeometry(m.windowWidth, m.windowHeight)
+	if !ok {
+		return m, nil
+	}
+
+	// g.first is where the window sits now, so this moves from wherever the
+	// list happened to open. window() does the clamping.
+	m.chooser.scroll = g.first + n
+	m.chooser.scrolled = true
+	return m, nil
+}
+
+// scrollbarColumn returns one entry per visible row, true where the thumb is.
+//
+// The thumb's size says how much of the list is showing and its position says
+// where in the list you are, which is the thing a long keyspace list needs and
+// a plain box cannot tell you. It is empty when the whole list fits, since a
+// bar that is always full says nothing.
+func scrollbarColumn(rows, first, total int) []bool {
+	thumb := make([]bool, max(rows, 0))
+	if rows <= 0 || total <= rows {
+		return thumb
+	}
+
+	size := max(rows*rows/total, 1)
+
+	// Scaled so the thumb reaches the bottom exactly when the last choice is
+	// showing, rather than stopping a row short.
+	start := 0
+	if lastFirst := total - rows; lastFirst > 0 {
+		start = first * (rows - size) / lastFirst
+	}
+
+	for i := start; i < start+size && i < rows; i++ {
+		thumb[i] = true
+	}
+	return thumb
 }
 
 // chooserGeometry works out where the list sits and which choices it shows.
@@ -96,8 +151,14 @@ func (m *MainModel) chooserGeometry(screenWidth, screenHeight int) (chooserGeome
 	}
 
 	// Rows above the status line, less the box's own border.
+	//
+	// Half of that, at most. A fixed cap was wrong in both directions: ten rows
+	// wasted a tall terminal, and no cap at all let a long keyspace list cover
+	// everything but the status line. Half leaves you able to see what is
+	// behind the list whatever size the terminal is, and short lists still take
+	// only the rows they need.
 	available := screenHeight - 1 - 2
-	rows := min(len(c.choices), min(chooserMaxHeight, available))
+	rows := min(len(c.choices), min(max(available/2, chooserMinHeight), available))
 	if rows <= 0 {
 		return chooserGeometry{}, false
 	}
@@ -110,8 +171,8 @@ func (m *MainModel) chooserGeometry(screenWidth, screenHeight int) (chooserGeome
 			inner = w
 		}
 	}
-	// A leading space, a gap, and the current-value marker.
-	inner += 3
+	// A leading space, a gap, the current-value marker, and the scrollbar.
+	inner += 4
 
 	// A keyspace name can be long enough to push the box off the screen, so the
 	// box is capped and the names inside it are truncated to fit.
@@ -181,6 +242,13 @@ func (m *MainModel) viewSettingChooser(screenWidth, screenHeight int) (Layer, bo
 		Foreground(lipgloss.Color("#87FFD7")).
 		Bold(true)
 
+	thumbStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#87D7FF"))
+	trackStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#3a3a3a"))
+
+	thumb := scrollbarColumn(g.last-g.first, g.first, len(c.choices))
+
 	var b strings.Builder
 	for i := g.first; i < g.last; i++ {
 		choice := c.choices[i]
@@ -193,13 +261,22 @@ func (m *MainModel) viewSettingChooser(screenWidth, screenHeight int) (Layer, bo
 		}
 
 		// Exactly innerWidth columns: a leading space, the name padded out,
-		// then the marker. Anything else and the box's borders do not line up
-		// with the width chooserGeometry reports, which is what choiceAt tests
-		// clicks against.
-		text := ansi.Truncate(choice, max(g.innerWidth-2, 0), "…")
-		fill := max(g.innerWidth-lipgloss.Width(text)-2, 0)
-		line := " " + text + strings.Repeat(" ", fill) + marker
-		b.WriteString(style.Render(line))
+		// the marker, then the scrollbar. Anything else and the box's borders
+		// do not line up with the width chooserGeometry reports, which is what
+		// choiceAt tests clicks against.
+		text := ansi.Truncate(choice, max(g.innerWidth-3, 0), "…")
+		fill := max(g.innerWidth-lipgloss.Width(text)-3, 0)
+		b.WriteString(style.Render(" " + text + strings.Repeat(" ", fill) + marker))
+
+		switch {
+		case len(thumb) == 0 || len(c.choices) <= g.last-g.first:
+			b.WriteString(" ")
+		case thumb[i-g.first]:
+			b.WriteString(thumbStyle.Render("\u2588"))
+		default:
+			b.WriteString(trackStyle.Render("\u2591"))
+		}
+
 		if i < g.last-1 {
 			b.WriteString("\n")
 		}
@@ -289,6 +366,8 @@ func settingCommand(setting, choice string) string {
 		return "CONSISTENCY " + choice
 	case settingPaging:
 		return "PAGING " + choice
+	case settingOutput:
+		return "OUTPUT " + choice
 	case settingTracing:
 		return "TRACING " + choice
 	case settingAutoFetch:

--- a/internal/ui/setting_chooser_test.go
+++ b/internal/ui/setting_chooser_test.go
@@ -1,11 +1,14 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,16 +43,13 @@ func TestClickingASettingOpensItsChoices(t *testing.T) {
 		"the list should open on the value already set")
 }
 
-func TestClickingAConnectionFactOpensNothing(t *testing.T) {
+func TestClickingPastTheEndOfTheLineOpensNothing(t *testing.T) {
 	m := chooserModel()
 
-	for _, seg := range m.statusBar.segments() {
-		if seg.clickable() {
-			continue
-		}
-		m.clickStatusSetting((seg.start + seg.end) / 2)
-		assert.False(t, m.chooser.active, "%q is not a setting", seg.label)
-	}
+	last := m.statusBar.segments()[len(m.statusBar.segments())-1]
+	m.clickStatusSetting(last.end + 4)
+
+	assert.False(t, m.chooser.active, "there is no field out there")
 }
 
 // TestChooserDismissedByAnyKey: there is no keyboard navigation, so a keypress
@@ -316,5 +316,264 @@ func TestClickingKSWithNoConnectionOpensNothing(t *testing.T) {
 		}
 	}
 
+	assert.False(t, m.chooser.active)
+}
+
+// TestConsistencyChoicesComeFromTheSessionsOwnList: the chooser must not carry
+// its own set of levels, or it drifts from the one CONSISTENCY applies. That
+// drift is what made picking SERIAL print an error rather than change
+// anything.
+func TestConsistencyChoicesComeFromTheSessionsOwnList(t *testing.T) {
+	choices, _ := settingChoices(settingConsistency, "ONE")
+	assert.Equal(t, db.ConsistencyLevels(), choices)
+}
+
+// chooserWithChoices opens a list of n numbered choices on a screen of the
+// given height, which is how a long keyspace list is reproduced.
+func chooserWithChoices(n, screenHeight int) (*MainModel, []string) {
+	choices := make([]string, n)
+	for i := range choices {
+		choices[i] = fmt.Sprintf("keyspace_%02d", i)
+	}
+
+	m := chooserModel()
+	m.windowHeight = screenHeight
+	m.openSettingChooser(settingKeyspace, 4, choices, choices[0])
+	return m, choices
+}
+
+// TestEveryChoiceIsReachableByScrolling is the bug: a cluster with more
+// keyspaces than the box had rows showed the first few and no way to the rest.
+// There is no keyboard navigation here by design, so the wheel is the only way
+// the window can move.
+func TestEveryChoiceIsReachableByScrolling(t *testing.T) {
+	const screenHeight = 20
+	m, choices := chooserWithChoices(40, screenHeight)
+
+	seen := map[string]bool{}
+	record := func() {
+		g, ok := m.chooserGeometry(m.windowWidth, screenHeight)
+		require.True(t, ok)
+		for i := g.first; i < g.last; i++ {
+			seen[choices[i]] = true
+		}
+	}
+
+	record()
+	require.Less(t, len(seen), len(choices), "the list should not fit, or this proves nothing")
+
+	// Wheel to the bottom, then back to the top.
+	for range len(choices) {
+		m.scrollChooser(chooserScrollStep)
+		record()
+	}
+	for range len(choices) {
+		m.scrollChooser(-chooserScrollStep)
+		record()
+	}
+
+	for _, choice := range choices {
+		assert.True(t, seen[choice], "%s could never be scrolled to", choice)
+	}
+}
+
+// TestScrollingStopsAtTheEnds: the wheel must not run the window off either
+// end and leave the box empty or short.
+func TestScrollingStopsAtTheEnds(t *testing.T) {
+	const screenHeight = 20
+	m, choices := chooserWithChoices(40, screenHeight)
+
+	for range 200 {
+		m.scrollChooser(chooserScrollStep)
+	}
+	g, ok := m.chooserGeometry(m.windowWidth, screenHeight)
+	require.True(t, ok)
+	assert.Equal(t, len(choices), g.last, "scrolling down should stop with the last choice showing")
+	assert.Equal(t, g.height-2, g.last-g.first, "the box should still be full")
+
+	for range 200 {
+		m.scrollChooser(-chooserScrollStep)
+	}
+	g, _ = m.chooserGeometry(m.windowWidth, screenHeight)
+	assert.Equal(t, 0, g.first, "scrolling up should stop at the first choice")
+	assert.Equal(t, g.height-2, g.last-g.first)
+}
+
+// TestTheListUsesTheRoomAvailable: it used to be capped at ten rows however
+// tall the terminal was.
+func TestTheListUsesTheRoomAvailable(t *testing.T) {
+	short, _ := chooserWithChoices(40, 14)
+	tall, _ := chooserWithChoices(40, 40)
+
+	sg, ok := short.chooserGeometry(short.windowWidth, 14)
+	require.True(t, ok)
+	tg, ok := tall.chooserGeometry(tall.windowWidth, 40)
+	require.True(t, ok)
+
+	assert.Greater(t, tg.height, sg.height, "a taller terminal should show more choices")
+	assert.Greater(t, tg.last-tg.first, 10, "the ten row cap is gone")
+}
+
+// TestShortListsStayShort: only the long ones grow. A box covering the screen
+// to offer ON and OFF would be absurd.
+func TestShortListsStayShort(t *testing.T) {
+	m := chooserModel()
+	m.windowHeight = 40
+	m.openSettingChooser(settingTracing, 10, []string{"ON", "OFF"}, "OFF")
+
+	g, ok := m.chooserGeometry(m.windowWidth, 40)
+	require.True(t, ok)
+	assert.Equal(t, 2+2, g.height, "two choices and two borders")
+}
+
+// TestTheScrollbarSaysWhereYouAre: without it, a box holding ten of your
+// thirty keyspaces looks exactly like one holding all of them, and there is no
+// way to tell how far down the list you have got.
+func TestTheScrollbarSaysWhereYouAre(t *testing.T) {
+	const screenHeight = 24
+	m, _ := chooserWithChoices(40, screenHeight)
+
+	// The scrollbar is the last column inside the box.
+	bar := func() string {
+		layer, ok := m.viewSettingChooser(m.windowWidth, screenHeight)
+		require.True(t, ok)
+
+		var col []rune
+		for _, row := range strings.Split(stripAnsiForTest(layer.Content), "\n")[1:] {
+			runes := []rune(row)
+			if len(runes) < 2 {
+				continue
+			}
+			col = append(col, runes[len(runes)-2])
+		}
+		return string(col[:len(col)-1]) // drop the bottom border
+	}
+
+	atTop := bar()
+	assert.Equal(t, '\u2588', []rune(atTop)[0], "the thumb should start at the top: %q", atTop)
+	assert.Contains(t, atTop, "\u2591", "and there should be track below it")
+
+	for range 200 {
+		m.scrollChooser(chooserScrollStep)
+	}
+	atBottom := bar()
+	assert.Equal(t, '\u2588', []rune(atBottom)[len([]rune(atBottom))-1],
+		"scrolled to the end, the thumb should reach the bottom: %q", atBottom)
+	assert.Equal(t, '\u2591', []rune(atBottom)[0], "and there should be track above it")
+}
+
+// TestNoScrollbarWhenTheListFits: a bar that is always full says nothing.
+func TestNoScrollbarWhenTheListFits(t *testing.T) {
+	m := chooserModel()
+	m.windowHeight = 24
+	m.openSettingChooser(settingTracing, 10, []string{"ON", "OFF"}, "OFF")
+
+	layer, ok := m.viewSettingChooser(m.windowWidth, 24)
+	require.True(t, ok)
+
+	plain := stripAnsiForTest(layer.Content)
+	assert.NotContains(t, plain, "\u2588")
+	assert.NotContains(t, plain, "\u2591")
+}
+
+// TestTheThumbGrowsWithTheProportionShowing.
+func TestTheThumbGrowsWithTheProportionShowing(t *testing.T) {
+	count := func(thumb []bool) int {
+		n := 0
+		for _, t := range thumb {
+			if t {
+				n++
+			}
+		}
+		return n
+	}
+
+	assert.Equal(t, 0, count(scrollbarColumn(10, 0, 10)), "a list that fits has no thumb")
+	assert.Greater(t, count(scrollbarColumn(10, 0, 20)), count(scrollbarColumn(10, 0, 200)),
+		"showing half the list should give a bigger thumb than showing a twentieth")
+	assert.GreaterOrEqual(t, count(scrollbarColumn(10, 0, 1000)), 1,
+		"a huge list still needs a thumb you can see")
+}
+
+// TestTheWheelScrollsTheListNotTheViewBehindIt.
+func TestTheWheelScrollsTheListNotTheViewBehindIt(t *testing.T) {
+	const screenHeight = 20
+	m, _ := chooserWithChoices(40, screenHeight)
+	m.historyViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(10))
+	m.historyViewport.SetContent(strings.Repeat("line\n", 100))
+	m.viewMode = "history"
+
+	before := m.historyViewport.YOffset()
+	m.handleMouseInput(tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 5, Y: 5})
+
+	g, ok := m.chooserGeometry(m.windowWidth, screenHeight)
+	require.True(t, ok)
+	assert.Equal(t, chooserScrollStep, g.first, "the wheel should have moved the list")
+	assert.Equal(t, before, m.historyViewport.YOffset(), "the view behind must not have moved")
+}
+
+// settingColumn is the middle of a setting's field on the status line.
+func settingColumn(m *MainModel, setting string) int {
+	for _, seg := range m.statusBar.segments() {
+		if seg.setting == setting {
+			return (seg.start + seg.end) / 2
+		}
+	}
+	return -1
+}
+
+// pressAt delivers a left button press, the way the terminal does.
+func pressAt(m *MainModel, col, row int) {
+	m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseLeft, X: col, Y: row})
+}
+
+// TestClickingTheSameSettingClosesItsList is the bug: the press closed the list
+// and reopened it in the same breath, so it never appeared to go away and you
+// had to click somewhere else to be rid of it.
+func TestClickingTheSameSettingClosesItsList(t *testing.T) {
+	m := chooserModel()
+	col := settingColumn(m, settingConsistency)
+	require.Positive(t, col)
+
+	pressAt(m, col, m.windowHeight-1)
+	require.True(t, m.chooser.active, "the first click should open the list")
+
+	pressAt(m, col, m.windowHeight-1)
+	assert.False(t, m.chooser.active, "clicking the same setting again should close it")
+}
+
+// TestClickingAnotherSettingSwitchesLists.
+func TestClickingAnotherSettingSwitchesLists(t *testing.T) {
+	m := chooserModel()
+
+	pressAt(m, settingColumn(m, settingConsistency), m.windowHeight-1)
+	require.Equal(t, settingConsistency, m.chooser.setting)
+
+	pressAt(m, settingColumn(m, settingTracing), m.windowHeight-1)
+	assert.True(t, m.chooser.active, "clicking a different setting should open that one")
+	assert.Equal(t, settingTracing, m.chooser.setting)
+}
+
+// TestClickingEmptyStatusLineClosesTheList: a click on the bar but not on a
+// field dismisses whatever was open.
+func TestClickingEmptyStatusLineClosesTheList(t *testing.T) {
+	m := chooserModel()
+	pressAt(m, settingColumn(m, settingConsistency), m.windowHeight-1)
+	require.True(t, m.chooser.active)
+
+	segs := m.statusBar.segments()
+	pressAt(m, segs[len(segs)-1].end+4, m.windowHeight-1)
+
+	assert.False(t, m.chooser.active)
+}
+
+// TestClickingTheTabsClosesTheList.
+func TestClickingTheTabsClosesTheList(t *testing.T) {
+	m := chooserModel()
+	m.viewMode = "history"
+	pressAt(m, settingColumn(m, settingConsistency), m.windowHeight-1)
+	require.True(t, m.chooser.active)
+
+	pressAt(m, 2, 0)
 	assert.False(t, m.chooser.active)
 }

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -54,6 +54,9 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 	pageStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#87FFD7"))
 
+	outputStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#87D7FF"))
+
 	tracingOnStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FF5F5F")).
 		Bold(true)
@@ -72,6 +75,8 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 			return keyspaceStyle
 		case settingConsistency:
 			return consistencyStyle
+		case settingOutput:
+			return outputStyle
 		case settingPaging:
 			return pageStyle
 		case settingTracing, settingAutoFetch:
@@ -79,9 +84,6 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 				return tracingOnStyle
 			}
 			return tracingOffStyle
-		}
-		if seg.label == "v" {
-			return lipgloss.NewStyle().Foreground(lipgloss.Color("#B8B8B8"))
 		}
 		return hostStyle
 	}

--- a/internal/ui/statusbar_fields.go
+++ b/internal/ui/statusbar_fields.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/axonops/cqlai/internal/db"
 )
 
 // Clickable settings on the status line.
@@ -15,8 +17,10 @@ import (
 
 // Setting keys, used to tie a click to what it changes.
 const (
+	settingConnection  = "Connection"
 	settingKeyspace    = "KS"
 	settingConsistency = "CL"
+	settingOutput      = "Output"
 	settingPaging      = "Pg"
 	settingTracing     = "Trace"
 	settingAutoFetch   = "Fetch"
@@ -24,8 +28,8 @@ const (
 
 // statusSegment is one "Label: value" pair on the status line.
 //
-// A segment with an empty setting is information rather than a control - the
-// server version, the user, the host - and ignores clicks.
+// A segment with an empty setting is information rather than a control and
+// ignores clicks.
 type statusSegment struct {
 	setting    string // one of the setting constants, or "" if not clickable
 	label      string
@@ -51,11 +55,6 @@ func (m StatusBarModel) segments() []statusSegment {
 		keyspace = "(none)"
 	}
 
-	username := m.Username
-	if username == "" {
-		username = "(anonymous)"
-	}
-
 	onOff := func(b bool) string {
 		if b {
 			return "ON"
@@ -63,19 +62,18 @@ func (m StatusBarModel) segments() []statusSegment {
 		return "OFF"
 	}
 
-	var segs []statusSegment
-	if m.Version != "" {
-		segs = append(segs, statusSegment{label: "v", value: m.Version})
+	// The version, the user and the host were three fields taking a third of
+	// the line to say things that rarely change. They are one field now, and
+	// clicking it opens the lot, encryption included.
+	segs := []statusSegment{
+		{setting: settingConnection, label: "Connection", value: ""},
+		{setting: settingKeyspace, label: "KS: ", value: keyspace},
+		{setting: settingConsistency, label: "CL: ", value: m.Consistency},
+		{setting: settingOutput, label: "Output: ", value: m.OutputFormat},
+		{setting: settingPaging, label: "Pg: ", value: fmt.Sprintf("%d", m.PagingSize)},
+		{setting: settingTracing, label: "Trace: ", value: onOff(m.Tracing)},
+		{setting: settingAutoFetch, label: "Fetch: ", value: onOff(m.AutoFetch)},
 	}
-	segs = append(segs,
-		statusSegment{label: "User: ", value: username},
-		statusSegment{label: "Host: ", value: m.Host},
-		statusSegment{setting: settingKeyspace, label: "KS: ", value: keyspace},
-		statusSegment{setting: settingConsistency, label: "CL: ", value: m.Consistency},
-		statusSegment{setting: settingPaging, label: "Pg: ", value: fmt.Sprintf("%d", m.PagingSize)},
-		statusSegment{setting: settingTracing, label: "Trace: ", value: onOff(m.Tracing)},
-		statusSegment{setting: settingAutoFetch, label: "Fetch: ", value: onOff(m.AutoFetch)},
-	)
 
 	// Columns, not bytes. The separator is three columns wide but five bytes,
 	// because of the box-drawing character, and lipgloss.Width also gets
@@ -109,14 +107,18 @@ func (m StatusBarModel) settingAt(col int) (setting string, at int, ok bool) {
 // settingChoices lists the values a setting can take, and which is current.
 //
 // Keyspaces are not here: they come from the cluster, so the caller supplies
-// them.
+// them. Neither is Connection, which is not a setting at all - it opens a panel
+// of facts rather than a list of values.
 func settingChoices(setting string, current string) (choices []string, selected int) {
 	switch setting {
 	case settingConsistency:
-		choices = []string{
-			"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL",
-			"LOCAL_QUORUM", "EACH_QUORUM", "LOCAL_ONE", "SERIAL", "LOCAL_SERIAL",
-		}
+		// From the same table CONSISTENCY applies, so the list cannot offer a
+		// level that then fails to set.
+		choices = db.ConsistencyLevels()
+	case settingOutput:
+		// From config, which is where ParseOutputFormat reads them, so the list
+		// cannot offer a format OUTPUT then refuses.
+		choices = config.OutputFormats()
 	case settingPaging:
 		// The values PAGING accepts, plus OFF, which is how it is turned off.
 		choices = []string{"OFF", "50", "100", "500", "1000", "5000"}

--- a/internal/ui/statusbar_fields_test.go
+++ b/internal/ui/statusbar_fields_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,4 +134,59 @@ func TestSettingChoicesUnknownSetting(t *testing.T) {
 	// Keyspaces come from the cluster, so they are not baked in here.
 	choices, _ = settingChoices(settingKeyspace, "system")
 	assert.Nil(t, choices)
+}
+
+// TestOutputFormatIsOnTheLineAndClickable: OUTPUT changes what every result
+// looks like, so it belongs next to the other session settings rather than
+// only being reachable by typing it.
+func TestOutputFormatIsOnTheLineAndClickable(t *testing.T) {
+	m := testStatusBar()
+	m.OutputFormat = "ASCII"
+
+	var seg statusSegment
+	var found bool
+	for _, s := range m.segments() {
+		if s.setting == settingOutput {
+			seg, found = s, true
+		}
+	}
+	require.True(t, found, "there is no Output field on the status line")
+	assert.Equal(t, "ASCII", seg.value)
+
+	setting, _, ok := m.settingAt((seg.start + seg.end) / 2)
+	require.True(t, ok)
+	assert.Equal(t, settingOutput, setting)
+}
+
+// TestOutputSitsAfterConsistency, where it was asked for.
+func TestOutputSitsAfterConsistency(t *testing.T) {
+	order := []string{}
+	for _, s := range testStatusBar().segments() {
+		order = append(order, s.setting)
+	}
+
+	cl := slices.Index(order, settingConsistency)
+	out := slices.Index(order, settingOutput)
+	require.NotEqual(t, -1, cl)
+	require.Equal(t, cl+1, out, "Output should follow CL: %v", order)
+}
+
+// TestOutputChoicesComeFromConfig: the formats are decided by
+// ParseOutputFormat, so the list must not carry its own copy of them.
+func TestOutputChoicesComeFromConfig(t *testing.T) {
+	choices, _ := settingChoices(settingOutput, "TABLE")
+	assert.Equal(t, config.OutputFormats(), choices)
+}
+
+// TestEveryOfferedFormatCanBeSet is the guard the consistency levels went
+// without.
+func TestEveryOfferedFormatCanBeSet(t *testing.T) {
+	choices, _ := settingChoices(settingOutput, "TABLE")
+	require.NotEmpty(t, choices)
+
+	for _, choice := range choices {
+		_, err := config.ParseOutputFormat(choice)
+		assert.NoError(t, err, "%s is offered but OUTPUT will not take it", choice)
+		assert.Equal(t, "OUTPUT "+choice, settingCommand(settingOutput, choice))
+	}
 }


### PR DESCRIPTION
Six changes, all in the bottom line and the panels it opens.

## SERIAL and LOCAL_SERIAL are accepted

Both were on the `CL` list and suggested by Tab, and neither could be set:

```
> CONSISTENCY SERIAL
Error setting consistency: invalid consistency level: SERIAL
```

cqlsh takes them, and so should we. They are consistency levels like the rest - the driver has them as ordinary `Consistency` values, `0x08` and `0x09`, alongside `QUORUM`. A read at `SERIAL` goes through Paxos and sees a lightweight transaction that is still in flight, which is the point of having them.

## One list, not five

That bug was possible because there were five hand-written copies of the levels and only one of them decided anything - the status line, two completion paths, the "Valid levels:" message, and `SetConsistency`. Three listed eleven; `SetConsistency` knew nine.

There is now one table in `internal/db/consistency.go` holding each level's name and its driver value. `SetConsistency` and `Consistency` read it in either direction, which also removes the second switch that mapped values back to names, and everything offering a choice reads `ConsistencyLevels`.

The output formats had the same shape - four copies - and now come from `config.OutputFormats()`, which is what `ParseOutputFormat` matches on.

## Clicking an open setting closes it

It used to close the list and reopen it in the same press, so the list never appeared to go away and the only way to dismiss it was to click somewhere else entirely. `clickStatusSetting` owns the closing now, so it can see which field the open list belonged to before deciding.

## The keyspace list shows every keyspace

It was capped at ten rows however tall the terminal was, the wheel went to the view behind it rather than to the list, and there is deliberately no keyboard navigation here - so on a cluster with more than ten keyspaces the rest could not be reached at all.

The box now takes up to half the height above the status line, the wheel scrolls it three rows at a time as the viewports do, and a scrollbar down the right edge says how much is showing and where you are:

```
╭───────────────╮
│ keyspace_09  ░│
│ keyspace_10  ░│
│ keyspace_11  █│
│ keyspace_12  █│
│ keyspace_13  ░│
│ keyspace_14  ░│
╰───────────────╯
```

Half the height rather than all of it: a fixed cap was wrong in both directions - ten rows wasted a tall terminal, and no cap at all let a long list cover everything but the status line itself.

## Version, user and host become one Connection field

Three fields took a third of the line to say things that rarely change:

```
 Connection │ KS: system │ CL: LOCAL_ONE │ Output: ASCII │ Pg: 100 │ Trace: OFF │ Fetch: ON
```

Clicking `Connection` opens them, with the port, the negotiated protocol version, and the encryption settings, which were not shown anywhere before:

```
╭─────────────────────────────────────────────────────────────────────╮
│ Cassandra   5.0.9                                                   │
│ Protocol    v5                                                      │
│ User        svc_app                                                 │
│ Host        cass.internal:9142                                      │
│ Encryption  TLS, certificate verified, own CA, client certificate   │
╰─────────────────────────────────────────────────────────────────────╯
```

Unencrypted reads `Encryption  none`. The case worth building this for is the third:

```
│ Encryption  TLS, certificate NOT verified   │
```

TLS with certificate checking off is encrypted and still open to anything sitting in the middle of the connection. "TLS" alone would imply safety it does not have, so the panel says which it is rather than leaving it to be inferred from a missing note.

Encryption is read from the cluster configuration rather than the wire. That says what was asked for, which for TLS is the same thing: gocql fails the connection outright if the handshake does not meet it.

## OUTPUT on the line

After `CL`, so the format every result is rendered in can be changed by clicking rather than only by typing.

The connection panel reuses the settings list rather than adding a second kind of popup - same anchoring, geometry and dismissal. Nothing in it is marked, because it has no current value, and clicking a row only closes it, because `settingCommand` has nothing to return for `Connection`.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: every offered consistency level being settable and the table matching the driver's own set; every offered output format parsing; the click-to-close toggle driven through real `MouseClickMsg` presses; walking a 40-entry list to both ends and asserting every entry is reachable; the scrollbar thumb size, position and absence; and the connection panel's rows, alignment and encryption wording.

Checked by hand against a build for the parts tests cannot reach.

Closes #110
