### PR TITLE
fix(ui): show every output format in the Results view

### DIFF
--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
@@ -196,6 +197,7 @@ func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) 
 	// EXPAND format - use table viewport for pagination support
 	m.tableHeaders = headers
 	m.columnTypes = columnTypes
+	m.resultFormat = config.OutputFormatExpand
 	m.hasTable = true
 	m.viewMode = "table"
 	m.initialColumnWidths = nil // Reset initial widths for new table
@@ -217,6 +219,132 @@ func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) 
 	return m, nil
 }
 
+// showQueryResult draws a result that arrived complete, in whatever format
+// OUTPUT is set to.
+func (m *MainModel) showQueryResult(data [][]string, columnTypes []string, outputFormat config.OutputFormat) {
+	if len(data) == 0 {
+		return
+	}
+
+	// Every format goes to the Results view. ASCII and JSON used to be
+	// written into the console as text instead, where it is wrapped to the
+	// window - which breaks an ASCII table's borders mid-row and gives up
+	// the sideways scrolling that wide output needs.
+	m.lastTableData = data
+	m.tableHeaders = data[0]
+	m.columnTypes = columnTypes
+	m.resultFormat = outputFormat
+	m.horizontalOffset = 0
+	m.hasTable = true
+	m.viewMode = "table"
+	m.initialColumnWidths = nil // Reset initial widths for new table
+	m.cachedTableLines = nil    // Clear cache for new table
+	m.tableRowBoundaries = nil
+
+	var content string
+	switch outputFormat {
+	case config.OutputFormatASCII:
+		content = FormatASCIITable(data)
+	case config.OutputFormatJSON:
+		content = formatRowsAsJSON(data)
+	case config.OutputFormatExpand:
+		var boundaries []int
+		content, boundaries = FormatExpandTableWithBoundaries(data, m.styles)
+		m.tableRowBoundaries = boundaries
+	default:
+		content = m.formatTableForViewport(data)
+	}
+	if content == "" {
+		content = "No results"
+	}
+
+	m.tableViewport.SetContent(content)
+	m.tableViewport.GotoTop()
+	m.tableWidth = widestLine(content)
+}
+
+// jsonLines renders rows as one JSON object per line.
+//
+// A SELECT JSON already comes back as JSON in a single "[json]" column, so that
+// is passed through rather than wrapped in an object a second time.
+func jsonLines(headers []string, rows [][]string) string {
+	var b strings.Builder
+
+	if len(headers) == 1 && headers[0] == "[json]" {
+		for _, row := range rows {
+			if len(row) > 0 {
+				b.WriteString(row[0] + "\n")
+			}
+		}
+		return b.String()
+	}
+
+	for _, row := range rows {
+		object := make(map[string]interface{}, len(headers))
+		for i, header := range headers {
+			if i < len(row) {
+				object[header] = row[i]
+			}
+		}
+		if encoded, err := json.Marshal(object); err == nil {
+			b.WriteString(string(encoded) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// formatRowsAsJSON renders a result whose first row is its headers.
+func formatRowsAsJSON(data [][]string) string {
+	if len(data) < 2 {
+		return ""
+	}
+	return jsonLines(data[0], data[1:])
+}
+
+// widestLine is the width of the longest line, for horizontal scrolling.
+func widestLine(s string) int {
+	widest := 0
+	for _, line := range strings.Split(s, "\n") {
+		if w := lipgloss.Width(line); w > widest {
+			widest = w
+		}
+	}
+	return widest
+}
+
+// fetchAllPages pulls the rest of a streaming result in, when AutoFetch is on.
+//
+// It says nothing about where the result is then shown. AutoFetch decides how
+// much is fetched; the OUTPUT format decides how it is drawn. Tangling the two
+// is what sent ASCII and JSON results to the console rather than the Results
+// view, wrapped to the window and with their borders broken in half.
+func (m *MainModel) fetchAllPages(format string) {
+	if m.session == nil || !m.session.AutoFetch() ||
+		!m.slidingWindow.hasMoreData || m.slidingWindow.streamingResult == nil {
+		return
+	}
+
+	logger.DebugfToFile("HandleEnterKey", "%s format with AutoFetch ON: fetching all remaining pages", format)
+
+	totalFetched := 0
+	for m.slidingWindow.hasMoreData {
+		pageSize := m.session.PageSize()
+		if pageSize == 0 {
+			pageSize = 100 // Default page size
+		}
+		loadedRows := m.slidingWindow.LoadMoreRows(pageSize)
+		if loadedRows == 0 {
+			break
+		}
+		totalFetched += loadedRows
+	}
+	logger.DebugfToFile("HandleEnterKey", "%s format: fetched %d rows, total rows: %d",
+		format, totalFetched, m.slidingWindow.TotalRowsSeen)
+
+	m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
+	m.rowCount = int(m.slidingWindow.TotalRowsSeen)
+}
+
 // displayASCIIFormat displays results in ASCII table format
 func (m *MainModel) displayASCIIFormat(headers []string, columnTypes []string) (*MainModel, tea.Cmd) {
 	logger.DebugToFile("HandleEnterKey", "Formatting output as ASCII")
@@ -224,89 +352,39 @@ func (m *MainModel) displayASCIIFormat(headers []string, columnTypes []string) (
 	// Store headers and types for table view
 	m.tableHeaders = headers
 	m.columnTypes = columnTypes
+	m.resultFormat = config.OutputFormatASCII
 
-	// Check if AutoFetch is ON
-	if m.session != nil && m.session.AutoFetch() && m.slidingWindow.hasMoreData && m.slidingWindow.streamingResult != nil {
-		logger.DebugToFile("HandleEnterKey", "ASCII format with AutoFetch ON: fetching all remaining pages")
+	// AutoFetch only decides how much is pulled in; the result goes to the
+	// Results view either way, the same as TABLE and EXPAND.
+	m.fetchAllPages("ASCII")
 
-		// Keep loading until we have all data
-		totalFetched := 0
-		for m.slidingWindow.hasMoreData {
-			pageSize := m.session.PageSize()
-			if pageSize == 0 {
-				pageSize = 100 // Default page size
-			}
-			loadedRows := m.slidingWindow.LoadMoreRows(pageSize)
-			if loadedRows == 0 {
-				break
-			}
-			totalFetched += loadedRows
-			logger.DebugfToFile("HandleEnterKey", "ASCII format: fetched %d more rows, total fetched: %d",
-				loadedRows, totalFetched)
-		}
-		logger.DebugfToFile("HandleEnterKey", "ASCII format: finished fetching, total rows: %d",
-			m.slidingWindow.TotalRowsSeen)
+	m.hasTable = true
+	m.viewMode = "table"
+	m.horizontalOffset = 0
+	m.initialColumnWidths = nil // Reset initial widths for new table
+	m.cachedTableLines = nil    // Clear cache for new table
 
-		// Update row count in top bar
-		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
-		m.rowCount = int(m.slidingWindow.TotalRowsSeen)
+	allData := append([][]string{headers}, m.slidingWindow.Rows...)
+	m.lastTableData = allData
 
-		// When AutoFetch is ON, display all ASCII in history view
-		m.hasTable = false
-		m.viewMode = "history"
+	asciiStr := FormatASCIITable(allData)
 
-		// Format all data as ASCII table
-		allData := append([][]string{headers}, m.slidingWindow.Rows...)
-		asciiStr := FormatASCIITable(allData)
-
-		// Add to history
-		if asciiStr != "" {
-			m.fullHistoryContent += "\n" + asciiStr
-		} else {
-			m.fullHistoryContent += "\nNo results"
-		}
-		m.updateHistoryWrapping()
-		m.historyViewport.GotoBottom()
-	} else {
-		// AutoFetch is OFF - use table view for progressive loading
-		logger.DebugfToFile("HandleEnterKey", "ASCII format with AutoFetch OFF: using table view for progressive loading")
-
-		m.hasTable = true
-		m.viewMode = "table"
-		m.horizontalOffset = 0
-		m.initialColumnWidths = nil // Reset initial widths for new table
-		m.cachedTableLines = nil    // Clear cache for new table
-
-		// Build initial ASCII display
-		allData := append([][]string{headers}, m.slidingWindow.Rows...)
-		m.lastTableData = allData
-
-		// Format as ASCII table
-		asciiStr := FormatASCIITable(allData)
-
-		// Add notice about more data if applicable
-		if m.slidingWindow.hasMoreData {
-			asciiStr += "\n" + m.styles.MutedText.Render(
-				fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
-					len(m.slidingWindow.Rows)))
-		}
-
-		// Set content in table viewport
-		// No record boundaries in this layout; stale ones would cap scrolling.
-		m.tableRowBoundaries = nil
-		m.tableViewport.SetContent(asciiStr)
-		m.tableViewport.GotoTop()
-
-		// Calculate width for horizontal scrolling
-		lines := strings.Split(asciiStr, "\n")
-		maxWidth := 0
-		for _, line := range lines {
-			if width := len(stripAnsi(line)); width > maxWidth {
-				maxWidth = width
-			}
-		}
-		m.tableWidth = maxWidth
+	// Add notice about more data if applicable. AutoFetch will have taken the
+	// lot already, so this only shows when it is off.
+	if m.slidingWindow.hasMoreData {
+		asciiStr += "\n" + m.styles.MutedText.Render(
+			fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
+				len(m.slidingWindow.Rows)))
 	}
+
+	// Set content in table viewport
+	// No record boundaries in this layout; stale ones would cap scrolling.
+	m.tableRowBoundaries = nil
+	m.tableViewport.SetContent(asciiStr)
+	m.tableViewport.GotoTop()
+
+	// Calculate width for horizontal scrolling
+	m.tableWidth = widestLine(asciiStr)
 
 	m.input.Reset()
 	return m, nil
@@ -319,128 +397,39 @@ func (m *MainModel) displayJSONFormat(headers []string, columnTypes []string, co
 	// Store headers and types for table view
 	m.tableHeaders = headers
 	m.columnTypes = columnTypes
+	m.resultFormat = config.OutputFormatJSON
 
-	// Check if AutoFetch is ON
-	if m.session != nil && m.session.AutoFetch() && m.slidingWindow.hasMoreData && m.slidingWindow.streamingResult != nil {
-		logger.DebugToFile("HandleEnterKey", "JSON format with AutoFetch ON: fetching all remaining pages")
+	// AutoFetch only decides how much is pulled in; the result goes to the
+	// Results view either way, the same as TABLE and EXPAND.
+	m.fetchAllPages("JSON")
 
-		// Keep loading until we have all data
-		totalFetched := 0
-		for m.slidingWindow.hasMoreData {
-			pageSize := m.session.PageSize()
-			if pageSize == 0 {
-				pageSize = 100 // Default page size
-			}
-			loadedRows := m.slidingWindow.LoadMoreRows(pageSize)
-			if loadedRows == 0 {
-				break
-			}
-			totalFetched += loadedRows
-			logger.DebugfToFile("HandleEnterKey", "JSON format: fetched %d more rows, total fetched: %d",
-				loadedRows, totalFetched)
-		}
-		logger.DebugfToFile("HandleEnterKey", "JSON format: finished fetching, total rows: %d",
-			m.slidingWindow.TotalRowsSeen)
+	m.hasTable = true
+	m.viewMode = "table"
+	m.horizontalOffset = 0
+	m.initialColumnWidths = nil // Reset initial widths for new table
+	m.cachedTableLines = nil    // Clear cache for new table
 
-		// Update row count in top bar
-		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
-		m.rowCount = int(m.slidingWindow.TotalRowsSeen)
+	allData := append([][]string{headers}, m.slidingWindow.Rows...)
+	m.lastTableData = allData
 
-		// When AutoFetch is ON, display all JSON in history view
-		m.hasTable = false
-		m.viewMode = "history"
+	jsonStr := jsonLines(headers, m.slidingWindow.Rows)
 
-		// Convert all data to JSON
-		jsonStr := ""
-		if len(headers) == 1 && headers[0] == "[json]" {
-			for _, row := range m.slidingWindow.Rows {
-				if len(row) > 0 {
-					jsonStr += row[0] + "\n"
-				}
-			}
-		} else {
-			for _, row := range m.slidingWindow.Rows {
-				jsonMap := make(map[string]interface{})
-				for i, header := range headers {
-					if i < len(row) {
-						jsonMap[header] = row[i]
-					}
-				}
-				jsonBytes, err := json.Marshal(jsonMap)
-				if err == nil {
-					jsonStr += string(jsonBytes) + "\n"
-				}
-			}
-		}
-
-		// Add to history
-		if jsonStr != "" {
-			m.fullHistoryContent += "\n" + jsonStr
-		} else {
-			m.fullHistoryContent += "\nNo results"
-		}
-		m.updateHistoryWrapping()
-		m.historyViewport.GotoBottom()
-	} else {
-		// AutoFetch is OFF - use table view for progressive loading
-		logger.DebugfToFile("HandleEnterKey", "JSON format with AutoFetch OFF: using table view for progressive loading")
-
-		m.hasTable = true
-		m.viewMode = "table"
-		m.horizontalOffset = 0
-		m.initialColumnWidths = nil // Reset initial widths for new table
-		m.cachedTableLines = nil    // Clear cache for new table
-
-		// Build initial JSON display
-		allData := append([][]string{headers}, m.slidingWindow.Rows...)
-		m.lastTableData = allData
-
-		// Convert to JSON format
-		jsonStr := ""
-		if len(headers) == 1 && headers[0] == "[json]" {
-			for _, row := range m.slidingWindow.Rows {
-				if len(row) > 0 {
-					jsonStr += row[0] + "\n"
-				}
-			}
-		} else {
-			for _, row := range m.slidingWindow.Rows {
-				jsonMap := make(map[string]interface{})
-				for i, header := range headers {
-					if i < len(row) {
-						jsonMap[header] = row[i]
-					}
-				}
-				jsonBytes, err := json.Marshal(jsonMap)
-				if err == nil {
-					jsonStr += string(jsonBytes) + "\n"
-				}
-			}
-		}
-
-		// Add notice about more data if applicable
-		if m.slidingWindow.hasMoreData {
-			jsonStr += "\n" + m.styles.MutedText.Render(
-				fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
-					len(m.slidingWindow.Rows)))
-		}
-
-		// Set content in table viewport
-		// No record boundaries in this layout; stale ones would cap scrolling.
-		m.tableRowBoundaries = nil
-		m.tableViewport.SetContent(jsonStr)
-		m.tableViewport.GotoTop()
-
-		// Calculate width for horizontal scrolling
-		lines := strings.Split(jsonStr, "\n")
-		maxWidth := 0
-		for _, line := range lines {
-			if width := len(stripAnsi(line)); width > maxWidth {
-				maxWidth = width
-			}
-		}
-		m.tableWidth = maxWidth
+	// Add notice about more data if applicable. AutoFetch will have taken the
+	// lot already, so this only shows when it is off.
+	if m.slidingWindow.hasMoreData {
+		jsonStr += "\n" + m.styles.MutedText.Render(
+			fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
+				len(m.slidingWindow.Rows)))
 	}
+
+	// Set content in table viewport
+	// No record boundaries in this layout; stale ones would cap scrolling.
+	m.tableRowBoundaries = nil
+	m.tableViewport.SetContent(jsonStr)
+	m.tableViewport.GotoTop()
+
+	// Calculate width for horizontal scrolling
+	m.tableWidth = widestLine(jsonStr)
 
 	m.input.Reset()
 	return m, nil
@@ -451,6 +440,7 @@ func (m *MainModel) displayTableFormat(headers []string, columnTypes []string) (
 	// TABLE format - use table viewport
 	m.tableHeaders = headers
 	m.columnTypes = columnTypes
+	m.resultFormat = config.OutputFormatTable
 	m.hasTable = true
 	m.viewMode = "table"
 	m.initialColumnWidths = nil // Reset initial widths for new table
@@ -489,104 +479,7 @@ func (m *MainModel) processQueryResult(command string, v db.QueryResult) (*MainM
 		}
 		logger.DebugfToFile("keyboard_handler_enter", "QueryResult Format: %v", outputFormat)
 
-		// Check output format
-		switch outputFormat {
-		case config.OutputFormatASCII:
-			// ASCII format - display in CQL view as text
-			m.hasTable = false     // No table, just text
-			m.viewMode = "history" // Use history view for text output
-
-			// Format as ASCII table
-			asciiOutput := FormatASCIITable(v.Data)
-
-			// Add ASCII output to history content
-			if asciiOutput != "" {
-				m.fullHistoryContent += "\n" + asciiOutput
-			} else {
-				m.fullHistoryContent += "\nNo results"
-			}
-
-			// Update with wrapped content
-			m.updateHistoryWrapping()
-			m.historyViewport.GotoBottom()
-		case config.OutputFormatExpand:
-			// EXPAND format - use table viewport for scrolling support
-			// Store table data and headers
-			m.lastTableData = v.Data
-			m.tableHeaders = v.Data[0]    // Store the header row
-			m.columnTypes = v.ColumnTypes // Store column types
-			m.horizontalOffset = 0
-			m.hasTable = true
-			m.viewMode = "table"
-			m.initialColumnWidths = nil // Reset initial widths for new table
-			m.cachedTableLines = nil    // Clear cache for new table
-
-			// Format as expanded vertical table
-			expandOutput, boundaries := FormatExpandTableWithBoundaries(v.Data, m.styles)
-			m.tableRowBoundaries = boundaries
-			m.tableViewport.SetContent(expandOutput)
-			m.tableViewport.GotoTop() // Start at top of table
-		case config.OutputFormatJSON:
-			// JSON format - display in CQL view as text
-			m.hasTable = false     // No table, just text
-			m.viewMode = "history" // Use history view for text output
-
-			// Check if this is already JSON from SELECT JSON
-			jsonOutput := ""
-			if len(v.Data) > 1 {
-				headers := v.Data[0]
-				// Check if we have a single [json] column from SELECT JSON
-				if len(headers) == 1 && headers[0] == "[json]" {
-					// This is already JSON from SELECT JSON - just extract it
-					for _, row := range v.Data[1:] {
-						if len(row) > 0 {
-							jsonOutput += row[0] + "\n"
-						}
-					}
-				} else {
-					// Convert regular table data to JSON
-					for _, row := range v.Data[1:] {
-						jsonMap := make(map[string]interface{})
-						for i, header := range headers {
-							if i < len(row) {
-								jsonMap[header] = row[i]
-							}
-						}
-						jsonBytes, err := json.Marshal(jsonMap)
-						if err == nil {
-							jsonOutput += string(jsonBytes) + "\n"
-						}
-					}
-				}
-			}
-
-			// Add JSON output to history content
-			if jsonOutput != "" {
-				m.fullHistoryContent += "\n" + jsonOutput
-			} else {
-				m.fullHistoryContent += "\nNo results"
-			}
-
-			// Update with wrapped content
-			m.updateHistoryWrapping()
-			m.historyViewport.GotoBottom()
-		default:
-			// Use table viewport for TABLE format
-			// Store table data and headers
-			m.lastTableData = v.Data
-			m.tableHeaders = v.Data[0]    // Store the header row
-			m.columnTypes = v.ColumnTypes // Store column types
-			m.horizontalOffset = 0
-			m.hasTable = true
-			m.viewMode = "table"
-			m.initialColumnWidths = nil // Reset initial widths for new table
-			m.cachedTableLines = nil    // Clear cache for new table
-
-			// Format and display in table viewport
-			tableStr := m.formatTableForViewport(v.Data)
-			m.tableViewport.SetContent(tableStr)
-			m.tableViewport.GotoTop() // Start at top of table
-		}
+		m.showQueryResult(v.Data, v.ColumnTypes, outputFormat)
 
 		// Write to capture file if capturing
 		metaHandler := router.GetMetaHandler()
@@ -619,6 +512,7 @@ func (m *MainModel) processTableResult(command string, v [][]string) (*MainModel
 		// Store table data and headers
 		m.lastTableData = v
 		m.tableHeaders = v[0] // Store the header row
+		m.resultFormat = config.OutputFormatTable
 		m.horizontalOffset = 0
 		m.hasTable = true
 		m.viewMode = "table"

--- a/internal/ui/keyboard_navigation_pager.go
+++ b/internal/ui/keyboard_navigation_pager.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	tea "charm.land/bubbletea/v2"
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
 )
@@ -376,13 +377,8 @@ func (m *MainModel) handleHorizontalScrollLeft() (*MainModel, tea.Cmd) {
 		}
 	case m.viewMode == "table" && m.hasTable:
 		if m.horizontalOffset > 0 {
-			m.horizontalOffset -= 10
-			if m.horizontalOffset < 0 {
-				m.horizontalOffset = 0
-			}
-			if m.lastTableData != nil {
-				m.refreshTableView()
-			}
+			m.horizontalOffset = max(m.horizontalOffset-horizontalStep, 0)
+			m.applyHorizontalOffset()
 		}
 	}
 	return m, nil
@@ -472,19 +468,33 @@ func (m *MainModel) handleHorizontalScrollRight() (*MainModel, tea.Cmd) {
 		}
 	case m.viewMode == "table" && m.hasTable:
 		if m.tableWidth > m.tableViewport.Width() {
-			maxOffset := m.tableWidth - m.tableViewport.Width() + 10
+			maxOffset := m.tableWidth - m.tableViewport.Width() + horizontalStep
 			if m.horizontalOffset < maxOffset {
-				m.horizontalOffset += 10
-				if m.horizontalOffset > maxOffset {
-					m.horizontalOffset = maxOffset
-				}
-				if m.lastTableData != nil {
-					m.refreshTableView()
-				}
+				m.horizontalOffset = min(m.horizontalOffset+horizontalStep, maxOffset)
+				m.applyHorizontalOffset()
 			}
 		}
 	}
 	return m, nil
+}
+
+// horizontalStep is how far one press scrolls sideways.
+const horizontalStep = 10
+
+// applyHorizontalOffset moves the Results view sideways.
+//
+// A boxed table is rebuilt, because it drops whole columns rather than cutting
+// one down the middle. Everything else is text - ASCII art, JSON lines - and is
+// slid under the viewport instead. Rebuilding those as a table is what replaced
+// what you were reading with a mangled one on the first sideways scroll.
+func (m *MainModel) applyHorizontalOffset() {
+	if m.resultFormat == config.OutputFormatTable {
+		if m.lastTableData != nil {
+			m.refreshTableView()
+		}
+		return
+	}
+	m.tableViewport.SetXOffset(m.horizontalOffset)
 }
 
 // loadMoreTableDataHelper loads more rows when scrolling near the bottom

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -109,15 +109,21 @@ type MainModel struct {
 	columnWidths           []int             // Store column widths for proper alignment
 	initialColumnWidths    []int             // Store initial column widths to maintain consistency
 	hasTable               bool              // Whether we're currently displaying a table
-	cachedTableLines       []string          // Cache rendered table lines for fast scrolling
-	navigationMode         bool              // Toggle between navigation keys and input mode
-	mouseEnabled           bool              // Whether to ask the terminal for mouse reporting
-	chooser                settingChooser    // Open list of values for a status bar setting
-	selection              textSelection     // Text being dragged out with the mouse, if any
-	viewMode               string            // "history", "table", "trace", or "ai_info"
-	showDataTypes          bool              // Whether to show column data types in table headers
-	columnTypes            []string          // Store column data types
-	tableRowBoundaries     []int             // Line numbers where table rows start
+	// resultFormat is what the Results view is drawn as. The table machinery -
+	// the frozen header, rebuilding columns as you scroll sideways - only
+	// applies to a boxed table. ASCII art and JSON lines are text, and running
+	// them through it draws a header over content that has none and replaces
+	// what you are reading with a table the moment you scroll sideways.
+	resultFormat       config.OutputFormat
+	cachedTableLines   []string       // Cache rendered table lines for fast scrolling
+	navigationMode     bool           // Toggle between navigation keys and input mode
+	mouseEnabled       bool           // Whether to ask the terminal for mouse reporting
+	chooser            settingChooser // Open list of values for a status bar setting
+	selection          textSelection  // Text being dragged out with the mouse, if any
+	viewMode           string         // "history", "table", "trace", or "ai_info"
+	showDataTypes      bool           // Whether to show column data types in table headers
+	columnTypes        []string       // Store column data types
+	tableRowBoundaries []int          // Line numbers where table rows start
 
 	// AI conversation view
 	aiConversationActive   bool            // Whether AI conversation view is active

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -226,54 +226,29 @@ func (m *MainModel) handleMouseWheelDown() (*MainModel, tea.Cmd) {
 
 // handleMouseWheelLeft handles horizontal scrolling left
 func (m *MainModel) handleMouseWheelLeft() (*MainModel, tea.Cmd) {
-	logger.DebugfToFile("Mouse", "handleMouseWheelLeft: viewMode=%s, hasTable=%v, hasData=%v",
-		m.viewMode, m.hasTable, m.lastTableData != nil)
+	if m.viewMode != "table" || !m.hasTable {
+		return m, nil
+	}
 
-	if m.viewMode == "table" && m.hasTable && m.lastTableData != nil {
-		// Scroll left by 10 columns
-		oldOffset := m.horizontalOffset
-		m.horizontalOffset = max(0, m.horizontalOffset-10)
-
-		logger.DebugfToFile("Mouse", "Scrolling left: oldOffset=%d, newOffset=%d, tableWidth=%d, viewportWidth=%d",
-			oldOffset, m.horizontalOffset, m.tableWidth, m.tableViewport.Width())
-
-		// Only re-render if offset actually changed
-		if oldOffset != m.horizontalOffset {
-			// Refresh the table view (same as arrow keys do)
-			m.refreshTableView()
-			logger.DebugfToFile("Mouse", "Table refreshed with left scroll")
-		}
+	if m.horizontalOffset > 0 {
+		m.horizontalOffset = max(m.horizontalOffset-horizontalStep, 0)
+		m.applyHorizontalOffset()
 	}
 	return m, nil
 }
 
 // handleMouseWheelRight handles horizontal scrolling right
 func (m *MainModel) handleMouseWheelRight() (*MainModel, tea.Cmd) {
-	logger.DebugfToFile("Mouse", "handleMouseWheelRight: viewMode=%s, hasTable=%v, hasData=%v",
-		m.viewMode, m.hasTable, m.lastTableData != nil)
+	if m.viewMode != "table" || !m.hasTable {
+		return m, nil
+	}
 
-	if m.viewMode == "table" && m.hasTable && m.lastTableData != nil {
-		// Scroll right by 10 columns
-		oldOffset := m.horizontalOffset
-
-		// Calculate max offset based on actual table width
-		if m.tableWidth > m.tableViewport.Width() {
-			maxOffset := m.tableWidth - m.tableViewport.Width() + 10 // Add some buffer
-			m.horizontalOffset = min(maxOffset, m.horizontalOffset+10)
-		} else {
-			// Table fits in viewport, but allow some scrolling anyway
-			m.horizontalOffset += 10
-		}
-
-		logger.DebugfToFile("Mouse", "Scrolling right: oldOffset=%d, newOffset=%d, tableWidth=%d, viewportWidth=%d",
-			oldOffset, m.horizontalOffset, m.tableWidth, m.tableViewport.Width())
-
-		// Only re-render if offset actually changed
-		if oldOffset != m.horizontalOffset {
-			// Refresh the table view (same as arrow keys do)
-			m.refreshTableView()
-			logger.DebugfToFile("Mouse", "Table refreshed with right scroll")
-		}
+	// Stop where the content ends. It used to scroll on past the end when the
+	// content was narrower than the window, leaving you looking at nothing.
+	maxOffset := max(m.tableWidth-m.tableViewport.Width()+horizontalStep, 0)
+	if m.horizontalOffset < maxOffset {
+		m.horizontalOffset = min(m.horizontalOffset+horizontalStep, maxOffset)
+		m.applyHorizontalOffset()
 	}
 	return m, nil
 }

--- a/internal/ui/output_view_test.go
+++ b/internal/ui/output_view_test.go
@@ -1,0 +1,313 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// outputModel builds a model holding one page of a result, with a second page
+// still to come.
+func outputModel(t *testing.T, autoFetch bool) *MainModel {
+	t.Helper()
+
+	session := &db.Session{}
+	session.SetAutoFetch(autoFetch)
+
+	window := NewSlidingWindowTable(1000, 10)
+	window.Headers = []string{"id", "name"}
+	window.ColumnNames = window.Headers
+	for _, row := range [][]string{{"1", "alice"}, {"2", "bob"}} {
+		window.AddRow(row)
+	}
+
+	// A second page, delivered once and then exhausted.
+	remaining := [][]string{{"3", "carol"}, {"4", "dave"}}
+	window.hasMoreData = true
+	window.streamingResult = &db.StreamingResult{
+		LoadMore: func(_ context.Context, _ int) ([][]string, bool, error) {
+			rows := remaining
+			remaining = nil
+			return rows, false, nil
+		},
+	}
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		session:         session,
+		windowWidth:     100,
+		windowHeight:    30,
+		viewMode:        "history",
+		slidingWindow:   window,
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+		tableViewport:   viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+}
+
+// TestASCIIResultsGoToTheResultsView whichever way AutoFetch is set.
+//
+// With it on, they used to be dumped into the console as text. The console
+// wraps to the window, so an ASCII table came out with its borders broken in
+// half - and the Results view is where it can scroll sideways instead.
+func TestASCIIResultsGoToTheResultsView(t *testing.T) {
+	for _, autoFetch := range []bool{false, true} {
+		m := outputModel(t, autoFetch)
+		before := m.fullHistoryContent
+
+		m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+
+		assert.Equal(t, "table", m.viewMode, "AutoFetch %v", autoFetch)
+		assert.True(t, m.hasTable, "AutoFetch %v", autoFetch)
+		assert.Equal(t, before, m.fullHistoryContent,
+			"AutoFetch %v: nothing should have been written to the console", autoFetch)
+		assert.Contains(t, m.tableViewport.GetContent(), "alice")
+	}
+}
+
+// TestJSONResultsGoToTheResultsView: the same bug, in the other format.
+func TestJSONResultsGoToTheResultsView(t *testing.T) {
+	for _, autoFetch := range []bool{false, true} {
+		m := outputModel(t, autoFetch)
+		before := m.fullHistoryContent
+
+		m.displayJSONFormat(m.slidingWindow.Headers, nil, m.slidingWindow.ColumnNames)
+
+		assert.Equal(t, "table", m.viewMode, "AutoFetch %v", autoFetch)
+		assert.True(t, m.hasTable, "AutoFetch %v", autoFetch)
+		assert.Equal(t, before, m.fullHistoryContent,
+			"AutoFetch %v: nothing should have been written to the console", autoFetch)
+		assert.Contains(t, m.tableViewport.GetContent(), "alice")
+	}
+}
+
+// TestAutoFetchStillFetchesEverything. It decides how much is pulled in, which
+// is the part that should not have changed.
+func TestAutoFetchStillFetchesEverything(t *testing.T) {
+	m := outputModel(t, true)
+
+	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+
+	assert.False(t, m.slidingWindow.hasMoreData, "AutoFetch should have taken the rest")
+	assert.Len(t, m.slidingWindow.Rows, 4)
+	assert.Contains(t, m.tableViewport.GetContent(), "dave", "the second page should be on screen")
+}
+
+// TestWithoutAutoFetchTheRestIsLeft, and the notice says so.
+func TestWithoutAutoFetchTheRestIsLeft(t *testing.T) {
+	m := outputModel(t, false)
+
+	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+
+	assert.True(t, m.slidingWindow.hasMoreData)
+	assert.Len(t, m.slidingWindow.Rows, 2)
+	assert.Contains(t, stripAnsiForTest(m.tableViewport.GetContent()), "More data available")
+}
+
+// TestTheNoticeIsGoneOnceEverythingIsFetched: it tells you to press PgDn for
+// rows that are already on screen otherwise.
+func TestTheNoticeIsGoneOnceEverythingIsFetched(t *testing.T) {
+	m := outputModel(t, true)
+
+	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+
+	assert.NotContains(t, stripAnsiForTest(m.tableViewport.GetContent()), "More data available")
+}
+
+// TestAllFourFormatsAgreeOnWhereResultsGo. ASCII and JSON were the odd ones
+// out; TABLE and EXPAND always used the Results view.
+func TestAllFourFormatsAgreeOnWhereResultsGo(t *testing.T) {
+	display := map[string]func(m *MainModel){
+		"ASCII":  func(m *MainModel) { m.displayASCIIFormat(m.slidingWindow.Headers, nil) },
+		"JSON":   func(m *MainModel) { m.displayJSONFormat(m.slidingWindow.Headers, nil, m.slidingWindow.ColumnNames) },
+		"EXPAND": func(m *MainModel) { m.displayExpandFormat(m.slidingWindow.Headers, nil) },
+	}
+
+	for name, show := range display {
+		for _, autoFetch := range []bool{false, true} {
+			m := outputModel(t, autoFetch)
+			show(m)
+			assert.Equal(t, "table", m.viewMode, "%s with AutoFetch %v", name, autoFetch)
+		}
+	}
+}
+
+// TestWidestLineMeasuresColumns, since it drives horizontal scrolling and the
+// content can carry styling.
+func TestWidestLineMeasuresColumns(t *testing.T) {
+	assert.Equal(t, 5, widestLine("abc\nabcde\nab"))
+	assert.Equal(t, 0, widestLine(""))
+
+	styled := DefaultStyles().MutedText.Render("abcde")
+	assert.Equal(t, 5, widestLine(styled), "styling is not width: %q", styled)
+	assert.Equal(t, 4, widestLine(strings.Join([]string{"ab", "世界"}, "\n")),
+		"a wide character takes two columns")
+}
+
+// queryResultModel builds a model for the non-streaming path, which is the one
+// that carries all the rows at once in a QueryResult.
+func queryResultModel(t *testing.T) *MainModel {
+	t.Helper()
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		sessionManager:  nil,
+		windowWidth:     100,
+		windowHeight:    30,
+		viewMode:        "history",
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+		tableViewport:   viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+}
+
+// TestEveryFormatUsesTheResultsViewOnTheDirectPath.
+//
+// There are two paths a result can take: streaming, and everything-at-once.
+// Fixing only the streaming one left this second switch sending ASCII and JSON
+// to the console, with no AutoFetch involved at all - which is why the first
+// fix appeared to change nothing.
+func TestEveryFormatUsesTheResultsViewOnTheDirectPath(t *testing.T) {
+	data := [][]string{{"id", "name"}, {"1", "alice"}, {"2", "bob"}}
+
+	for _, format := range []config.OutputFormat{
+		config.OutputFormatTable,
+		config.OutputFormatASCII,
+		config.OutputFormatExpand,
+		config.OutputFormatJSON,
+	} {
+		m := queryResultModel(t)
+		before := m.fullHistoryContent
+
+		m.showQueryResult(data, nil, format)
+
+		assert.Equal(t, "table", m.viewMode, "%s", format)
+		assert.True(t, m.hasTable, "%s", format)
+		assert.Equal(t, before, m.fullHistoryContent,
+			"%s: nothing should have been written to the console", format)
+		assert.Contains(t, stripAnsiForTest(m.tableViewport.GetContent()), "alice", "%s", format)
+		assert.Positive(t, m.tableWidth, "%s: horizontal scrolling needs a width", format)
+	}
+}
+
+// TestJSONIsOneObjectPerRow.
+func TestJSONIsOneObjectPerRow(t *testing.T) {
+	out := formatRowsAsJSON([][]string{{"id", "name"}, {"1", "alice"}, {"2", "bob"}})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 2)
+	assert.JSONEq(t, `{"id":"1","name":"alice"}`, lines[0])
+	assert.JSONEq(t, `{"id":"2","name":"bob"}`, lines[1])
+}
+
+// TestSelectJSONIsPassedThrough rather than wrapped in another object.
+func TestSelectJSONIsPassedThrough(t *testing.T) {
+	out := formatRowsAsJSON([][]string{{"[json]"}, {`{"id": 1}`}, {`{"id": 2}`}})
+
+	assert.Equal(t, "{\"id\": 1}\n{\"id\": 2}\n", out)
+}
+
+func TestNoRowsIsNoJSON(t *testing.T) {
+	assert.Empty(t, formatRowsAsJSON([][]string{{"id"}}))
+	assert.Empty(t, formatRowsAsJSON(nil))
+}
+
+// resultsModel puts content into the Results view as a given format, the way a
+// query would.
+func resultsModel(t *testing.T, format config.OutputFormat, data [][]string) *MainModel {
+	t.Helper()
+
+	m := queryResultModel(t)
+	m.columnWidths = []int{8, 8} // left over from an earlier table render
+	m.showQueryResult(data, nil, format)
+	return m
+}
+
+func wideData() [][]string {
+	return [][]string{
+		{"id", "payload"},
+		{"1", strings.Repeat("a", 300)},
+		{"2", strings.Repeat("b", 300)},
+	}
+}
+
+// TestOnlyATableGetsAFrozenHeader.
+//
+// The header is drawn over the first rows once the view is scrolled. On JSON or
+// ASCII that puts columns on screen that nothing below them lines up with -
+// which is why the header appeared out of nowhere on scrolling down.
+func TestOnlyATableGetsAFrozenHeader(t *testing.T) {
+	for _, format := range []config.OutputFormat{
+		config.OutputFormatJSON,
+		config.OutputFormatASCII,
+		config.OutputFormatExpand,
+	} {
+		m := resultsModel(t, format, wideData())
+		m.tableViewport.SetYOffset(3)
+
+		assert.Zero(t, m.stickyHeaderRows(), "%s has no columns to freeze", format)
+	}
+
+	m := resultsModel(t, config.OutputFormatTable, wideData())
+	m.tableViewport.SetYOffset(3)
+	assert.Equal(t, stickyHeaderHeight, m.stickyHeaderRows())
+}
+
+// TestScrollingTextSidewaysDoesNotRebuildItAsATable. Scrolling right used to
+// re-render lastTableData as a boxed table, so the JSON you were reading was
+// replaced by a mangled table.
+func TestScrollingTextSidewaysDoesNotRebuildItAsATable(t *testing.T) {
+	for _, format := range []config.OutputFormat{config.OutputFormatJSON, config.OutputFormatASCII} {
+		m := resultsModel(t, format, wideData())
+		before := m.tableViewport.GetContent()
+
+		m.handleHorizontalScrollRight()
+
+		assert.Equal(t, before, m.tableViewport.GetContent(),
+			"%s: the content itself should not have been rebuilt", format)
+		assert.Positive(t, m.tableViewport.XOffset(), "%s: it should have slid sideways", format)
+		assert.Equal(t, horizontalStep, m.horizontalOffset, "%s", format)
+	}
+}
+
+// TestScrollingBackLeftReturnsToTheStart.
+func TestScrollingBackLeftReturnsToTheStart(t *testing.T) {
+	m := resultsModel(t, config.OutputFormatJSON, wideData())
+
+	for range 4 {
+		m.handleHorizontalScrollRight()
+	}
+	require.Positive(t, m.tableViewport.XOffset())
+
+	for range 10 {
+		m.handleHorizontalScrollLeft()
+	}
+	assert.Zero(t, m.horizontalOffset)
+	assert.Zero(t, m.tableViewport.XOffset())
+}
+
+// TestSidewaysScrollingStopsAtTheEnd rather than running off into blank space.
+func TestSidewaysScrollingStopsAtTheEnd(t *testing.T) {
+	m := resultsModel(t, config.OutputFormatJSON, wideData())
+
+	for range 100 {
+		m.handleHorizontalScrollRight()
+	}
+
+	assert.LessOrEqual(t, m.horizontalOffset, m.tableWidth)
+}
+
+// TestNarrowContentDoesNotScrollSideways: there is nothing out there to see.
+func TestNarrowContentDoesNotScrollSideways(t *testing.T) {
+	m := resultsModel(t, config.OutputFormatJSON, [][]string{{"id"}, {"1"}})
+
+	m.handleMouseWheelRight()
+
+	assert.Zero(t, m.horizontalOffset)
+}

--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -108,6 +109,12 @@ func (m *MainModel) selectionTarget() (*viewport.Model, string) {
 // something other than what is under the pointer. View draws the header only
 // when this is non-zero, so the two agree by construction.
 func (m *MainModel) stickyHeaderRows() int {
+	// Only a boxed table has a header to freeze. ASCII art and JSON lines are
+	// text, and drawing a table header over them puts columns on screen that
+	// nothing below them lines up with.
+	if m.resultFormat != config.OutputFormatTable {
+		return 0
+	}
 	if m.viewMode == "table" && m.hasTable && m.tableViewport.YOffset() > 0 &&
 		len(m.tableHeaders) > 0 && m.lastTableData != nil && m.columnWidths != nil {
 		return stickyHeaderHeight

--- a/internal/ui/selection_test.go
+++ b/internal/ui/selection_test.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -312,6 +313,7 @@ func TestStickyHeaderRowsAreNotSelectable(t *testing.T) {
 		styles:        DefaultStyles(),
 		viewMode:      "table",
 		hasTable:      true,
+		resultFormat:  config.OutputFormatTable,
 		tableViewport: vp,
 		tableHeaders:  []string{"id"},
 		lastTableData: [][]string{{"id"}},


### PR DESCRIPTION
## The bug

Set `OUTPUT ASCII` and the results were dumped into the console as text instead of appearing in the Results view. `OUTPUT JSON` did the same. `TABLE` and `EXPAND` always used the Results view, so two of the four formats disagreed with the other two.

That is worse than being in the wrong tab. The console wraps everything to the width of the window, so an ASCII table came out with its borders broken mid-row - and the sideways scrolling that wide output needs exists only in the Results view.

## Two routes, two switches

A result reaches the screen by two routes - streaming, and complete at once - and each had its own switch on the output format. Both sent ASCII and JSON to the console: the streaming one when AutoFetch was on and there was more than one page, the other unconditionally.

AutoFetch decides how much is fetched, not where the result is drawn, so that condition is gone. `fetchAllPages` does the fetching and the display functions do the drawing.

Nothing set AutoFetch except typing `AUTOFETCH ON`, which is why this went unnoticed. Clicking `Fetch` on the bottom line is new, so it became easy to turn on - and turning it on quietly moved where two of the four formats appeared.

The complete-at-once branch is now `showQueryResult`, which is what made the second route testable. It was reachable only through a live query before, which is why fixing the first route appeared to change nothing.

## Then the Results view had to stop assuming everything in it was a table

Putting text into it exposed two more:

**A table header drawn over JSON.** The frozen header engages whenever the view is scrolled and `columnWidths` is set - and those are left over from an earlier table render. So a header appeared out of nowhere on scrolling down, with columns nothing below them lined up with.

**Scrolling sideways rebuilt the content as a table.** `refreshTableView` re-rendered `lastTableData` as a boxed table whatever was on screen, so the JSON you were reading was replaced by a mangled one.

The Results view now records what it is showing. A boxed table is rebuilt when it scrolls sideways, because it drops whole columns rather than cutting one down the middle. Text slides under the viewport instead:

```
--- at offset 0 ---
{"id":"1","name":"row","payload":"xxxxxxxxxxxxxxxxxxxxxxxxxx
{"id":"2","name":"row","payload":"xxxxxxxxxxxxxxxxxxxxxxxxxx

--- after scrolling right ---
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
```

The frozen header now applies to a table and nothing else.

Also fixed: the wheel scrolled on past the end of the content when it was narrower than the window, leaving you looking at blank space.

## Duplication removed

- The JSON row-to-object conversion existed in three copies; it is now `jsonLines`.
- The fetch-all-pages loop, in two.
- The widest-line calculation, in three - all using `len()` over styled strings, so they over-measured and the horizontal scroll limit was wrong with them.

Production code is down ~290 lines.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests drive a fake `LoadMore`, so both AutoFetch settings are covered for real on the streaming route, and `showQueryResult` directly for the other. They cover: all four formats landing in the Results view on both routes; the console being left untouched; AutoFetch still pulling every page in; the "More data available" notice appearing only when there is; the frozen header applying to `TABLE` alone; sideways scrolling not rebuilding text, returning to the start, and stopping at both ends; and the JSON conversion including `SELECT JSON` pass-through.

Checked by hand against a build for the parts tests cannot reach.

Closes #114
