### PR TITLE
feat(ui): leave the AI tab out when AI is not configured

### DIFF
--- a/internal/ai/configured.go
+++ b/internal/ai/configured.go
@@ -1,0 +1,61 @@
+package ai
+
+import "github.com/axonops/cqlai/internal/config"
+
+// IsConfigured reports whether there is an AI provider that can actually answer.
+//
+// Without one, NewClient falls back to the mock provider, which returns canned
+// replies. That is the right default for a library - it never fails to build a
+// client - but it means the UI cannot tell "AI is set up" from "AI is not set
+// up" by asking for a client, and so offered an AI view backed by a stub.
+//
+// The mock provider counts only when it was asked for by name. Set on purpose
+// it is a choice; arrived at because nothing was configured it is not.
+//
+// Keys reach the config from cqlai.json or from the environment - config
+// merges both before this sees it - so there is nothing to read here beyond
+// what has already been loaded.
+func IsConfigured(cfg *config.AIConfig) bool {
+	if cfg == nil {
+		return false
+	}
+
+	switch Provider(cfg.Provider) {
+	case ProviderMock:
+		return true
+
+	case ProviderOllama:
+		// Ollama runs locally and takes no key, so a URL is what it needs.
+		return providerURL(cfg, cfg.Ollama) != ""
+
+	case ProviderOpenAI:
+		return providerKey(cfg, cfg.OpenAI) != ""
+	case ProviderAnthropic:
+		return providerKey(cfg, cfg.Anthropic) != ""
+	case ProviderGemini:
+		return providerKey(cfg, cfg.Gemini) != ""
+	case ProviderOpenRouter:
+		return providerKey(cfg, cfg.OpenRouter) != ""
+
+	default:
+		// No provider at all, or one nothing here knows how to talk to.
+		return false
+	}
+}
+
+// providerKey is the key for a provider: its own, or the general one it falls
+// back to. The same order NewClient resolves them in.
+func providerKey(cfg *config.AIConfig, provider *config.AIProviderConfig) string {
+	if provider != nil && provider.APIKey != "" {
+		return provider.APIKey
+	}
+	return cfg.APIKey
+}
+
+// providerURL is the URL for a provider, resolved the same way.
+func providerURL(cfg *config.AIConfig, provider *config.AIProviderConfig) string {
+	if provider != nil && provider.URL != "" {
+		return provider.URL
+	}
+	return cfg.URL
+}

--- a/internal/ai/configured_test.go
+++ b/internal/ai/configured_test.go
@@ -1,0 +1,70 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNothingConfiguredIsNotConfigured(t *testing.T) {
+	assert.False(t, IsConfigured(nil))
+	assert.False(t, IsConfigured(&config.AIConfig{}))
+}
+
+// TestAProviderWithoutItsKeyIsNotConfigured. Offering the AI view and then
+// failing on the first question is worse than not offering it.
+func TestAProviderWithoutItsKeyIsNotConfigured(t *testing.T) {
+	for _, provider := range []string{"openai", "anthropic", "gemini", "openrouter"} {
+		assert.False(t, IsConfigured(&config.AIConfig{Provider: provider}),
+			"%s has no key", provider)
+	}
+}
+
+func TestAProviderWithItsKeyIsConfigured(t *testing.T) {
+	for _, provider := range []string{"openai", "anthropic", "gemini", "openrouter"} {
+		assert.True(t, IsConfigured(&config.AIConfig{Provider: provider, APIKey: "k"}),
+			"%s with the general key", provider)
+	}
+
+	// A provider's own key counts as well as the general one.
+	assert.True(t, IsConfigured(&config.AIConfig{
+		Provider:  "anthropic",
+		Anthropic: &config.AIProviderConfig{APIKey: "k"},
+	}))
+}
+
+// TestAKeyForTheWrongProviderDoesNotCount.
+func TestAKeyForTheWrongProviderDoesNotCount(t *testing.T) {
+	assert.False(t, IsConfigured(&config.AIConfig{
+		Provider: "anthropic",
+		OpenAI:   &config.AIProviderConfig{APIKey: "k"},
+	}))
+}
+
+// TestOllamaNeedsAURLNotAKey: it runs locally and takes no key, so a key is
+// not what tells you it is set up.
+func TestOllamaNeedsAURLNotAKey(t *testing.T) {
+	assert.False(t, IsConfigured(&config.AIConfig{Provider: "ollama"}))
+	assert.False(t, IsConfigured(&config.AIConfig{Provider: "ollama", APIKey: "k"}))
+
+	assert.True(t, IsConfigured(&config.AIConfig{Provider: "ollama", URL: "http://localhost:11434"}))
+	assert.True(t, IsConfigured(&config.AIConfig{
+		Provider: "ollama",
+		Ollama:   &config.AIProviderConfig{URL: "http://localhost:11434"},
+	}))
+}
+
+// TestMockCountsOnlyWhenItWasAskedFor.
+//
+// NewClient falls back to mock when no provider is set, which is a sensible
+// default for a library but means asking it for a client cannot tell the two
+// apart. Set on purpose, mock is a choice; arrived at, it is not.
+func TestMockCountsOnlyWhenItWasAskedFor(t *testing.T) {
+	assert.True(t, IsConfigured(&config.AIConfig{Provider: "mock"}))
+	assert.False(t, IsConfigured(&config.AIConfig{Provider: ""}))
+}
+
+func TestAnUnknownProviderIsNotConfigured(t *testing.T) {
+	assert.False(t, IsConfigured(&config.AIConfig{Provider: "telepathy", APIKey: "k"}))
+}

--- a/internal/ui/keyboard_handler_function_keys.go
+++ b/internal/ui/keyboard_handler_function_keys.go
@@ -73,6 +73,16 @@ func (m *MainModel) handleF4() (*MainModel, tea.Cmd) {
 
 // handleF5 handles F5 key - switch to AI view
 func (m *MainModel) handleF5() (*MainModel, tea.Cmd) {
+	// Say why rather than doing nothing. A key that silently does nothing is
+	// how someone concludes the build is broken.
+	if !m.aiAvailable() {
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("AI is not configured.") +
+			m.styles.MutedText.Render(" Set a provider and key in cqlai.json, or export ANTHROPIC_API_KEY.") + "\n"
+		m.updateHistoryWrapping()
+		m.historyViewport.GotoBottom()
+		return m, nil
+	}
+
 	if m.viewMode != "ai" {
 		m.viewMode = "ai"
 		m.aiConversationActive = true

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/ai"
 )
 
 // The mode tabs across the top.
@@ -49,14 +50,39 @@ func (m *MainModel) tabAvailable(mode string) bool {
 	}
 }
 
+// visibleTabs is the tabs to draw.
+//
+// AI is left out rather than dimmed when there is no provider configured.
+// Results and Trace are dimmed because they fill in as you work; whether AI is
+// set up cannot change while cqlai is running, so a permanently dimmed tab
+// would only be taking room from the others.
+func (m *MainModel) visibleTabs() []modeTab {
+	if m.aiAvailable() {
+		return modeTabs
+	}
+
+	tabs := make([]modeTab, 0, len(modeTabs))
+	for _, t := range modeTabs {
+		if t.mode != "ai" {
+			tabs = append(tabs, t)
+		}
+	}
+	return tabs
+}
+
+// aiAvailable reports whether the AI view has a provider behind it.
+func (m *MainModel) aiAvailable() bool {
+	return ai.IsConfigured(m.aiConfig)
+}
+
 // tabText renders the tab labels at one of three widths. The bar must never
 // wrap onto a second line, so it drops the key hints and then shortens the
 // names before anything is left out.
-func tabText(width int) []string {
-	full := make([]string, len(modeTabs))
-	plain := make([]string, len(modeTabs))
-	short := make([]string, len(modeTabs))
-	for i, t := range modeTabs {
+func tabText(tabs []modeTab, width int) []string {
+	full := make([]string, len(tabs))
+	plain := make([]string, len(tabs))
+	short := make([]string, len(tabs))
+	for i, t := range tabs {
 		full[i] = t.label + " (" + t.key + ")"
 		plain[i] = t.label
 		// Not label[:1]: two labels can share a first letter, and a bar of
@@ -103,11 +129,12 @@ func (m *MainModel) layoutTabs(width int) []tabSpan {
 		return nil
 	}
 
-	labels := tabText(width)
+	tabs := m.visibleTabs()
+	labels := tabText(tabs, width)
 
-	spans := make([]tabSpan, 0, len(modeTabs))
+	spans := make([]tabSpan, 0, len(tabs))
 	col := 0
-	for i, t := range modeTabs {
+	for i, t := range tabs {
 		next := col
 		if i > 0 {
 			next += len(tabSeparator)

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -7,13 +7,20 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"github.com/axonops/cqlai/internal/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// configuredAI is an AI setup good enough to count as configured, so the
+// layout tests get all four tabs.
+func configuredAI() *config.AIConfig {
+	return &config.AIConfig{Provider: "anthropic", APIKey: "test-key"}
+}
+
 func TestTabBarNeverWraps(t *testing.T) {
-	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 	// Every width from unusable to generous.
 	for width := 1; width <= 200; width++ {
@@ -27,7 +34,7 @@ func TestTabBarNeverWraps(t *testing.T) {
 }
 
 func TestTabBarShowsKeysWhenThereIsRoom(t *testing.T) {
-	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 	wide := stripAnsiForTest(m.ViewTabBar(120))
 	for _, want := range []string{"Console (F2)", "Results (F3)", "Trace (F4)", "AI (F5)"} {
@@ -62,7 +69,7 @@ func TestShortLabelsAreDistinct(t *testing.T) {
 // TestNarrowBarStaysDistinct is the same guarantee through the rendered output,
 // so it holds for whatever the layout actually draws.
 func TestNarrowBarStaysDistinct(t *testing.T) {
-	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 	bar := stripAnsiForTest(m.ViewTabBar(20))
 	fields := strings.Fields(bar)
@@ -81,7 +88,7 @@ func TestNarrowBarStaysDistinct(t *testing.T) {
 func TestTabBarMarksTheCurrentMode(t *testing.T) {
 	for _, mode := range []string{"history", "table", "trace", "ai"} {
 		t.Run(mode, func(t *testing.T) {
-			m := &MainModel{viewMode: mode, hasTable: true, hasTrace: true}
+			m := &MainModel{viewMode: mode, hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 			active := []string{}
 			for _, span := range m.layoutTabs(120) {
@@ -99,7 +106,7 @@ func TestTabBarMarksTheCurrentMode(t *testing.T) {
 // TestTabBarUnknownModeHighlightsNothing guards the edge where viewMode is
 // something the bar does not list, so it must not pick an arbitrary tab.
 func TestTabBarUnknownModeHighlightsNothing(t *testing.T) {
-	m := &MainModel{viewMode: "ai_info", hasTable: true, hasTrace: true}
+	m := &MainModel{viewMode: "ai_info", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 	for _, span := range m.layoutTabs(120) {
 		assert.False(t, span.active, "%q should not be marked active", span.mode)
 	}
@@ -107,13 +114,13 @@ func TestTabBarUnknownModeHighlightsNothing(t *testing.T) {
 
 // TestTabAvailability covers the "modes with no data look unavailable" rule.
 func TestTabAvailability(t *testing.T) {
-	empty := &MainModel{viewMode: "history"}
+	empty := &MainModel{viewMode: "history", aiConfig: configuredAI()}
 	assert.True(t, empty.tabAvailable("history"))
 	assert.True(t, empty.tabAvailable("ai"))
 	assert.False(t, empty.tabAvailable("table"), "no results yet, so nothing to show")
 	assert.False(t, empty.tabAvailable("trace"), "no trace yet, so nothing to show")
 
-	loaded := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	loaded := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 	assert.True(t, loaded.tabAvailable("table"))
 	assert.True(t, loaded.tabAvailable("trace"))
 }
@@ -122,7 +129,7 @@ func TestTabAvailability(t *testing.T) {
 // tab line has to resolve back to the mode drawn there.
 func TestModeAtMapsClicksToTabs(t *testing.T) {
 	const width = 120
-	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 	spans := m.layoutTabs(width)
 	require.Len(t, spans, 4)
@@ -150,7 +157,7 @@ func TestModeAtMapsClicksToTabs(t *testing.T) {
 // unavailable must not respond.
 func TestUnavailableTabsIgnoreClicks(t *testing.T) {
 	const width = 120
-	m := &MainModel{viewMode: "history"} // no results, no trace
+	m := &MainModel{viewMode: "history", aiConfig: configuredAI()} // no results, no trace
 
 	for _, span := range m.layoutTabs(width) {
 		mode, ok := m.modeAt(width, (span.start+span.end)/2)
@@ -308,4 +315,115 @@ func TestRenderDoesNotTouchTheTerminal(t *testing.T) {
 		m.newView("")
 	})
 	assert.Empty(t, out, "rendering should write nothing directly to the terminal")
+}
+
+// TestTheAITabIsHiddenWithoutAProvider.
+//
+// Without one, the AI client falls back to a mock that returns canned replies,
+// so the view looked like it worked. Leaving the tab out rather than dimming
+// it: Results and Trace fill in as you work, but whether AI is configured
+// cannot change while cqlai is running.
+func TestTheAITabIsHiddenWithoutAProvider(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	bar := stripAnsiForTest(m.ViewTabBar(120))
+	assert.NotContains(t, bar, "AI")
+	for _, want := range []string{"Console", "Results", "Trace"} {
+		assert.Contains(t, bar, want, "the other tabs should be untouched")
+	}
+
+	for _, span := range m.layoutTabs(120) {
+		assert.NotEqual(t, "ai", span.mode)
+	}
+}
+
+// TestTheAITabIsThereWhenItIsConfigured.
+func TestTheAITabIsThereWhenItIsConfigured(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
+
+	assert.Contains(t, stripAnsiForTest(m.ViewTabBar(120)), "AI")
+}
+
+// TestTheHiddenTabTakesNoColumns: the tabs after it must not be laid out around
+// a gap, and a click has to land on what is drawn.
+func TestTheHiddenTabTakesNoColumns(t *testing.T) {
+	const width = 120
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	spans := m.layoutTabs(width)
+	require.Len(t, spans, 3)
+
+	for _, span := range spans {
+		mode, ok := m.modeAt(width, (span.start+span.end)/2)
+		assert.Equal(t, span.mode, mode)
+		assert.True(t, ok)
+	}
+
+	// Nothing answers past the last tab, where AI used to be.
+	_, ok := m.modeAt(width, spans[len(spans)-1].end+2)
+	assert.False(t, ok)
+}
+
+// TestTheBarStillFitsWithoutAI at every width.
+func TestTheBarStillFitsWithoutAI(t *testing.T) {
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
+
+	for width := 1; width <= 200; width++ {
+		bar := m.ViewTabBar(width)
+		assert.NotContains(t, bar, "\n", "the tab bar wrapped at width %d", width)
+
+		plain := stripAnsiForTest(bar)
+		assert.LessOrEqual(t, len([]rune(strings.TrimRight(plain, " "))), width,
+			"tab bar overflowed at width %d: %q", width, plain)
+	}
+}
+
+// TestF5SaysWhyWhenAIIsNotConfigured. A key that silently does nothing is how
+// someone concludes the build is broken.
+func TestF5SaysWhyWhenAIIsNotConfigured(t *testing.T) {
+	m := &MainModel{
+		viewMode:        "history",
+		styles:          DefaultStyles(),
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+	}
+
+	m.handleF5()
+
+	assert.Equal(t, "history", m.viewMode, "F5 should not have opened an empty AI view")
+	assert.False(t, m.aiConversationActive)
+
+	said := stripAnsiForTest(m.fullHistoryContent)
+	assert.Contains(t, said, "AI is not configured")
+	assert.Contains(t, said, "cqlai.json", "it should say where to set it")
+}
+
+// TestF5StillOpensAIWhenConfigured.
+func TestF5StillOpensAIWhenConfigured(t *testing.T) {
+	m := &MainModel{
+		viewMode:        "history",
+		styles:          DefaultStyles(),
+		input:           newTestInput(),
+		aiConfig:        configuredAI(),
+		historyViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+	}
+
+	m.handleF5()
+
+	assert.Equal(t, "ai", m.viewMode)
+	assert.True(t, m.aiConversationActive)
+	assert.Empty(t, m.fullHistoryContent, "nothing to explain when it is configured")
+}
+
+// TestF5IsNotAdvertisedWhenAIIsNotConfigured. Suggesting a key that then tells
+// you it cannot do anything is the same defect as showing the tab.
+func TestF5IsNotAdvertisedWhenAIIsNotConfigured(t *testing.T) {
+	without := &MainModel{styles: DefaultStyles()}
+	with := &MainModel{styles: DefaultStyles(), aiConfig: configuredAI()}
+
+	assert.Empty(t, aiKeyHint(without))
+	assert.Contains(t, aiKeyHint(with), "F5")
+
+	assert.NotContains(t, stripAnsiForTest(without.getWelcomeMessage()), "F5")
+	assert.Contains(t, stripAnsiForTest(with.getWelcomeMessage()), "F5")
 }

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -40,6 +40,16 @@ func (m *MainModel) newView(content string) tea.View {
 	return v
 }
 
+// aiKeyHint is the "F5: AI" part of the key hints, or nothing when there is no
+// provider configured. Advertising a key that then tells you it cannot do
+// anything is the same defect as showing the tab.
+func aiKeyHint(m *MainModel) string {
+	if !m.aiAvailable() {
+		return ""
+	}
+	return " | F5: AI"
+}
+
 // View renders the main model.
 func (m *MainModel) View() tea.View {
 	if !m.ready {
@@ -108,21 +118,23 @@ func (m *MainModel) View() tea.View {
 	case "trace":
 		modeIndicator := m.styles.AccentText.Render("[TRACE VIEW]")
 		scrollInfo = " " + modeIndicator
-		scrollInfo += " " + m.styles.MutedText.Render("[F2: History | F5: AI]")
+		scrollInfo += " " + m.styles.MutedText.Render("[F2: History"+aiKeyHint(m)+"]")
 		if m.hasTable {
 			scrollInfo += " " + m.styles.MutedText.Render("[F3: Table]")
 		}
 	case "table":
 		modeIndicator := m.styles.AccentText.Render("[TABLE VIEW]")
 		scrollInfo = " " + modeIndicator
-		scrollInfo += " " + m.styles.MutedText.Render("[F2: History | F5: AI | F6: Toggle Types]")
+		scrollInfo += " " + m.styles.MutedText.Render("[F2: History"+aiKeyHint(m)+" | F6: Toggle Types]")
 		if m.hasTrace {
 			scrollInfo += " " + m.styles.MutedText.Render("[F4: Trace]")
 		}
 	default: // history view
 		modeIndicator := m.styles.MutedText.Render("[CQL VIEW]")
 		scrollInfo = " " + modeIndicator
-		scrollInfo += " " + m.styles.MutedText.Render("[F5: AI]")
+		if hint := aiKeyHint(m); hint != "" {
+			scrollInfo += " " + m.styles.MutedText.Render("["+strings.TrimPrefix(hint, " | ")+"]")
+		}
 		if m.hasTable {
 			scrollInfo += " " + m.styles.MutedText.Render("[F3: Table]")
 		}
@@ -469,8 +481,10 @@ func (m *MainModel) getWelcomeMessage() string {
 	welcome.WriteString("\n")
 	welcome.WriteString(m.styles.MutedText.Render("  • F4 - Switch to trace view"))
 	welcome.WriteString("\n")
-	welcome.WriteString(m.styles.MutedText.Render("  • F5 - Switch to AI assistant mode"))
-	welcome.WriteString("\n")
+	if m.aiAvailable() {
+		welcome.WriteString(m.styles.MutedText.Render("  • F5 - Switch to AI assistant mode"))
+		welcome.WriteString("\n")
+	}
 	welcome.WriteString(m.styles.MutedText.Render("  • F6 - Toggle column data types (in table view)"))
 	welcome.WriteString("\n\n")
 


### PR DESCRIPTION
The AI tab was always there and `F5` always opened it, whether or not there was a provider behind them. With nothing configured `NewClient` falls back to the mock provider, so you got an AI view that looked like it worked, backed by canned replies, with nothing saying so.

```
AI none:      [ Console (F2)    Results (F3)    Trace (F4)               ]
AI anthropic: [ Console (F2)    Results (F3)    Trace (F4)    AI (F5)    ]
```

## One question, four askers

`ai.IsConfigured` answers whether there is a provider that can actually reply:

- **The tab** - left out, so the remaining three get the room.
- **`F5`** - says `AI is not configured. Set a provider and key in cqlai.json, or export ANTHROPIC_API_KEY.` rather than opening an empty room.
- **The key hints** in the right-hand info area - `[F5: AI]` dropped.
- **The welcome message** - the `F5 - Switch to AI assistant mode` line dropped.

The last two were not in the issue but are the same defect: advertising a key that then tells you it cannot do anything.

`F5` explains itself rather than doing nothing, because a key that silently does nothing is how someone concludes the build is broken.

## Left out, not dimmed

Results and Trace are dimmed when they have nothing to show, because they fill in as you work. Whether AI is configured cannot change while cqlai is running, so a permanently dimmed tab would only be taking room from the others.

## Two things the check has to get right

**Ollama takes a URL, not a key.** It runs locally and needs no key, so testing for an API key would call a working local Ollama unconfigured - and a key set for it means nothing.

**`mock` counts only when it was asked for by name.** `NewClient` falls back to mock when no provider is set:

```go
if config.Provider == "" {
    config.Provider = "mock" // Default to mock for safety
}
```

That is a sensible default for a library - it never fails to build a client - but it means asking it for a client cannot tell "set up" from "not set up", which is how the stub-backed view came to look real. Set on purpose, `mock` is a choice; arrived at, it is not.

A key set for a different provider does not count either, and a provider name nothing here knows is not configured.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover each provider with and without what it needs, a provider's own key as well as the general one, a key belonging to the wrong provider, Ollama's URL, both readings of `mock`, and an unknown provider. On the UI side: the tab absent and present, the hidden tab taking no columns so clicks still land on what is drawn, the bar still fitting at every width from 1 to 200, and `F5` in both states.

The existing tab layout tests now build a configured AI, because they assert four tabs.

Closes #116
