### PR TITLE
fix(db): show key column markers reliably, and say what order the key is in

### DIFF
--- a/internal/db/executor.go
+++ b/internal/db/executor.go
@@ -492,18 +492,7 @@ func (s *Session) ExecuteSelectQuery(query string) interface{} {
 			columnTypes[i] = fullType
 		}
 
-		// Add indicators for key columns
-		if keyInfo, exists := keyColumns[col.Name]; exists {
-			logger.DebugfToFile("executeSelectQuery", "Adding indicator for %s: %s", col.Name, keyInfo.Kind)
-			switch keyInfo.Kind {
-			case "partition_key":
-				headers[i] += " (PK)"
-			case "clustering":
-				headers[i] += " (C)"
-			}
-		} else {
-			logger.DebugfToFile("executeSelectQuery", "No key info for column %s", col.Name)
-		}
+		headers[i] += keyColumns.Marker(col.Name)
 	}
 
 	// Collect results - use MapScan for better type handling
@@ -829,15 +818,7 @@ func (s *Session) ExecuteStreamingQuery(query string) interface{} {
 			columnTypes[i] = fullType
 		}
 
-		// Add indicators for key columns
-		if keyInfo, exists := keyColumns[col.Name]; exists {
-			switch keyInfo.Kind {
-			case "partition_key":
-				headers[i] += " (PK)"
-			case "clustering":
-				headers[i] += " (C)"
-			}
-		}
+		headers[i] += keyColumns.Marker(col.Name)
 	}
 
 	// Return streaming result with iterator
@@ -881,13 +862,13 @@ func ConvertToJSONQuery(query string) string {
 }
 
 // GetKeyColumns returns information about partition and clustering columns for a table
-func (s *Session) GetKeyColumns(query string) map[string]KeyColumnInfo {
-	keyColumns := make(map[string]KeyColumnInfo)
+func (s *Session) GetKeyColumns(query string) KeyColumns {
+	keyColumns := make(KeyColumns)
 
 	// Try to extract table name from the SELECT query
-	// Handle patterns like: SELECT ... FROM keyspace.table or FROM table
-	re := regexp.MustCompile(`(?i)FROM\s+(?:([a-zA-Z_][a-zA-Z0-9_]*)\.)?([a-zA-Z_][a-zA-Z0-9_]*)`)
-	matches := re.FindStringSubmatch(query)
+	// Handle patterns like: SELECT ... FROM keyspace.table or FROM table,
+	// with either part quoted.
+	matches := fromClause.FindStringSubmatch(query)
 
 	logger.DebugfToFile("getKeyColumns", "Query: %s", query)
 	logger.DebugfToFile("getKeyColumns", "Regex matches: %v", matches)
@@ -897,13 +878,17 @@ func (s *Session) GetKeyColumns(query string) map[string]KeyColumnInfo {
 		return keyColumns
 	}
 
-	keyspaceName := matches[1] // May be empty
-	tableName := matches[2]
+	keyspaceName := cqlIdentifier(matches[1]) // May be empty
+	tableName := cqlIdentifier(matches[2])
 
-	// If no keyspace specified, we can't determine key columns
-	// The UI/router layer should track the current keyspace
+	// An unqualified query means the keyspace the session is on, which is what
+	// USE sets. Giving up here is why the markers only ever appeared when the
+	// query happened to name the keyspace.
 	if keyspaceName == "" {
-		logger.DebugToFile("getKeyColumns", "No keyspace specified")
+		keyspaceName = s.Keyspace()
+	}
+	if keyspaceName == "" {
+		logger.DebugToFile("getKeyColumns", "No keyspace in the query and none set on the session")
 		return keyColumns
 	}
 

--- a/internal/db/key_columns.go
+++ b/internal/db/key_columns.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// The markers appended to result headers for the columns that make up a
+// table's primary key.
+//
+// One place builds them and one place strips them. They used to be written out
+// by hand wherever they were needed - ten files strip them before writing CSV,
+// Parquet or a capture - so changing what a marker looks like meant finding
+// every one of those and would silently break exports if any were missed.
+
+// KeyColumns describes which columns of a table form its primary key.
+type KeyColumns map[string]KeyColumnInfo
+
+// Marker is the suffix to append to a column's header, or "" if the column is
+// not part of the key.
+//
+// The component number appears only when there is more than one component to
+// tell apart. A composite partition key on (tenant, region) reads "(PK1)" and
+// "(PK2)", because the order is part of the key and cannot be read off the
+// column order on screen. A key with one partition column reads "(PK)", since
+// a number there says nothing.
+func (k KeyColumns) Marker(name string) string {
+	info, ok := k[name]
+	if !ok {
+		return ""
+	}
+
+	var label string
+	switch info.Kind {
+	case "partition_key":
+		label = "PK"
+	case "clustering":
+		label = "C"
+	default:
+		return ""
+	}
+
+	if k.count(info.Kind) > 1 {
+		// system_schema counts components from zero; people count from one.
+		return fmt.Sprintf(" (%s%d)", label, info.Position+1)
+	}
+	return " (" + label + ")"
+}
+
+// count is how many columns are of a kind.
+func (k KeyColumns) count(kind string) int {
+	n := 0
+	for _, info := range k {
+		if info.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// keyMarker matches a marker at the end of a header: (PK), (C), or either with
+// a component number.
+var keyMarker = regexp.MustCompile(`\s+\((?:PK|C)\d*\)$`)
+
+// StripKeyMarker removes the key marker from a header, leaving the column name
+// as Cassandra knows it.
+//
+// Anything writing a column name back out - a CSV header, a Parquet field, a
+// capture file, a COPY - goes through here, so an export can be read back in.
+func StripKeyMarker(header string) string {
+	return keyMarker.ReplaceAllString(header, "")
+}
+
+// StripKeyMarkers removes the markers from a row of headers.
+func StripKeyMarkers(headers []string) []string {
+	clean := make([]string, len(headers))
+	for i, header := range headers {
+		clean[i] = StripKeyMarker(header)
+	}
+	return clean
+}
+
+// fromClause picks the keyspace and table out of a SELECT. Either part may be
+// quoted, which is how a name keeps its capitals in Cassandra.
+var fromClause = regexp.MustCompile(`(?i)FROM\s+(?:("[^"]+"|[a-zA-Z_][a-zA-Z0-9_]*)\.)?("[^"]+"|[a-zA-Z_][a-zA-Z0-9_]*)`)
+
+// cqlIdentifier resolves a name the way Cassandra does.
+//
+// An unquoted name is folded to lower case, so SELECT * FROM Users is the table
+// "users"; a quoted one keeps exactly the case it was created with. Looking the
+// name up as it was typed meant a mixed-case query found nothing in
+// system_schema, and the markers quietly did not appear.
+func cqlIdentifier(name string) string {
+	if len(name) >= 2 && name[0] == '"' && name[len(name)-1] == '"' {
+		return name[1 : len(name)-1]
+	}
+	return strings.ToLower(name)
+}

--- a/internal/db/key_columns_test.go
+++ b/internal/db/key_columns_test.go
@@ -1,0 +1,161 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestASingleComponentKeyIsNotNumbered: a number on a key with one component
+// says nothing.
+func TestASingleComponentKeyIsNotNumbered(t *testing.T) {
+	keys := KeyColumns{
+		"id":      {Kind: "partition_key", Position: 0},
+		"created": {Kind: "clustering", Position: 0},
+	}
+
+	assert.Equal(t, " (PK)", keys.Marker("id"))
+	assert.Equal(t, " (C)", keys.Marker("created"))
+}
+
+// TestACompositePartitionKeyShowsItsOrder.
+//
+// The order of the components is part of the key, and the column order on
+// screen need not match it, so it cannot be read off the display.
+func TestACompositePartitionKeyShowsItsOrder(t *testing.T) {
+	keys := KeyColumns{
+		"tenant": {Kind: "partition_key", Position: 0},
+		"region": {Kind: "partition_key", Position: 1},
+	}
+
+	assert.Equal(t, " (PK1)", keys.Marker("tenant"))
+	assert.Equal(t, " (PK2)", keys.Marker("region"))
+}
+
+// TestSeveralClusteringColumnsShowTheirOrder, which is the sort order.
+func TestSeveralClusteringColumnsShowTheirOrder(t *testing.T) {
+	keys := KeyColumns{
+		"created": {Kind: "clustering", Position: 0},
+		"id":      {Kind: "clustering", Position: 1},
+	}
+
+	assert.Equal(t, " (C1)", keys.Marker("created"))
+	assert.Equal(t, " (C2)", keys.Marker("id"))
+}
+
+// TestTheTwoKindsAreCountedSeparately: one partition column and two clustering
+// columns means (PK) and (C1)/(C2), not (PK1).
+func TestTheTwoKindsAreCountedSeparately(t *testing.T) {
+	keys := KeyColumns{
+		"id":      {Kind: "partition_key", Position: 0},
+		"created": {Kind: "clustering", Position: 0},
+		"seq":     {Kind: "clustering", Position: 1},
+	}
+
+	assert.Equal(t, " (PK)", keys.Marker("id"))
+	assert.Equal(t, " (C1)", keys.Marker("created"))
+	assert.Equal(t, " (C2)", keys.Marker("seq"))
+}
+
+func TestAColumnOutsideTheKeyGetsNoMarker(t *testing.T) {
+	keys := KeyColumns{"id": {Kind: "partition_key", Position: 0}}
+
+	assert.Empty(t, keys.Marker("email"))
+	assert.Empty(t, KeyColumns{}.Marker("id"))
+	assert.Empty(t, keys.Marker(""))
+}
+
+// TestRegularColumnsAreNotMarked: system_schema also lists "regular" and
+// "static" columns, which are not part of the key.
+func TestRegularColumnsAreNotMarked(t *testing.T) {
+	keys := KeyColumns{
+		"id":    {Kind: "partition_key", Position: 0},
+		"email": {Kind: "regular", Position: -1},
+		"count": {Kind: "static", Position: -1},
+	}
+
+	assert.Equal(t, " (PK)", keys.Marker("id"))
+	assert.Empty(t, keys.Marker("email"))
+	assert.Empty(t, keys.Marker("count"))
+}
+
+// TestEveryMarkerCanBeStrippedAgain is what keeps exports readable: a CSV
+// written with markers has to be importable, so whatever Marker produces
+// StripKeyMarker has to remove.
+func TestEveryMarkerCanBeStrippedAgain(t *testing.T) {
+	for _, keys := range []KeyColumns{
+		{"id": {Kind: "partition_key", Position: 0}},
+		{"a": {Kind: "partition_key", Position: 0}, "b": {Kind: "partition_key", Position: 1}},
+		{"a": {Kind: "clustering", Position: 0}, "b": {Kind: "clustering", Position: 1}},
+		{"a": {Kind: "partition_key", Position: 0}, "b": {Kind: "clustering", Position: 0}},
+	} {
+		for name := range keys {
+			header := name + keys.Marker(name)
+			assert.Equal(t, name, StripKeyMarker(header), "could not strip %q", header)
+		}
+	}
+}
+
+// TestStrippingLeavesEverythingElseAlone.
+func TestStrippingLeavesEverythingElseAlone(t *testing.T) {
+	for _, header := range []string{
+		"id",
+		"",
+		"pk",                  // not a marker
+		"my (PK) column",      // not at the end
+		"weird(PK)",           // no space before it
+		"comment (see notes)", // parentheses, but not a marker
+	} {
+		assert.Equal(t, header, StripKeyMarker(header))
+	}
+}
+
+// TestStrippingHandlesTheOldMarkers, so a CSV exported before this change can
+// still be read back.
+func TestStrippingHandlesTheOldMarkers(t *testing.T) {
+	assert.Equal(t, "id", StripKeyMarker("id (PK)"))
+	assert.Equal(t, "created", StripKeyMarker("created (C)"))
+}
+
+func TestStrippingARowOfHeaders(t *testing.T) {
+	got := StripKeyMarkers([]string{"tenant (PK1)", "region (PK2)", "created (C)", "email"})
+
+	assert.Equal(t, []string{"tenant", "region", "created", "email"}, got)
+	assert.Empty(t, StripKeyMarkers(nil))
+}
+
+// TestTheTableComesOutOfTheQuery covers what GetKeyColumns has to recognise
+// before it can look anything up.
+func TestTheTableComesOutOfTheQuery(t *testing.T) {
+	tests := []struct{ query, keyspace, table string }{
+		{"SELECT * FROM users", "", "users"},
+		{"SELECT * FROM myks.users", "myks", "users"},
+		{"select id from myks.users where id = 1", "myks", "users"},
+		{"SELECT * FROM  myks.users ;", "myks", "users"},
+
+		// Unquoted names are folded, the way Cassandra folds them.
+		{"SELECT * FROM Users", "", "users"},
+		{"SELECT * FROM MyKS.Users", "myks", "users"},
+
+		// Quoted names keep the case they were created with.
+		{`SELECT * FROM "MyTable"`, "", "MyTable"},
+		{`SELECT * FROM "MyKS"."MyTable"`, "MyKS", "MyTable"},
+		{`SELECT * FROM myks."MyTable"`, "myks", "MyTable"},
+	}
+
+	for _, tt := range tests {
+		matches := fromClause.FindStringSubmatch(tt.query)
+		if !assert.Len(t, matches, 3, "no FROM clause found in %q", tt.query) {
+			continue
+		}
+		assert.Equal(t, tt.keyspace, cqlIdentifier(matches[1]), "keyspace of %q", tt.query)
+		assert.Equal(t, tt.table, cqlIdentifier(matches[2]), "table of %q", tt.query)
+	}
+}
+
+// TestQueriesWithNoTableAreIgnored rather than looking up nonsense.
+func TestQueriesWithNoTableAreIgnored(t *testing.T) {
+	for _, query := range []string{"SELECT 1", "", "DESCRIBE KEYSPACES"} {
+		assert.Nil(t, fromClause.FindStringSubmatch(query), "%q has no FROM", query)
+	}
+}

--- a/internal/router/capture.go
+++ b/internal/router/capture.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
 )
@@ -413,20 +414,8 @@ func (h *MetaCommandHandler) WriteCaptureResultWithTypes(command string, headers
 		// Create partitioned writer if not exists
 		if h.partitionedWriter == nil {
 			logger.DebugfToFile("WriteCaptureResultWithTypes", "Creating partitioned writer for path: %s", h.captureFile)
-			// Clean column names for Parquet - remove (PK) and (C) suffixes
-			cleanHeaders := make([]string, len(headers))
-			for i, header := range headers {
-				// Remove (PK) suffix
-				if idx := strings.Index(header, " (PK)"); idx != -1 {
-					cleanHeaders[i] = header[:idx]
-				} else if idx := strings.Index(header, " (C)"); idx != -1 {
-					// Remove (C) suffix
-					cleanHeaders[i] = header[:idx]
-				} else {
-					// No suffix to remove
-					cleanHeaders[i] = header
-				}
-			}
+			// Parquet wants the column names Cassandra knows.
+			cleanHeaders := db.StripKeyMarkers(headers)
 
 			// Parse options for compression and file size
 			compressionStr := ""

--- a/internal/router/copy.go
+++ b/internal/router/copy.go
@@ -446,20 +446,11 @@ func (h *MetaCommandHandler) handleCopyFrom(command string) interface{} {
 		if err != nil {
 			return fmt.Sprintf("Error reading header: %v", err)
 		}
-		// Clean column names - remove (PK) and (C) suffixes that may be present
-		// from COPY TO exports with HEADER=TRUE
+		// A COPY TO export with HEADER=TRUE carries the key markers, so strip
+		// them to get back to the column names Cassandra knows.
 		headerColumns = make([]string, len(headerRow))
 		for i, col := range headerRow {
-			cleanCol := strings.TrimSpace(col)
-			// Remove (PK) suffix for primary key columns
-			if idx := strings.Index(cleanCol, " (PK)"); idx != -1 {
-				cleanCol = cleanCol[:idx]
-			}
-			// Remove (C) suffix for clustering columns
-			if idx := strings.Index(cleanCol, " (C)"); idx != -1 {
-				cleanCol = cleanCol[:idx]
-			}
-			headerColumns[i] = strings.TrimSpace(cleanCol)
+			headerColumns[i] = strings.TrimSpace(db.StripKeyMarker(strings.TrimSpace(col)))
 		}
 	}
 

--- a/internal/router/copy_parquet.go
+++ b/internal/router/copy_parquet.go
@@ -82,14 +82,8 @@ func (h *MetaCommandHandler) executeCopyToParquet(table string, columns []string
 		cleanHeaders := make([]string, len(headers))
 
 		for i, header := range headers {
-			// Clean header for Parquet
-			if idx := strings.Index(header, " (PK)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else if idx := strings.Index(header, " (C)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else {
-				cleanHeaders[i] = header
-			}
+			// Parquet wants the column name Cassandra knows.
+			cleanHeaders[i] = db.StripKeyMarker(header)
 		}
 
 		// Set up Parquet writer options with optimizations
@@ -182,14 +176,8 @@ func (h *MetaCommandHandler) executeCopyToParquet(table string, columns []string
 		headers := v.Headers
 		cleanHeaders := make([]string, len(headers))
 		for i, header := range headers {
-			// Clean header for Parquet
-			if idx := strings.Index(header, " (PK)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else if idx := strings.Index(header, " (C)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else {
-				cleanHeaders[i] = header
-			}
+			// Parquet wants the column name Cassandra knows.
+			cleanHeaders[i] = db.StripKeyMarker(header)
 		}
 
 		// Set up Parquet writer options

--- a/internal/router/copy_parquet_partitioned.go
+++ b/internal/router/copy_parquet_partitioned.go
@@ -63,13 +63,7 @@ func (h *MetaCommandHandler) executeCopyToParquetPartitioned(table string, colum
 		// Clean headers
 		cleanHeaders := make([]string, len(v.Headers))
 		for i, header := range v.Headers {
-			if idx := strings.Index(header, " (PK)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else if idx := strings.Index(header, " (C)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else {
-				cleanHeaders[i] = header
-			}
+			cleanHeaders[i] = db.StripKeyMarker(header)
 		}
 
 		// Create compression option
@@ -176,13 +170,7 @@ func (h *MetaCommandHandler) executeCopyToParquetPartitioned(table string, colum
 		// Clean headers
 		cleanHeaders := make([]string, len(v.Headers))
 		for i, header := range v.Headers {
-			if idx := strings.Index(header, " (PK)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else if idx := strings.Index(header, " (C)"); idx != -1 {
-				cleanHeaders[i] = header[:idx]
-			} else {
-				cleanHeaders[i] = header
-			}
+			cleanHeaders[i] = db.StripKeyMarker(header)
 		}
 
 		// Create compression option

--- a/internal/router/save_command.go
+++ b/internal/router/save_command.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 )
 
@@ -269,8 +270,7 @@ func exportToCSV(filename string, data [][]string, options map[string]interface{
 			cleanCell := stripAnsi(cell)
 			// For header row, remove (PK) and (C) indicators
 			if i == 0 {
-				cleanCell = strings.TrimSuffix(cleanCell, " (PK)")
-				cleanCell = strings.TrimSuffix(cleanCell, " (C)")
+				cleanCell = db.StripKeyMarker(cleanCell)
 			}
 			cleanRow[j] = cleanCell
 		}
@@ -331,13 +331,10 @@ func exportToJSON(filename string, data [][]string, options map[string]interface
 	headers := data[0]
 	rows := data[1:]
 
-	// Clean headers - remove (PK) and (C) indicators
+	// Clean headers - the key markers are for the screen, not for a file.
 	cleanHeaders := make([]string, len(headers))
 	for i, header := range headers {
-		cleanHeader := stripAnsi(header)
-		cleanHeader = strings.TrimSuffix(cleanHeader, " (PK)")
-		cleanHeader = strings.TrimSuffix(cleanHeader, " (C)")
-		cleanHeaders[i] = cleanHeader
+		cleanHeaders[i] = db.StripKeyMarker(stripAnsi(header))
 	}
 
 	// Convert to array of objects
@@ -380,10 +377,8 @@ func exportToASCII(filename string, data [][]string, options map[string]interfac
 	for rowIdx, row := range data {
 		for i, cell := range row {
 			cleanCell := stripAnsi(cell)
-			// For headers, remove (PK) and (C) before calculating width
 			if rowIdx == 0 {
-				cleanCell = strings.TrimSuffix(cleanCell, " (PK)")
-				cleanCell = strings.TrimSuffix(cleanCell, " (C)")
+				cleanCell = db.StripKeyMarker(cleanCell)
 			}
 			cellWidth := len(cleanCell)
 			if cellWidth > colWidths[i] {
@@ -405,10 +400,7 @@ func exportToASCII(filename string, data [][]string, options map[string]interfac
 	if len(data) > 0 {
 		output.WriteString("|")
 		for i, header := range data[0] {
-			// Clean header - remove ANSI and (PK)/(C) indicators
-			cleanHeader := stripAnsi(header)
-			cleanHeader = strings.TrimSuffix(cleanHeader, " (PK)")
-			cleanHeader = strings.TrimSuffix(cleanHeader, " (C)")
+			cleanHeader := db.StripKeyMarker(stripAnsi(header))
 			padding := colWidths[i] - len(cleanHeader)
 			output.WriteString(" " + cleanHeader + strings.Repeat(" ", padding) + " |")
 		}

--- a/internal/ui/keyboard_handler_function_keys.go
+++ b/internal/ui/keyboard_handler_function_keys.go
@@ -6,6 +6,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"github.com/axonops/cqlai/internal/db"
 )
 
 // handleF2 handles F2 key - switch to query/history view
@@ -140,15 +141,8 @@ func (m *MainModel) handleF6() (*MainModel, tea.Cmd) {
 					}
 
 					// Extract base name and key indicator
-					baseName := original
-					keyIndicator := ""
-					if strings.HasSuffix(original, " (PK)") {
-						baseName = strings.TrimSuffix(original, " (PK)")
-						keyIndicator = " (PK)"
-					} else if strings.HasSuffix(original, " (C)") {
-						baseName = strings.TrimSuffix(original, " (C)")
-						keyIndicator = " (C)"
-					}
+					baseName := db.StripKeyMarker(original)
+					keyIndicator := strings.TrimPrefix(original, baseName)
 
 					// Build the new header
 					newHeader := baseName


### PR DESCRIPTION
## They only appeared when the query named the keyspace

```
cqlai> SELECT * FROM myks.users;
 id (PK)  │  created (C)  │  email

cqlai> USE myks;
cqlai> SELECT * FROM users;
 id  │  created  │  email
```

`GetKeyColumns` pulls the table out of the query text and gave up if there was nothing in front of it, with a comment saying the UI ought to track the current keyspace. It does - `s.Keyspace()` returns it, `SetKeyspace` updates it on every `USE`, and the executor already falls back to it a few lines above for UDT lookups. This one function did not.

Nothing removed the markers. They never worked for an unqualified query.

## They did not say what order the key was in

A table keyed on `((tenant, region), created_at, id)`:

```
before:  tenant (PK)    region (PK)    created_at (C)    id (C)
after:   tenant (PK1)   region (PK2)   created_at (C1)   id (C2)
```

That names the key columns but not that `tenant` comes before `region`, or that rows sort by `created_at` then `id`. For a composite partition key the component order is part of the key; for clustering columns it is the sort order. The column order on screen need not match the key order, so it could not be read off the display either.

The position was already being read from `system_schema.columns` and stored, then never read by anything.

The number appears only when there is more than one component to tell apart - a single partition column stays `(PK)`, since a number there says nothing. The two kinds are counted separately, so one partition column and two clustering columns gives `(PK)`, `(C1)`, `(C2)`.

## Two more silent misses found on the way

**A mixed-case table never matched.** `SELECT * FROM Users` looked up `Users` in `system_schema`, which holds `users`. Unquoted names are now folded and quoted names keep their case, the way Cassandra resolves them, so `"MyTable"` works too.

**The markers were written out by hand in nine files that strip them** before writing CSV, Parquet, a capture or a COPY. Numbering them would have broken every one of those exports, quietly - a CSV written with `id (PK1)` and read back by a stripper looking for `" (PK)"` keeps the marker as part of the column name.

There is now one place that builds a marker and one that strips it. A test asserts that whatever `Marker` produces `StripKeyMarker` removes, so an export stays importable. The old `(PK)` and `(C)` still strip, so files exported before this change still read.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: single and composite partition keys, several clustering columns, the two kinds counted separately, columns outside the key, `regular` and `static` columns, every generated marker round-tripping through the stripper, the old markers still stripping, headers that merely contain parentheses being left alone, and the `FROM` clause parsing for qualified, unqualified, mixed-case and quoted names.

Not covered by tests: the `system_schema` lookup itself, which needs a cluster. Checked by hand against a build.
