### PR TITLE
feat(ui): add a Help button and a scrollable help window

### DIFF
--- a/internal/router/meta_commands_help.go
+++ b/internal/router/meta_commands_help.go
@@ -2,7 +2,16 @@ package router
 
 // handleHelp handles HELP command
 func (h *MetaCommandHandler) handleHelp() interface{} {
-	help := [][]string{
+	return HelpRows()
+}
+
+// HelpRows is the help text, as category, command and description.
+//
+// One source, rendered twice: HELP prints it into the console and the Help
+// window on the tab line shows the same rows. Written out twice they would
+// drift, and the one nobody looks at would be the one that goes stale.
+func HelpRows() [][]string {
+	return [][]string{
 		{"Category", "Command", "Description"},
 		{"━━━━━━━━━", "━━━━━━━━", "━━━━━━━━━━━"},
 
@@ -77,7 +86,8 @@ func (h *MetaCommandHandler) handleHelp() interface{} {
 
 		// Keyboard Shortcuts
 		{"─────────", "─────────", "─────────────"},
-		{"Keys", "↑/↓ or Ctrl+P/N", "Navigate command history"},
+		{"Keys", "F1 or Alt+H", "Open this help (F1 is taken by some terminals)"},
+		{"", "↑/↓ or Ctrl+P/N", "Navigate command history"},
 		{"", "Ctrl+R", "Search history"},
 		{"", "Tab", "Auto-complete"},
 		{"", "Ctrl+L", "Clear screen"},
@@ -109,6 +119,4 @@ func (h *MetaCommandHandler) handleHelp() interface{} {
 		{"", "", ""},
 		{"", "Type 'HELP <topic>' for more details", ""},
 	}
-
-	return help
 }

--- a/internal/ui/help_window.go
+++ b/internal/ui/help_window.go
@@ -1,0 +1,196 @@
+package ui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/router"
+)
+
+// The help window, opened by the Help button on the tab line or by F1.
+//
+// HELP already prints the same rows into the console, which works but scrolls
+// away whatever you were looking at to tell you what PAGING does. A window you
+// open, read and close leaves the screen alone.
+//
+// It is not a commandList. That is a list of things to pick one of - it marks a
+// selection and Enter uses it - and there is nothing here to pick. What the two
+// do share is the parts worth sharing: the scrollbar, the padding, and the rule
+// that drawing and hit testing come from one description of the layout.
+
+// helpTitle says how to work the window, including the second key: on the
+// terminals that take F1 for themselves, this is where you find out there is
+// another one.
+const helpTitle = "Help  -  F1 or Alt+H  -  ↑↓ PgUp/PgDn scrolls  -  Esc closes"
+
+// helpMargin is how much screen is left showing around the window, so it reads
+// as something over the top of cqlai rather than a new screen.
+const helpMargin = 4
+
+// helpWindow is the open help, if any. Only the scroll position is state; the
+// rows come from router.HelpRows each time it is drawn.
+type helpWindow struct {
+	active bool
+	scroll int
+}
+
+// helpGeometry is where the window sits and how much of it is showing.
+type helpGeometry struct {
+	x, y          int
+	width, height int
+	rows          int // content rows, inside the border and the title
+	first, last   int // range of help rows drawn, last exclusive
+	innerWidth    int
+}
+
+// helpLines lays the help rows out as one line each, with the columns lined up.
+//
+// The category is only printed when it changes, which is how the console
+// version reads: the rows carry an empty category to mean "same as above".
+func helpLines(rows [][]string) []string {
+	category, command := 0, 0
+	for _, row := range rows {
+		if len(row) < 3 {
+			continue
+		}
+		category = max(category, lipgloss.Width(row[0]))
+		command = max(command, lipgloss.Width(row[1]))
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if len(row) < 3 {
+			continue
+		}
+		lines = append(lines, pad(row[0], category)+"  "+pad(row[1], command)+"  "+row[2])
+	}
+	return lines
+}
+
+// helpGeometry works out where the window sits and which rows it shows.
+//
+// Drawing and scrolling both go through this, so the scrollbar cannot describe
+// a different window from the one on screen.
+func (m *MainModel) helpGeometry(screenWidth, screenHeight int) (helpGeometry, []string, bool) {
+	if !m.help.active {
+		return helpGeometry{}, nil, false
+	}
+
+	lines := helpLines(router.HelpRows())
+	if len(lines) == 0 {
+		return helpGeometry{}, nil, false
+	}
+
+	width := min(screenWidth-helpMargin, longestLine(lines)+4) // borders, scrollbar, padding
+	height := min(screenHeight-helpMargin, len(lines)+3)       // borders and the title
+	if width < 20 || height < 6 {
+		// Too small to be worth drawing over what is already there.
+		return helpGeometry{}, nil, false
+	}
+
+	rows := height - 3
+	first := min(max(m.help.scroll, 0), max(len(lines)-rows, 0))
+
+	return helpGeometry{
+		x:          (screenWidth - width) / 2,
+		y:          (screenHeight - height) / 2,
+		width:      width,
+		height:     height,
+		rows:       rows,
+		first:      first,
+		last:       min(first+rows, len(lines)),
+		innerWidth: width - 2,
+	}, lines, true
+}
+
+// longestLine is the width of the widest line.
+func longestLine(lines []string) int {
+	widest := 0
+	for _, line := range lines {
+		if w := lipgloss.Width(line); w > widest {
+			widest = w
+		}
+	}
+	return widest
+}
+
+// viewHelp renders the window and says where to put it.
+func (m *MainModel) viewHelp(screenWidth, screenHeight int) (Layer, bool) {
+	g, lines, ok := m.helpGeometry(screenWidth, screenHeight)
+	if !ok {
+		return Layer{}, false
+	}
+
+	titleStyle := lipgloss.NewStyle().Foreground(m.styles.Accent).Bold(true)
+	textStyle := lipgloss.NewStyle().Foreground(m.styles.MutedText.GetForeground())
+	thumbStyle := lipgloss.NewStyle().Foreground(m.styles.Accent)
+	trackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
+
+	thumb := scrollbarColumn(g.last-g.first, g.first, len(lines))
+	scrolls := len(lines) > g.rows
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(centre(helpTitle, g.innerWidth)))
+	b.WriteString("\n")
+
+	for i := g.first; i < g.last; i++ {
+		// One column short, so the scrollbar has somewhere to go.
+		b.WriteString(textStyle.Render(pad(" "+lines[i], g.innerWidth-1)))
+
+		switch {
+		case !scrolls:
+			b.WriteString(" ")
+		case thumb[i-g.first]:
+			b.WriteString(thumbStyle.Render("█"))
+		default:
+			b.WriteString(trackStyle.Render("░"))
+		}
+
+		if i < g.last-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.styles.Accent).
+		Render(b.String())
+
+	return Layer{
+		Content: box,
+		X:       g.x,
+		Y:       g.y,
+		Width:   g.width,
+		Height:  g.height,
+		ZIndex:  300, // over everything; it was just asked for
+	}, true
+}
+
+// toggleHelp opens the window, or closes it if it is already open.
+func (m *MainModel) toggleHelp() (*MainModel, tea.Cmd) {
+	if m.help.active {
+		m.help = helpWindow{}
+		return m, nil
+	}
+	m.help = helpWindow{active: true}
+	return m, nil
+}
+
+// scrollHelp moves the window by n rows.
+//
+// The view behind it does not move: the window is what you are reading.
+func (m *MainModel) scrollHelp(n int) (*MainModel, tea.Cmd) {
+	g, lines, ok := m.helpGeometry(m.windowWidth, m.windowHeight)
+	if !ok {
+		return m, nil
+	}
+
+	m.help.scroll = min(max(g.first+n, 0), max(len(lines)-g.rows, 0))
+	return m, nil
+}
+
+// helpPageRows is how far PgUp and PgDn move the help window. A little less
+// than a screenful, so a line or two carries over and you can see where you
+// were.
+const helpPageRows = 15

--- a/internal/ui/help_window_test.go
+++ b/internal/ui/help_window_test.go
@@ -1,0 +1,324 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/router"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func helpModel() *MainModel {
+	return &MainModel{
+		viewMode:        "history",
+		hasTable:        true,
+		hasTrace:        true,
+		styles:          DefaultStyles(),
+		aiConfig:        configuredAI(),
+		mouseEnabled:    true,
+		windowWidth:     100,
+		windowHeight:    30,
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+}
+
+// TestTheHelpButtonIsOnTheTabLine, at the right-hand end.
+func TestTheHelpButtonIsOnTheTabLine(t *testing.T) {
+	m := helpModel()
+
+	assert.Contains(t, stripAnsiForTest(m.ViewTabBar(100)), "Help")
+
+	spans := m.layoutTabs(100)
+	help := spans[len(spans)-1]
+	assert.Equal(t, helpMode, help.mode, "the button should be last")
+	assert.Equal(t, 100, help.end, "and against the right edge")
+}
+
+// TestClickingHelpOpensAndClosesIt.
+func TestClickingHelpOpensAndClosesIt(t *testing.T) {
+	m := helpModel()
+
+	spans := m.layoutTabs(m.windowWidth)
+	help := spans[len(spans)-1]
+	col := (help.start + help.end) / 2
+
+	pressAt(m, col, 0)
+	require.True(t, m.help.active, "clicking Help should open it")
+
+	pressAt(m, col, 0)
+	assert.False(t, m.help.active, "clicking it again should close it")
+}
+
+// TestF1OpensAndClosesIt too, since that is the conventional key and it was
+// unbound.
+func TestF1OpensAndClosesIt(t *testing.T) {
+	m := helpModel()
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyF1})
+	require.True(t, m.help.active)
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyF1})
+	assert.False(t, m.help.active)
+}
+
+// TestEscapeClosesIt.
+func TestEscapeClosesIt(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	assert.False(t, m.help.active)
+}
+
+// TestClickingElsewhereClosesIt: the window covers the screen, so you cannot
+// aim at what is underneath anyway.
+func TestClickingElsewhereClosesIt(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	pressAt(m, 40, 10)
+
+	assert.False(t, m.help.active)
+}
+
+// TestTheContentComesFromTheHelpCommand, so typing HELP and clicking Help
+// cannot drift apart.
+func TestTheContentComesFromTheHelpCommand(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	layer, ok := m.viewHelp(m.windowWidth, m.windowHeight)
+	require.True(t, ok)
+
+	shown := stripAnsiForTest(layer.Content)
+	for _, row := range router.HelpRows()[:12] {
+		if row[1] == "" {
+			continue
+		}
+		assert.Contains(t, shown, row[1], "the window should show the same rows as HELP")
+	}
+}
+
+// TestTheWindowScrolls, and stops at both ends.
+func TestTheWindowScrolls(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	first := func() string {
+		layer, ok := m.viewHelp(m.windowWidth, m.windowHeight)
+		require.True(t, ok)
+		return strings.Split(stripAnsiForTest(layer.Content), "\n")[2]
+	}
+
+	top := first()
+	m.scrollHelp(helpPageRows)
+	assert.NotEqual(t, top, first(), "paging down should have moved it")
+
+	for range 100 {
+		m.scrollHelp(helpPageRows)
+	}
+	bottom := first()
+
+	m.scrollHelp(helpPageRows)
+	assert.Equal(t, bottom, first(), "it should stop at the end")
+
+	for range 100 {
+		m.scrollHelp(-helpPageRows)
+	}
+	assert.Equal(t, top, first(), "and come back to the start")
+	assert.Zero(t, m.help.scroll)
+}
+
+// TestTheWheelScrollsTheWindowNotTheViewBehindIt.
+func TestTheWheelScrollsTheWindowNotTheViewBehindIt(t *testing.T) {
+	m := helpModel()
+	m.historyViewport.SetContent(strings.Repeat("line\n", 200))
+	m.toggleHelp()
+
+	behind := m.historyViewport.YOffset()
+	m.handleMouseInput(tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 50, Y: 15})
+
+	assert.Equal(t, wheelLines, m.help.scroll)
+	assert.Equal(t, behind, m.historyViewport.YOffset(), "the view behind must not have moved")
+}
+
+// TestPageKeysScrollTheWindowNotTheViewBehindIt.
+func TestPageKeysScrollTheWindowNotTheViewBehindIt(t *testing.T) {
+	m := helpModel()
+	m.historyViewport.SetContent(strings.Repeat("line\n", 200))
+	m.toggleHelp()
+
+	behind := m.historyViewport.YOffset()
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyPgDown})
+
+	assert.Equal(t, helpPageRows, m.help.scroll)
+	assert.Equal(t, behind, m.historyViewport.YOffset())
+}
+
+// TestTypingDoesNotReachThePromptWhileHelpIsOpen.
+func TestTypingDoesNotReachThePromptWhileHelpIsOpen(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: 'x', Text: "x"})
+
+	assert.Empty(t, m.input.Value(), "the window is what the keys are aimed at")
+}
+
+// TestTheHelpScrollbarSaysWhereYouAre.
+func TestTheHelpScrollbarSaysWhereYouAre(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	bar := func() string {
+		layer, ok := m.viewHelp(m.windowWidth, m.windowHeight)
+		require.True(t, ok)
+
+		var col []rune
+		rows := strings.Split(stripAnsiForTest(layer.Content), "\n")
+		for _, row := range rows[2 : len(rows)-1] {
+			runes := []rune(row)
+			col = append(col, runes[len(runes)-2])
+		}
+		return string(col)
+	}
+
+	atTop := bar()
+	assert.Equal(t, '█', []rune(atTop)[0], "the thumb starts at the top: %q", atTop)
+
+	for range 100 {
+		m.scrollHelp(helpPageRows)
+	}
+	atBottom := bar()
+	assert.Equal(t, '█', []rune(atBottom)[len([]rune(atBottom))-1],
+		"and reaches the bottom: %q", atBottom)
+}
+
+// TestTheWindowIsSquareAndFitsTheScreen.
+func TestTheWindowIsSquareAndFitsTheScreen(t *testing.T) {
+	for _, size := range [][2]int{{100, 30}, {80, 24}, {200, 60}, {40, 12}} {
+		m := helpModel()
+		m.windowWidth, m.windowHeight = size[0], size[1]
+		m.toggleHelp()
+
+		layer, ok := m.viewHelp(size[0], size[1])
+		if !ok {
+			continue
+		}
+
+		assert.LessOrEqual(t, layer.X+layer.Width, size[0], "%v: too wide", size)
+		assert.LessOrEqual(t, layer.Y+layer.Height, size[1], "%v: too tall", size)
+
+		rows := strings.Split(layer.Content, "\n")
+		assert.Len(t, rows, layer.Height, "%v: wrong number of rows", size)
+		for _, row := range rows {
+			assert.Equal(t, layer.Width, lipgloss.Width(row), "%v: ragged row %q", size, row)
+		}
+	}
+}
+
+// TestATerminalTooSmallGetsNoWindow rather than a box with nothing in it.
+func TestATerminalTooSmallGetsNoWindow(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	_, ok := m.viewHelp(18, 30)
+	assert.False(t, ok, "too narrow")
+
+	_, ok = m.viewHelp(100, 5)
+	assert.False(t, ok, "too short")
+}
+
+// TestTheButtonGivesWayToTheTabNames.
+//
+// Key hints go first, because the keys are in the help the button opens. The
+// names do not: single letters are harder to read than a line with no button,
+// and F1 still opens it.
+func TestTheButtonGivesWayToTheTabNames(t *testing.T) {
+	m := helpModel()
+
+	wide := stripAnsiForTest(m.ViewTabBar(100))
+	assert.Contains(t, wide, "Console (F2)")
+	assert.Contains(t, wide, "Help")
+
+	// Room for the names and the button, but not the key hints.
+	medium := stripAnsiForTest(m.ViewTabBar(60))
+	assert.Contains(t, medium, "Console")
+	assert.NotContains(t, medium, "(F2)")
+	assert.Contains(t, medium, "Help")
+
+	// Room for the names only. The button goes rather than the names.
+	tight := stripAnsiForTest(m.ViewTabBar(44))
+	assert.Contains(t, tight, "Console")
+	assert.NotContains(t, tight, "Help")
+}
+
+// TestTheTabLineNeverWrapsWithTheButtonOnIt, at any width.
+func TestTheTabLineNeverWrapsWithTheButtonOnIt(t *testing.T) {
+	m := helpModel()
+
+	for width := 1; width <= 200; width++ {
+		bar := m.ViewTabBar(width)
+		assert.NotContains(t, bar, "\n", "wrapped at width %d", width)
+
+		plain := stripAnsiForTest(bar)
+		assert.LessOrEqual(t, len([]rune(strings.TrimRight(plain, " "))), width,
+			"overflowed at width %d: %q", width, plain)
+	}
+}
+
+// TestTheButtonNeverSitsOnATab: a click has to land on what was drawn.
+func TestTheButtonNeverSitsOnATab(t *testing.T) {
+	m := helpModel()
+
+	for width := 1; width <= 200; width++ {
+		spans := m.layoutTabs(width)
+		for i := 1; i < len(spans); i++ {
+			assert.GreaterOrEqual(t, spans[i].start, spans[i-1].end,
+				"width %d: %q overlaps %q", width, spans[i].mode, spans[i-1].mode)
+		}
+	}
+}
+
+// TestAltHOpensItToo. Terminator, Konsole and others take F1 for their own
+// help before the application sees it, so F1 cannot be the only key.
+func TestAltHOpensItToo(t *testing.T) {
+	m := helpModel()
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: 'h', Mod: tea.ModAlt})
+	require.True(t, m.help.active, "Alt+H should open the help")
+
+	m.handleKeyboardInput(tea.KeyPressMsg{Code: 'h', Mod: tea.ModAlt})
+	assert.False(t, m.help.active, "and close it again")
+}
+
+// TestTheWindowNamesBothKeys, because on a terminal that takes F1 this is
+// where you find out there is another one.
+func TestTheWindowNamesBothKeys(t *testing.T) {
+	m := helpModel()
+	m.toggleHelp()
+
+	layer, ok := m.viewHelp(m.windowWidth, m.windowHeight)
+	require.True(t, ok)
+
+	shown := stripAnsiForTest(layer.Content)
+	assert.Contains(t, shown, "F1")
+	assert.Contains(t, shown, "Alt+H")
+}
+
+// TestTheHelpRowsNameBothKeys, so HELP says it as well.
+func TestTheHelpRowsNameBothKeys(t *testing.T) {
+	var found bool
+	for _, row := range router.HelpRows() {
+		if strings.Contains(row[1], "Alt+H") {
+			found = true
+		}
+	}
+	assert.True(t, found, "the help text should say how to open the help")
+}

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -5,10 +5,33 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/axonops/cqlai/internal/logger"
+	"github.com/axonops/cqlai/internal/router"
 )
 
 // handleKeyboardInput handles keyboard input events
 func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
+	// The help window takes the keys while it is open: it is over everything
+	// else, so it is what a keypress is aimed at.
+	if m.help.active {
+		switch msg.String() {
+		case "esc", "f1", "alt+h", "q":
+			return m.toggleHelp()
+		case "up":
+			return m.scrollHelp(-1)
+		case "down":
+			return m.scrollHelp(1)
+		case "pgup":
+			return m.scrollHelp(-helpPageRows)
+		case "pgdown":
+			return m.scrollHelp(helpPageRows)
+		case "home":
+			return m.scrollHelp(-len(router.HelpRows()))
+		case "end":
+			return m.scrollHelp(len(router.HelpRows()))
+		}
+		return m, nil
+	}
+
 	// Any keypress drops the mouse selection: whatever happens next is likely
 	// to move or replace the text under it, and a highlight left behind on
 	// different text is worse than no highlight. Escape does nothing else, so
@@ -108,6 +131,12 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 
 	case "f4":
 		return m.handleF4()
+
+	// Alt+H as well as F1: Terminator, Konsole and others take F1 for their
+	// own help before an application ever sees it, so a key that only works on
+	// some terminals cannot be the only one.
+	case "f1", "alt+h":
+		return m.toggleHelp()
 
 	case "f5":
 		return m.handleF5()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -119,6 +119,7 @@ type MainModel struct {
 	navigationMode     bool           // Toggle between navigation keys and input mode
 	mouseEnabled       bool           // Whether to ask the terminal for mouse reporting
 	chooser            settingChooser // Open list of values for a status bar setting
+	help               helpWindow     // Open help window, if any
 	selection          textSelection  // Text being dragged out with the mouse, if any
 	viewMode           string         // "history", "table", "trace", or "ai_info"
 	showDataTypes      bool           // Whether to show column data types in table headers

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -38,6 +38,17 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 		return m.endSelection()
 
 	case tea.MouseWheelMsg:
+		// The help window is over everything, so it has the wheel first.
+		if m.help.active {
+			switch mouse.Button {
+			case tea.MouseWheelUp:
+				return m.scrollHelp(-wheelLines)
+			case tea.MouseWheelDown:
+				return m.scrollHelp(wheelLines)
+			}
+			return m, nil
+		}
+
 		// The command list has the wheel while it is open, for the same reason
 		// the settings lists do: otherwise it goes to the view behind and a
 		// list longer than the box cannot be got through.
@@ -74,6 +85,16 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 	// A press anywhere drops whatever was selected.
 	m.clearSelection()
+
+	// With the help open, a press dismisses it rather than acting on whatever
+	// is underneath - which you cannot see to aim at.
+	if m.help.active {
+		if mode, _ := m.modeAt(m.windowWidth, mouse.X); mouse.Y == 0 && mode == helpMode {
+			return m.toggleHelp()
+		}
+		m.help = helpWindow{}
+		return m, nil
+	}
 
 	// A press inside the open list picks that value.
 	if m.chooser.active {
@@ -342,6 +363,10 @@ func (m *MainModel) clickTab(col int) (*MainModel, tea.Cmd) {
 	}
 
 	logger.DebugfToFile("Mouse", "Tab clicked at column %d: switching to %s", col, mode)
+
+	if mode == helpMode {
+		return m.toggleHelp()
+	}
 
 	switch mode {
 	case "history":

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -75,10 +75,11 @@ func (m *MainModel) aiAvailable() bool {
 	return ai.IsConfigured(m.aiConfig)
 }
 
-// tabText renders the tab labels at one of three widths. The bar must never
-// wrap onto a second line, so it drops the key hints and then shortens the
-// names before anything is left out.
-func tabText(tabs []modeTab, width int) []string {
+// tabLabelTiers renders the tab labels at three widths, widest first.
+//
+// The bar must never wrap onto a second line, so it drops the key hints and
+// then shortens the names before anything is left out.
+func tabLabelTiers(tabs []modeTab) [][]string {
 	full := make([]string, len(tabs))
 	plain := make([]string, len(tabs))
 	short := make([]string, len(tabs))
@@ -89,13 +90,30 @@ func tabText(tabs []modeTab, width int) []string {
 		// indistinguishable letters is worse than no bar.
 		short[i] = t.short
 	}
+	return [][]string{full, plain, short}
+}
 
-	for _, candidate := range [][]string{full, plain, short} {
-		if tabBarWidth(candidate) <= width {
-			return candidate
+// fitTabs picks the labels to draw and whether the Help button fits beside
+// them.
+//
+// The order says what is worth giving up first. Key hints go before the button,
+// because the keys are also in the help the button opens. The names do not: a
+// bar of single letters is harder to read than a line with no button on it, and
+// F1 still opens the help either way.
+func fitTabs(tabs []modeTab, width int) ([]string, bool) {
+	tiers := tabLabelTiers(tabs)
+
+	for i, labels := range tiers {
+		if tabBarWidth(labels) <= width-helpReserve {
+			return labels, true
+		}
+		// Names survive at the button's expense; the first tier, which is
+		// names plus key hints, does not.
+		if i > 0 && tabBarWidth(labels) <= width {
+			return labels, false
 		}
 	}
-	return short
+	return tiers[len(tiers)-1], tabBarWidth(tiers[len(tiers)-1]) <= width-helpReserve
 }
 
 // tabSeparator sits between tabs; the padding is part of each tab's click area.
@@ -130,7 +148,7 @@ func (m *MainModel) layoutTabs(width int) []tabSpan {
 	}
 
 	tabs := m.visibleTabs()
-	labels := tabText(tabs, width)
+	labels, withHelp := fitTabs(tabs, width)
 
 	spans := make([]tabSpan, 0, len(tabs))
 	col := 0
@@ -154,7 +172,42 @@ func (m *MainModel) layoutTabs(width int) []tabSpan {
 		})
 		col = end
 	}
+
+	if withHelp {
+		if help, ok := helpSpan(width, col); ok {
+			spans = append(spans, help)
+		}
+	}
 	return spans
+}
+
+// helpReserve is the room the Help button wants: its longest label plus the
+// space either side of it.
+var helpReserve = lipgloss.Width(" Help (F1) ")
+
+// helpMode is the pseudo-mode the Help button reports. It is not a view: it
+// opens a window over whichever view you are in and leaves it there.
+const helpMode = "help"
+
+// helpSpan is where the Help button sits, at the right-hand end of the line.
+//
+// It shortens before it disappears, and it disappears before it would sit on
+// top of a tab: losing the button is better than a line where a click lands on
+// whatever happens to be underneath it.
+func helpSpan(width, tabsEnd int) (tabSpan, bool) {
+	for _, label := range []string{"Help (F1)", "Help", "?"} {
+		start := width - lipgloss.Width(label) - 2
+		if start > tabsEnd {
+			return tabSpan{
+				mode:      helpMode,
+				label:     label,
+				start:     start,
+				end:       width,
+				available: true,
+			}, true
+		}
+	}
+	return tabSpan{}, false
 }
 
 // modeAt returns the mode whose tab covers a column, and whether it can be
@@ -190,8 +243,14 @@ func (m *MainModel) ViewTabBar(width int) string {
 		Foreground(lipgloss.Color("#3a3a3a"))
 
 	var b strings.Builder
+	col := 0
 	for i, span := range spans {
-		if i > 0 {
+		// The Help button is placed against the right edge rather than after
+		// the tab before it, so pad out to wherever it starts.
+		switch {
+		case span.mode == helpMode:
+			b.WriteString(strings.Repeat(" ", max(span.start-col, 0)))
+		case i > 0:
 			b.WriteString(separatorStyle.Render(tabSeparator))
 		}
 
@@ -204,11 +263,12 @@ func (m *MainModel) ViewTabBar(width int) string {
 		default:
 			b.WriteString(unavailableStyle.Render(text))
 		}
+		col = span.end
 	}
 
 	// Pad by hand rather than with lipgloss Width, which wraps instead of
 	// truncating when the content is wider than the line.
-	if pad := width - spans[len(spans)-1].end; pad > 0 {
+	if pad := width - col; pad > 0 {
 		b.WriteString(strings.Repeat(" ", pad))
 	}
 

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// modeSpans is the tabs that switch view, without the Help button.
+func modeSpans(spans []tabSpan) []tabSpan {
+	tabs := make([]tabSpan, 0, len(spans))
+	for _, span := range spans {
+		if span.mode != helpMode {
+			tabs = append(tabs, span)
+		}
+	}
+	return tabs
+}
+
 // configuredAI is an AI setup good enough to count as configured, so the
 // layout tests get all four tabs.
 func configuredAI() *config.AIConfig {
@@ -132,7 +143,7 @@ func TestModeAtMapsClicksToTabs(t *testing.T) {
 	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI()}
 
 	spans := m.layoutTabs(width)
-	require.Len(t, spans, 4)
+	require.Len(t, modeSpans(spans), 4)
 
 	for _, span := range spans {
 		for _, col := range []int{span.start, (span.start + span.end) / 2, span.end - 1} {
@@ -142,8 +153,9 @@ func TestModeAtMapsClicksToTabs(t *testing.T) {
 		}
 	}
 
-	// Past the last tab there is nothing to click.
-	_, ok := m.modeAt(width, spans[len(spans)-1].end+1)
+	// Between the last tab and the Help button there is nothing to click.
+	tabs := modeSpans(spans)
+	_, ok := m.modeAt(width, tabs[len(tabs)-1].end+1)
 	assert.False(t, ok)
 
 	// Spans do not overlap and are in display order.
@@ -350,7 +362,7 @@ func TestTheHiddenTabTakesNoColumns(t *testing.T) {
 	const width = 120
 	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true}
 
-	spans := m.layoutTabs(width)
+	spans := modeSpans(m.layoutTabs(width))
 	require.Len(t, spans, 3)
 
 	for _, span := range spans {

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -391,6 +391,12 @@ func (m *MainModel) View() tea.View {
 		layerManager.AddLayer(layer)
 	}
 
+	// The help window is drawn over everything, including the modals: it was
+	// just asked for, so it is what you are looking at.
+	if layer, ok := m.viewHelp(screenWidth, screenHeight); ok {
+		layerManager.AddLayer(layer)
+	}
+
 	finalView = layerManager.Render(finalView)
 
 	// If modal is showing, render it as an overlay


### PR DESCRIPTION
A `Help` button at the right-hand end of the tab line, and a window of the help text over whatever you were looking at.

```
 Console (F2)   Results (F3)   Trace (F4)   AI (F5)                    Help (F1)

╭──────────────────────────────────────────────────────────────────────────────╮
│         Help  -  F1 or Alt+H  -  ↑↓ PgUp/PgDn scrolls  -  Esc closes         │
│ Category   Command                    Description                           █│
│ ━━━━━━━━━  ━━━━━━━━                   ━━━━━━━━━━━                           █│
│ CQL        SELECT ...                 Query data from tables                █│
│            INSERT ...                 Insert data into tables               ░│
│            UPDATE ...                 Update existing data                  ░│
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Why not just type HELP

`HELP` already prints the same rows into the console. That works, but it scrolls your query output away to tell you what `PAGING` does, and then you have to scroll back. A window you open, read and close leaves the screen alone.

It also gives the F-keys somewhere to be documented that people will find. Until now the only way to learn that `F6` toggles data types was to read the README.

## One source

The content comes from `HelpRows`, which `HELP` also prints, so the two cannot drift. Same lesson as the consistency levels and the output formats: a list written out twice goes stale in the copy nobody looks at.

## Opening and closing

The button, `F1`, or `Alt+H`. Closes by any of those, by `Esc`, or by a click anywhere - the window covers what is underneath, so there is nothing there to aim at.

**Two keys because F1 is not reliable.** Terminator, Konsole and others take it for their own help before an application ever sees it. Both keys are named in the window title and in the help text, so on a terminal that takes `F1` there is somewhere to find out about the other one.

## Scrolling

The wheel, `PgUp`/`PgDn`, the arrows and `Home`/`End`, with a scrollbar saying how much is showing and where you are. Neither the wheel nor the keys reach the view behind it.

## Not a commandList

`commandList` is a list of things to pick one of - it marks a selection and Enter uses it - and there is nothing in the help to pick. The parts worth sharing are shared: the scrollbar, the padding, and the rule that drawing and hit testing come from one description of the layout.

## Narrowing

The button gives way in an order that says what is worth losing first:

```
100: [ Console (F2)   Results (F3)   Trace (F4)   AI (F5)          Help (F1) ]
 60: [ Console   Results   Trace   AI                              Help (F1) ]
 44: [ Console   Results   Trace   AI                                        ]
 30: [ C   R   T   A                                               Help (F1) ]
 20: [ C   R   T   A                                                         ]
```

Key hints go before the button, because those keys are in the help the button opens. The names do not: a bar of single letters is harder to read than a line with no button on it, and `F1` still opens it either way.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: the button's position, opening and closing by click, `F1`, `Alt+H`, `Esc` and a click elsewhere; the content matching `HelpRows`; scrolling stopping at both ends; the wheel and page keys not reaching the view behind; typing not reaching the prompt; the scrollbar at top and bottom; the window fitting inside four screen sizes with no ragged rows; a terminal too small getting no window at all; the narrowing order; the line never wrapping at any width from 1 to 200; and the button never overlapping a tab at any width.

Closes #120
