### PR TITLE
fix: row counts, sideways scrolling, and PAGING

### DIFF
--- a/internal/db/executor.go
+++ b/internal/db/executor.go
@@ -500,7 +500,6 @@ func (s *Session) ExecuteSelectQuery(query string) interface{} {
 	rawData := make([]map[string]interface{}, 0)
 
 	logger.DebugToFile("executeSelectQuery", "Starting row scan with MapScan...")
-	rowNum := 0
 
 	// Extract clean column names (without PK/C indicators)
 	cleanHeaders := make([]string, len(filteredColumns))
@@ -508,164 +507,38 @@ func (s *Session) ExecuteSelectQuery(query string) interface{} {
 		cleanHeaders[i] = col.Name
 	}
 
-	// Use MapScan for all tables to safely handle NULL values
-	// gocql can panic when scanning NULLs into interface{} with regular Scan()
-	// MapScan handles NULLs gracefully by omitting them from the map
-	if true { // Always use MapScan for safety
-		virtualResults := make([][]string, 0)
-		for {
-			rowMap := make(map[string]interface{})
-			if !iter.MapScan(rowMap) {
-				break
-			}
-
-			// Convert map to row array in column order
-			row := make([]string, len(filteredColumns))
-			rawRow := make(map[string]interface{})
-
-			for i, col := range filteredColumns {
-				val, exists := rowMap[col.Name]
-				if !exists {
-					val = nil
-				}
-				rawRow[col.Name] = val
-				row[i] = FormatValue(val)
-			}
-
-			virtualResults = append(virtualResults, row)
-			rawData = append(rawData, rawRow)
+	// MapScan for every table: scanning a NULL into an interface{} with Scan
+	// panics, and MapScan leaves the key out of the map instead.
+	scanned := make([][]string, 0)
+	for {
+		rowMap := make(map[string]interface{})
+		if !iter.MapScan(rowMap) {
+			break
 		}
-		results = append(results, virtualResults...)
-	} else {
-		// Use Scan with interface{} slice for regular tables to get raw bytes for UDTs
-		// MapScan returns empty maps for UDTs, but we need to use RawBytes for UDT columns
-		for {
-			// Create a slice to scan into - use RawBytes for UDT columns
-			scanDest := make([]interface{}, len(filteredColumns))
-			for i, col := range filteredColumns {
-				// TypeInfo can be non-nil but internally invalid on virtual
-				// tables, where Type() panics; fall back to a plain destination.
-				func(idx int, info gocql.TypeInfo) {
-					defer func() {
-						if r := recover(); r != nil {
-							scanDest[idx] = new(interface{})
-						}
-					}()
-					scanDest[idx] = NewScanDest(info)
-				}(i, col.TypeInfo)
+
+		// Convert map to row array in column order
+		row := make([]string, len(filteredColumns))
+		rawRow := make(map[string]interface{})
+
+		for i, col := range filteredColumns {
+			val, exists := rowMap[col.Name]
+			if !exists {
+				val = nil
 			}
-
-			// Scan the row
-			if !iter.Scan(scanDest...) {
-				logger.DebugToFile("executeSelectQuery", "Scan returned false - no more rows or error")
-				break
-			}
-
-			// Store raw data for JSON export (preserves types)
-			rawRow := make(map[string]interface{})
-			// Create formatted row for display
-			row := make([]string, len(filteredColumns))
-
-			for i, col := range filteredColumns {
-				// nil here is a real NULL, not a zero value standing in for one.
-				val := ScanValue(scanDest[i])
-
-				if val == nil {
-					rawRow[cleanHeaders[i]] = nil
-					row[i] = "null"
-				} else {
-					// Special handling for UDTs and complex types
-					typeStr := columnTypes[i]
-
-					// Parse the type string to get structured type information
-					typeInfo, parseErr := ParseCQLType(typeStr)
-
-					// Add debug logging to understand what we're getting
-					logger.DebugfToFile("ExecuteSelectQuery", "Column %s: typeStr=%s, gocqlType=%v, parsedType=%v, parseErr=%v, valType=%T",
-						col.Name, typeStr, col.TypeInfo.Type(), typeInfo, parseErr, val)
-
-					// Determine the data type category
-					isUDT := col.TypeInfo.Type() == gocql.TypeUDT || (typeInfo != nil && typeInfo.BaseType == "udt")
-					isCollection := typeInfo != nil && (typeInfo.BaseType == "list" || typeInfo.BaseType == "set" ||
-						typeInfo.BaseType == "map" || typeInfo.BaseType == "tuple")
-
-					switch {
-					case isUDT:
-						// UDT handling - try to decode if we got raw bytes
-						if bytes, ok := val.([]byte); ok && len(bytes) > 0 {
-							logger.DebugfToFile("ExecuteSelectQuery", "UDT %s came as bytes: %d bytes", col.Name, len(bytes))
-
-							// Use our binary decoder to decode the UDT
-							decoder := NewBinaryDecoder(s.udtRegistry)
-
-							// Determine the keyspace - prefer query keyspace, then current
-							keyspace := currentKeyspace
-							if keyspace == "" {
-								keyspace = s.Keyspace()
-								if keyspace == "" && s.cluster != nil {
-									keyspace = s.cluster.Keyspace
-								}
-							}
-
-							// Try to decode the UDT
-							if typeInfo != nil {
-								decoded, err := decoder.Decode(bytes, typeInfo, keyspace)
-								if err != nil {
-									logger.DebugfToFile("ExecuteSelectQuery", "Failed to decode UDT %s: %v", col.Name, err)
-									// Fall back to showing raw bytes info
-									rawRow[cleanHeaders[i]] = map[string]interface{}{"_raw_bytes": fmt.Sprintf("%x", bytes)}
-									row[i] = fmt.Sprintf("{_raw_bytes:%d}", len(bytes))
-								} else {
-									// Successfully decoded UDT
-									rawRow[cleanHeaders[i]] = decoded
-									// Format for display
-									if m, ok := decoded.(map[string]interface{}); ok {
-										row[i] = formatUDTMap(m)
-									} else {
-										row[i] = fmt.Sprintf("%v", decoded)
-									}
-								}
-							} else {
-								// Couldn't parse type, show raw bytes
-								rawRow[cleanHeaders[i]] = map[string]interface{}{"_raw_bytes": fmt.Sprintf("%x", bytes)}
-								row[i] = fmt.Sprintf("{_raw_bytes:%d}", len(bytes))
-							}
-						} else if m, ok := val.(map[string]interface{}); ok {
-							// Sometimes gocql returns a map directly
-							if len(m) > 0 {
-								rawRow[cleanHeaders[i]] = m
-								row[i] = formatUDTMap(m)
-							} else {
-								// Empty map - common issue with gocql and UDTs
-								logger.DebugfToFile("ExecuteSelectQuery", "UDT %s returned empty map", col.Name)
-								rawRow[cleanHeaders[i]] = m
-								row[i] = "{}"
-							}
-						} else {
-							// Other format - just display as is
-							rawRow[cleanHeaders[i]] = val
-							row[i] = fmt.Sprintf("%v", val)
-						}
-
-					case isCollection:
-						// Collections are already decoded by gocql, just format them
-						rawRow[cleanHeaders[i]] = val
-						row[i] = FormatValue(val)
-
-					default:
-						// Store the actual value for JSON
-						rawRow[cleanHeaders[i]] = val
-
-						// Format for display - use formatValue which handles collections properly
-						row[i] = FormatValue(val)
-					}
-				}
-			}
-			rawData = append(rawData, rawRow)
-			results = append(results, row)
-			rowNum++
+			rawRow[col.Name] = val
+			row[i] = FormatValue(val)
 		}
+
+		scanned = append(scanned, row)
+		rawData = append(rawData, rawRow)
 	}
+	results = append(results, scanned...)
+
+	// Count what was collected. This used to be a counter incremented beside
+	// the append, in the other half of an "if true ... else": the rows came
+	// back from the half that runs and the count from the half that cannot, so
+	// every non-streaming SELECT reported no rows however many it returned.
+	rowNum := len(scanned)
 	logger.DebugfToFile("executeSelectQuery", "Scan completed. Total rows: %d", rowNum)
 
 	if err := iter.Close(); err != nil {
@@ -697,16 +570,20 @@ func (s *Session) shouldUseStreaming(query string) bool {
 	// Always use streaming unless there's a small LIMIT
 	upperQuery := strings.ToUpper(strings.TrimSpace(query))
 
-	// Check for LIMIT clause
-	if strings.Contains(upperQuery, " LIMIT ") {
-		// Extract limit value - simple regex for "LIMIT n"
+	// A LIMIT small enough to fit in one page has nothing to page through, so
+	// fetch it in one go.
+	//
+	// This used to compare the limit against a hardcoded 1000, which had no
+	// relationship to the page size: PAGING 100 with LIMIT 300 fetched all 300
+	// at once and PAGING was ignored. Measuring against the page size is what
+	// makes PAGING mean something.
+	if pageSize := s.PageSize(); pageSize > 0 && strings.Contains(upperQuery, " LIMIT ") {
 		re := regexp.MustCompile(`LIMIT\s+(\d+)`)
 		matches := re.FindStringSubmatch(upperQuery)
 		if len(matches) > 1 {
 			limit, err := strconv.Atoi(matches[1])
-			if err == nil && limit <= 1000 {
-				// Small limit, don't use streaming
-				logger.DebugfToFile("shouldUseStreaming", "Query has LIMIT %d, not using streaming", limit)
+			if err == nil && limit <= pageSize {
+				logger.DebugfToFile("shouldUseStreaming", "LIMIT %d fits in a page of %d, not using streaming", limit, pageSize)
 				return false
 			}
 		}

--- a/internal/db/streaming_choice_test.go
+++ b/internal/db/streaming_choice_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestALimitBiggerThanAPageStreams. PAGING 100 with LIMIT 300 used to fetch all
+// 300 at once, because the limit was compared against a hardcoded 1000 that had
+// nothing to do with the page size.
+func TestALimitBiggerThanAPageStreams(t *testing.T) {
+	s := &Session{}
+	s.SetPageSize(100)
+
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 300"))
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 1000"))
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 101"))
+}
+
+// TestALimitInsideAPageDoesNot: there is nothing to page through.
+func TestALimitInsideAPageDoesNot(t *testing.T) {
+	s := &Session{}
+	s.SetPageSize(100)
+
+	assert.False(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 100"))
+	assert.False(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 10"))
+	assert.False(t, s.shouldUseStreaming("select * from t limit 1"))
+}
+
+// TestTheThresholdFollowsThePageSize, rather than being a constant.
+func TestTheThresholdFollowsThePageSize(t *testing.T) {
+	s := &Session{}
+
+	s.SetPageSize(500)
+	assert.False(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 300"),
+		"300 fits in a page of 500")
+
+	s.SetPageSize(50)
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 300"),
+		"300 does not fit in a page of 50")
+}
+
+// TestPagingOffAlwaysStreams: with no page size there is nothing to measure a
+// limit against, so the sliding window handles it as it does everything else.
+func TestPagingOffAlwaysStreams(t *testing.T) {
+	s := &Session{}
+	s.SetPageSize(0)
+
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t LIMIT 10"))
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t"))
+}
+
+// TestAQueryWithNoLimitStreams.
+func TestAQueryWithNoLimitStreams(t *testing.T) {
+	s := &Session{}
+	s.SetPageSize(100)
+
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t"))
+	assert.True(t, s.shouldUseStreaming("SELECT * FROM t WHERE id = 1"))
+}

--- a/internal/ui/horizontal_scroll_test.go
+++ b/internal/ui/horizontal_scroll_test.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// altKey is an arrow with Alt held, which is how a wide table is scrolled.
+func altKey(code rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: code, Mod: tea.ModAlt}
+}
+
+// wideResults puts a result too wide for the screen into the Results view.
+func wideResults(t *testing.T, format config.OutputFormat) *MainModel {
+	t.Helper()
+
+	m := queryResultModel(t)
+	m.tableViewport.SetWidth(40)
+	m.columnWidths = []int{8, 8}
+	m.showQueryResult([][]string{
+		{"id", "payload"},
+		{"1", strings.Repeat("a", 300)},
+		{"2", strings.Repeat("b", 300)},
+	}, nil, format)
+	return m
+}
+
+// scrollRight names the four ways of scrolling right, so each is covered.
+var scrollRight = map[string]func(*MainModel){
+	"Alt+Right": func(m *MainModel) { m.handleRightArrow(altKey(tea.KeyRight)) },
+	"l":         func(m *MainModel) { m.handleHorizontalScrollRight() },
+	">":         func(m *MainModel) { m.handlePageRightScroll() },
+	"wheel":     func(m *MainModel) { m.handleMouseWheelRight() },
+}
+
+var scrollLeft = map[string]func(*MainModel){
+	"Alt+Left": func(m *MainModel) { m.handleLeftArrow(altKey(tea.KeyLeft)) },
+	"h":        func(m *MainModel) { m.handleHorizontalScrollLeft() },
+	"<":        func(m *MainModel) { m.handlePageLeftScroll() },
+	"wheel":    func(m *MainModel) { m.handleMouseWheelLeft() },
+}
+
+// TestScrollingSidewaysLeavesTextAlone, by every route.
+//
+// #115 fixed two of the four and left the other two rebuilding ASCII output as
+// a boxed table - including Alt+arrows, which is what the README tells you to
+// use.
+func TestScrollingSidewaysLeavesTextAlone(t *testing.T) {
+	for _, format := range []config.OutputFormat{config.OutputFormatASCII, config.OutputFormatJSON} {
+		for name, scroll := range scrollRight {
+			m := wideResults(t, format)
+			before := m.tableViewport.GetContent()
+
+			scroll(m)
+
+			assert.Equal(t, before, m.tableViewport.GetContent(),
+				"%s by %s rebuilt the content", format, name)
+			assert.Positive(t, m.tableViewport.XOffset(),
+				"%s by %s did not scroll", format, name)
+		}
+	}
+}
+
+// TestABoxedTableIsRebuiltWhenItScrolls, because it drops whole columns rather
+// than cutting one down the middle.
+func TestABoxedTableIsRebuiltWhenItScrolls(t *testing.T) {
+	for name, scroll := range scrollRight {
+		m := wideResults(t, config.OutputFormatTable)
+
+		scroll(m)
+
+		assert.Zero(t, m.tableViewport.XOffset(),
+			"%s: a table scrolls by rebuilding, not by sliding", name)
+		assert.Positive(t, m.horizontalOffset, "%s did not scroll", name)
+	}
+}
+
+// TestEveryRouteStopsAtTheSamePlace.
+func TestEveryRouteStopsAtTheSamePlace(t *testing.T) {
+	limits := map[string]int{}
+	for name, scroll := range scrollRight {
+		m := wideResults(t, config.OutputFormatASCII)
+		for range 200 {
+			scroll(m)
+		}
+		limits[name] = m.horizontalOffset
+	}
+
+	var want int
+	for _, got := range limits {
+		if want == 0 {
+			want = got
+		}
+		assert.Equal(t, want, got, "the routes stop in different places: %v", limits)
+	}
+	assert.Positive(t, want)
+}
+
+// TestScrollingBackReachesTheLeftEdge, by every route.
+func TestScrollingBackReachesTheLeftEdge(t *testing.T) {
+	for name, back := range scrollLeft {
+		m := wideResults(t, config.OutputFormatASCII)
+		for range 20 {
+			m.handleHorizontalScrollRight()
+		}
+		require.Positive(t, m.horizontalOffset)
+
+		for range 200 {
+			back(m)
+		}
+		assert.Zero(t, m.horizontalOffset, "%s did not reach the left edge", name)
+		assert.Zero(t, m.tableViewport.XOffset(), "%s left the viewport scrolled", name)
+	}
+}
+
+// TestANewResultStartsAtTheLeftEdge. Resetting only horizontalOffset left the
+// viewport's own offset behind, so ASCII output arrived already scrolled.
+func TestANewResultStartsAtTheLeftEdge(t *testing.T) {
+	m := wideResults(t, config.OutputFormatASCII)
+	for range 20 {
+		m.handleHorizontalScrollRight()
+	}
+	require.Positive(t, m.tableViewport.XOffset())
+
+	m.showQueryResult([][]string{{"id"}, {"1"}}, nil, config.OutputFormatASCII)
+
+	assert.Zero(t, m.horizontalOffset)
+	assert.Zero(t, m.tableViewport.XOffset())
+}
+
+// TestNarrowContentDoesNotScroll: there is nothing out there to see.
+func TestNarrowContentDoesNotScroll(t *testing.T) {
+	m := queryResultModel(t)
+	m.tableViewport.SetWidth(80)
+	m.showQueryResult([][]string{{"id"}, {"1"}}, nil, config.OutputFormatASCII)
+
+	for name, scroll := range scrollRight {
+		scroll(m)
+		assert.Zero(t, m.horizontalOffset, "%s scrolled past the end of the content", name)
+	}
+}

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -75,6 +75,24 @@ func (m *MainModel) processCommandResult(command string, result interface{}, sta
 	return m, nil
 }
 
+// rowsWithoutPaging is the batch to fetch when PAGING is off and there is no
+// page size to take it from.
+const rowsWithoutPaging = 100
+
+// initialRowsToLoad is how many rows to fetch before drawing anything: one
+// page, which is what PAGING sets.
+//
+// It was a hardcoded 100, so PAGING 500 still showed 100 first and PAGING 50
+// still showed 100. It matching the default was a coincidence.
+func (m *MainModel) initialRowsToLoad() int {
+	if m.session != nil {
+		if pageSize := m.session.PageSize(); pageSize > 0 {
+			return pageSize
+		}
+	}
+	return rowsWithoutPaging
+}
+
 // processStreamingQueryResult handles streaming query results
 func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQueryResult, startTime time.Time) (*MainModel, tea.Cmd) {
 	// Use the new StreamingProcessor from the database layer
@@ -96,7 +114,7 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 
 	// Load initial batch of rows using the streaming processor
 	ctx := context.Background()
-	maxInitialRows := 100 // Show first 100 rows immediately
+	maxInitialRows := m.initialRowsToLoad()
 
 	// Load initial rows from the streaming processor
 	initialRows, hasMore, err := streamingResult.LoadMore(ctx, maxInitialRows)
@@ -167,10 +185,9 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 	// Update UI
 	m.topBar.HasQueryData = true
 	m.topBar.QueryTime = time.Since(v.StartTime)
-	m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
 	m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 
-	logger.DebugfToFile("HandleEnterKey", "TopBar.RowCount set to %d", m.topBar.RowCount)
+	logger.DebugfToFile("HandleEnterKey", "Row count set to %d", m.rowCount)
 
 	// Prepare display based on format
 	outputFormat := config.OutputFormatTable
@@ -206,7 +223,7 @@ func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) 
 	// Format initial data as expanded vertical format
 	allData := append([][]string{headers}, m.slidingWindow.Rows...)
 	m.lastTableData = allData // Store for pagination
-	m.horizontalOffset = 0    // Reset horizontal scroll
+	m.resetHorizontalScroll()
 
 	// Format as expanded vertical table. The boundaries have to come from this
 	// layout: paging snaps to them, and a record here is many lines tall.
@@ -234,7 +251,7 @@ func (m *MainModel) showQueryResult(data [][]string, columnTypes []string, outpu
 	m.tableHeaders = data[0]
 	m.columnTypes = columnTypes
 	m.resultFormat = outputFormat
-	m.horizontalOffset = 0
+	m.resetHorizontalScroll()
 	m.hasTable = true
 	m.viewMode = "table"
 	m.initialColumnWidths = nil // Reset initial widths for new table
@@ -341,7 +358,6 @@ func (m *MainModel) fetchAllPages(format string) {
 	logger.DebugfToFile("HandleEnterKey", "%s format: fetched %d rows, total rows: %d",
 		format, totalFetched, m.slidingWindow.TotalRowsSeen)
 
-	m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
 	m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 }
 
@@ -360,7 +376,7 @@ func (m *MainModel) displayASCIIFormat(headers []string, columnTypes []string) (
 
 	m.hasTable = true
 	m.viewMode = "table"
-	m.horizontalOffset = 0
+	m.resetHorizontalScroll()
 	m.initialColumnWidths = nil // Reset initial widths for new table
 	m.cachedTableLines = nil    // Clear cache for new table
 
@@ -405,7 +421,7 @@ func (m *MainModel) displayJSONFormat(headers []string, columnTypes []string, co
 
 	m.hasTable = true
 	m.viewMode = "table"
-	m.horizontalOffset = 0
+	m.resetHorizontalScroll()
 	m.initialColumnWidths = nil // Reset initial widths for new table
 	m.cachedTableLines = nil    // Clear cache for new table
 
@@ -449,7 +465,7 @@ func (m *MainModel) displayTableFormat(headers []string, columnTypes []string) (
 	// Format initial data for display
 	allData := append([][]string{headers}, m.slidingWindow.Rows...)
 	m.lastTableData = allData // Store for horizontal scrolling
-	m.horizontalOffset = 0    // Reset horizontal scroll
+	m.resetHorizontalScroll()
 	logger.DebugfToFile("HandleEnterKey", "Formatting table with %d rows (including header)", len(allData))
 	tableStr := m.formatTableForViewport(allData)
 	logger.DebugfToFile("HandleEnterKey", "Table string length: %d", len(tableStr))
@@ -467,7 +483,6 @@ func (m *MainModel) processQueryResult(command string, v db.QueryResult) (*MainM
 	if len(v.Data) > 0 {
 		// Update top bar with query metadata
 		m.topBar.QueryTime = v.Duration
-		m.topBar.RowCount = v.RowCount
 		m.topBar.HasQueryData = true
 
 		m.rowCount = v.RowCount
@@ -509,11 +524,12 @@ func (m *MainModel) processTableResult(command string, v [][]string) (*MainModel
 	// Table data without metadata (for backward compatibility)
 	if len(v) > 0 {
 		m.rowCount = len(v) - 1 // Exclude header
+		m.topBar.HasQueryData = true
 		// Store table data and headers
 		m.lastTableData = v
 		m.tableHeaders = v[0] // Store the header row
 		m.resultFormat = config.OutputFormatTable
-		m.horizontalOffset = 0
+		m.resetHorizontalScroll()
 		m.hasTable = true
 		m.viewMode = "table"
 		m.initialColumnWidths = nil // Reset initial widths for new table

--- a/internal/ui/keyboard_handler_enter_special.go
+++ b/internal/ui/keyboard_handler_enter_special.go
@@ -30,7 +30,7 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 		m.input.Reset()
 		m.lastCommand = ""
 		m.rowCount = 0
-		m.horizontalOffset = 0
+		m.resetHorizontalScroll()
 		m.lastTableData = nil
 		m.tableWidth = 0
 		m.tableHeaders = nil

--- a/internal/ui/keyboard_navigation_pager.go
+++ b/internal/ui/keyboard_navigation_pager.go
@@ -375,11 +375,8 @@ func (m *MainModel) handleHorizontalScrollLeft() (*MainModel, tea.Cmd) {
 			}
 			m.refreshTraceView()
 		}
-	case m.viewMode == "table" && m.hasTable:
-		if m.horizontalOffset > 0 {
-			m.horizontalOffset = max(m.horizontalOffset-horizontalStep, 0)
-			m.applyHorizontalOffset()
-		}
+	default:
+		m.scrollHorizontally(-horizontalStep)
 	}
 	return m, nil
 }
@@ -399,20 +396,8 @@ func (m *MainModel) handlePageLeftScroll() (*MainModel, tea.Cmd) {
 			}
 			m.refreshTraceView()
 		}
-	case m.viewMode == "table" && m.hasTable:
-		if m.horizontalOffset > 0 {
-			scrollAmount := m.tableViewport.Width() / 2
-			if scrollAmount < 10 {
-				scrollAmount = 10
-			}
-			m.horizontalOffset -= scrollAmount
-			if m.horizontalOffset < 0 {
-				m.horizontalOffset = 0
-			}
-			if m.lastTableData != nil {
-				m.refreshTableView()
-			}
-		}
+	default:
+		m.scrollHorizontally(-m.halfScreen())
 	}
 	return m, nil
 }
@@ -433,21 +418,8 @@ func (m *MainModel) handlePageRightScroll() (*MainModel, tea.Cmd) {
 			}
 			m.refreshTraceView()
 		}
-	case m.viewMode == "table" && m.hasTable:
-		if m.tableWidth > m.tableViewport.Width() {
-			scrollAmount := m.tableViewport.Width() / 2
-			if scrollAmount < 10 {
-				scrollAmount = 10
-			}
-			maxOffset := m.tableWidth - m.tableViewport.Width() + 10
-			m.horizontalOffset += scrollAmount
-			if m.horizontalOffset > maxOffset {
-				m.horizontalOffset = maxOffset
-			}
-			if m.lastTableData != nil {
-				m.refreshTableView()
-			}
-		}
+	default:
+		m.scrollHorizontally(m.halfScreen())
 	}
 	return m, nil
 }
@@ -466,20 +438,51 @@ func (m *MainModel) handleHorizontalScrollRight() (*MainModel, tea.Cmd) {
 				m.refreshTraceView()
 			}
 		}
-	case m.viewMode == "table" && m.hasTable:
-		if m.tableWidth > m.tableViewport.Width() {
-			maxOffset := m.tableWidth - m.tableViewport.Width() + horizontalStep
-			if m.horizontalOffset < maxOffset {
-				m.horizontalOffset = min(m.horizontalOffset+horizontalStep, maxOffset)
-				m.applyHorizontalOffset()
-			}
-		}
+	default:
+		m.scrollHorizontally(horizontalStep)
 	}
 	return m, nil
 }
 
-// horizontalStep is how far one press scrolls sideways.
+// horizontalStep is how far one press of h, l or an arrow scrolls sideways.
 const horizontalStep = 10
+
+// halfScreen is how far < and > scroll: half the width on screen, so a page
+// sideways leaves half of what you were reading in view.
+func (m *MainModel) halfScreen() int {
+	return max(m.tableViewport.Width()/2, horizontalStep)
+}
+
+// scrollHorizontally moves the Results view sideways by n columns.
+//
+// Every route sideways comes through here - h and l, the arrows, < and >, and
+// the wheel. They used to be six copies of the same clamp-then-rebuild, in
+// three files, and #115 fixed two of them: the other four went on rebuilding
+// ASCII output as a boxed table the moment you scrolled.
+func (m *MainModel) scrollHorizontally(n int) {
+	if m.viewMode != "table" || !m.hasTable {
+		return
+	}
+
+	maxOffset := max(m.tableWidth-m.tableViewport.Width()+horizontalStep, 0)
+	offset := min(max(m.horizontalOffset+n, 0), maxOffset)
+	if offset == m.horizontalOffset {
+		return
+	}
+
+	m.horizontalOffset = offset
+	m.applyHorizontalOffset()
+}
+
+// resetHorizontalScroll puts a new result back at the left-hand edge.
+//
+// Both halves matter: the offset the table renderer reads, and the viewport's
+// own, which is what slides text sideways. Resetting only the first left ASCII
+// output still scrolled off the left when the next query landed.
+func (m *MainModel) resetHorizontalScroll() {
+	m.horizontalOffset = 0
+	m.tableViewport.SetXOffset(0)
+}
 
 // applyHorizontalOffset moves the Results view sideways.
 //
@@ -525,7 +528,6 @@ func (m *MainModel) loadMoreTableDataHelper() {
 		m.refreshTableContent(allData)
 
 		// Update row count
-		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
 		m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 	}
 }

--- a/internal/ui/keyboard_navtigation.go
+++ b/internal/ui/keyboard_navtigation.go
@@ -153,7 +153,6 @@ func (m *MainModel) handlePageDown(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
 					m.refreshTableContent(allData)
 
 					// Update row count
-					m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
 					m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 				}
 			}
@@ -250,18 +249,8 @@ func (m *MainModel) handleLeftArrow(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
 				// Refresh the trace view using existing table renderer
 				m.refreshTraceView()
 			}
-		case m.viewMode == "table" && m.hasTable:
-			// Scroll data table left
-			if m.horizontalOffset > 0 {
-				m.horizontalOffset -= 10
-				if m.horizontalOffset < 0 {
-					m.horizontalOffset = 0
-				}
-				// Refresh the table view if we have table data
-				if m.lastTableData != nil {
-					m.refreshTableView()
-				}
-			}
+		default:
+			m.scrollHorizontally(-horizontalStep)
 		}
 		return m, nil
 	}
@@ -295,21 +284,8 @@ func (m *MainModel) handleRightArrow(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) 
 					m.refreshTraceView()
 				}
 			}
-		case m.viewMode == "table" && m.hasTable:
-			// Scroll data table right
-			if m.tableWidth > m.tableViewport.Width() {
-				maxOffset := m.tableWidth - m.tableViewport.Width() + 10 // Add some buffer
-				if m.horizontalOffset < maxOffset {
-					m.horizontalOffset += 10
-					if m.horizontalOffset > maxOffset {
-						m.horizontalOffset = maxOffset
-					}
-					// Refresh the table view if we have table data
-					if m.lastTableData != nil {
-						m.refreshTableView()
-					}
-				}
-			}
+		default:
+			m.scrollHorizontally(horizontalStep)
 		}
 		return m, nil
 	}

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -247,30 +247,13 @@ func (m *MainModel) handleMouseWheelDown() (*MainModel, tea.Cmd) {
 
 // handleMouseWheelLeft handles horizontal scrolling left
 func (m *MainModel) handleMouseWheelLeft() (*MainModel, tea.Cmd) {
-	if m.viewMode != "table" || !m.hasTable {
-		return m, nil
-	}
-
-	if m.horizontalOffset > 0 {
-		m.horizontalOffset = max(m.horizontalOffset-horizontalStep, 0)
-		m.applyHorizontalOffset()
-	}
+	m.scrollHorizontally(-horizontalStep)
 	return m, nil
 }
 
 // handleMouseWheelRight handles horizontal scrolling right
 func (m *MainModel) handleMouseWheelRight() (*MainModel, tea.Cmd) {
-	if m.viewMode != "table" || !m.hasTable {
-		return m, nil
-	}
-
-	// Stop where the content ends. It used to scroll on past the end when the
-	// content was narrower than the window, leaving you looking at nothing.
-	maxOffset := max(m.tableWidth-m.tableViewport.Width()+horizontalStep, 0)
-	if m.horizontalOffset < maxOffset {
-		m.horizontalOffset = min(m.horizontalOffset+horizontalStep, maxOffset)
-		m.applyHorizontalOffset()
-	}
+	m.scrollHorizontally(horizontalStep)
 	return m, nil
 }
 
@@ -311,7 +294,6 @@ func (m *MainModel) loadMoreTableData() {
 		m.refreshTableContent(allData)
 
 		// Update row count
-		m.topBar.RowCount = int(m.slidingWindow.TotalRowsSeen)
 		m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 	}
 }

--- a/internal/ui/row_count_test.go
+++ b/internal/ui/row_count_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rowCountModel(t *testing.T) *MainModel {
+	t.Helper()
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		windowWidth:     100,
+		windowHeight:    30,
+		viewMode:        "history",
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+		tableViewport:   viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+}
+
+// shownRows is what the info bar says, after View has synced it.
+func shownRows(m *MainModel) string {
+	m.topBar.RowCount = m.rowCount // what View does
+	for _, seg := range m.topBar.segments() {
+		if seg.label == "Rows: " {
+			return seg.value
+		}
+	}
+	return ""
+}
+
+// TestASelectReportsItsRowCount. The count used to be incremented in the dead
+// half of an "if true ... else", so every non-streaming SELECT said 0 however
+// many rows it returned.
+func TestASelectReportsItsRowCount(t *testing.T) {
+	m := rowCountModel(t)
+
+	m.processQueryResult("SELECT * FROM t", db.QueryResult{
+		Data:     [][]string{{"id"}, {"1"}, {"2"}, {"3"}},
+		RowCount: 3,
+		Duration: 12 * time.Millisecond,
+		Headers:  []string{"id"},
+	})
+
+	assert.Equal(t, 3, m.rowCount)
+	assert.Equal(t, "3", shownRows(m))
+}
+
+// TestDescribeReportsItsRowCount: it counted its rows and never told the bar,
+// so Rows read "-" after a DESCRIBE.
+func TestDescribeReportsItsRowCount(t *testing.T) {
+	m := rowCountModel(t)
+
+	m.processTableResult("DESCRIBE TABLES", [][]string{{"name"}, {"users"}, {"events"}, {"logs"}})
+
+	assert.Equal(t, 3, m.rowCount)
+	assert.Equal(t, "3", shownRows(m))
+}
+
+// TestNoQueryYetShowsADash rather than a zero that looks like a real answer.
+func TestNoQueryYetShowsADash(t *testing.T) {
+	m := rowCountModel(t)
+
+	assert.Equal(t, infoPlaceholder, shownRows(m))
+}
+
+// TestAQueryReturningNothingShowsZero, which is a real answer.
+func TestAQueryReturningNothingShowsZero(t *testing.T) {
+	m := rowCountModel(t)
+
+	m.processQueryResult("SELECT * FROM t", db.QueryResult{
+		Data:     [][]string{{"id"}},
+		RowCount: 0,
+		Duration: time.Millisecond,
+		Headers:  []string{"id"},
+	})
+
+	assert.Equal(t, "0", shownRows(m))
+}
+
+// TestTheBarFollowsTheModel: the count is derived in View rather than pushed in
+// by each handler, which is how one of six paths came to forget.
+func TestTheBarFollowsTheModel(t *testing.T) {
+	m := rowCountModel(t)
+	m.topBar.HasQueryData = true
+
+	for _, n := range []int{0, 1, 42, 1000} {
+		m.rowCount = n
+		require.Equal(t, n, m.rowCount)
+		assert.Equal(t, itoa(n), shownRows(m))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+// TestMoreToFetchIsMarked: the "+" says the number is what has been fetched so
+// far, not what the query would return.
+func TestMoreToFetchIsMarked(t *testing.T) {
+	m := rowCountModel(t)
+	m.topBar.HasQueryData = true
+	m.rowCount = 100
+	m.topBar.HasMoreData = true
+
+	assert.Equal(t, "100+", shownRows(m))
+
+	m.topBar.AutoFetch = true
+	assert.Equal(t, "100", shownRows(m), "AutoFetch means there is nothing left to fetch")
+}
+
+// TestTheFirstBatchIsOnePage. It was a hardcoded 100, so PAGING 500 still
+// showed 100 first and PAGING 50 still showed 100.
+func TestTheFirstBatchIsOnePage(t *testing.T) {
+	for _, pageSize := range []int{50, 100, 500} {
+		m := rowCountModel(t)
+		m.session = &db.Session{}
+		m.session.SetPageSize(pageSize)
+
+		assert.Equal(t, pageSize, m.initialRowsToLoad())
+	}
+}
+
+// TestWithPagingOffTheBatchFallsBack, since there is no page size to take.
+func TestWithPagingOffTheBatchFallsBack(t *testing.T) {
+	m := rowCountModel(t)
+	m.session = &db.Session{}
+	m.session.SetPageSize(0)
+
+	assert.Equal(t, rowsWithoutPaging, m.initialRowsToLoad())
+
+	m.session = nil
+	assert.Equal(t, rowsWithoutPaging, m.initialRowsToLoad())
+}

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -57,6 +57,11 @@ func (m *MainModel) View() tea.View {
 	}
 
 	m.topBar.LastCommand = m.latestCommand()
+
+	// The row count comes from the model rather than being pushed into the bar
+	// by each handler. It was assigned as a pair in six places and the DESCRIBE
+	// path forgot, so its results never reached the bar at all.
+	m.topBar.RowCount = m.rowCount
 	if m.session != nil {
 		autoFetch := m.session.AutoFetch()
 		m.statusBar.AutoFetch = autoFetch


### PR DESCRIPTION
Three bugs, all found from one debug log.

## `Rows:` always read 0 (#122)

```
Context: shouldUseStreaming | Query has LIMIT 300, not using streaming
Context: executeSelectQuery | Scan completed. Total rows: 0
Context: ExecuteSelectQuery | Returning QueryResult with 0 rows
```

The database layer reported zero for a query that returned 300, and everything above it was faithfully showing what it was told.

```go
if true { // Always use MapScan for safety
    ...
    virtualResults = append(virtualResults, row)   // the rows
} else {
    ...
    rowNum++                                        // the count
}
```

The rows come from the half that runs; `rowNum++` is in the half that cannot. So **every** non-streaming `SELECT` has reported no rows. Streaming queries count from the sliding window, which is why it only showed on results small enough not to stream.

The `if true` looks like a switch flipped to force `MapScan`, because `Scan` into an `interface{}` panics on NULLs. That was right. What it also did was strand the counter in 129 lines that can no longer run. The count comes from the rows actually collected now, and the dead half is gone.

The same trail turned up `processTableResult` - the path `DESCRIBE` takes - counting its rows and never telling the info bar. `m.rowCount` and `m.topBar.RowCount` were assigned as a pair in six places and that was the one that forgot. `View` derives it now, the way it already derives the last command and AutoFetch.

## Scrolling sideways rebuilt ASCII as a table (#123)

#115 fixed this in two of the places it happens. There are six, in three files, each its own copy of clamp-the-offset-then-rebuild:

| route | fixed in #115 |
|---|---|
| `h` / `l` | yes |
| wheel sideways | yes |
| **`Alt+←` / `Alt+→`** | no - what the README tells you to use |
| `<` / `>` | no |

One `scrollHorizontally` now, with the callers differing only in distance: ten columns for the arrows, `h`/`l` and the wheel, half a screen for `<`/`>`.

New results also arrived still scrolled. Seven places reset `m.horizontalOffset` for a new result and none reset the viewport's own X offset - the thing that actually slides text - so once ASCII scrolled by sliding, the next query landed off the left edge. One function does both.

A boxed table still rebuilds when it scrolls, because it drops whole columns rather than cutting one down the middle. That is asserted too, so the two cannot get crossed.

## PAGING did not control how much was fetched (#124)

Two hardcoded numbers. The streaming decision compared a query's `LIMIT` against a constant `1000`, so `PAGING 100` with `LIMIT 300` fetched all 300 at once. And the first batch was a hardcoded `100`, so `PAGING 500` still showed 100 first - it matching the default was a coincidence.

Both come from the page size now.

**A decision the issue left open.** It asked whether a small `LIMIT` should page at all. Taken as: a `LIMIT` that fits inside one page has nothing to page through, so it is still fetched in one go - `LIMIT 100` with `PAGING 100` does not stream, `LIMIT 300` does.

The alternative was to make everything stream. That would have left the entire non-streaming query path unreachable, which is precisely the dead-code trap that caused the first of these three bugs. Say if you would rather have it the other way.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: a `SELECT` and a `DESCRIBE` reporting their counts, a query returning nothing showing `0` rather than a dash, and no query yet showing a dash; all four sideways routes leaving ASCII and JSON alone, a table still rebuilding, every route stopping at the same place at both ends, and a new result starting at the left edge; and the streaming decision against page sizes above, below and equal to the limit, with paging off.

Closes #122
Closes #123
Closes #124
