### PR TITLE
feat(ui): name both help keys on the button

### DIFF
--- a/internal/ui/help_window_test.go
+++ b/internal/ui/help_window_test.go
@@ -254,9 +254,42 @@ func TestTheButtonGivesWayToTheTabNames(t *testing.T) {
 	assert.Contains(t, medium, "Help")
 
 	// Room for the names only. The button goes rather than the names.
-	tight := stripAnsiForTest(m.ViewTabBar(44))
+	tight := stripAnsiForTest(m.ViewTabBar(40))
 	assert.Contains(t, tight, "Console")
 	assert.NotContains(t, tight, "Help")
+}
+
+// TestTheButtonNamesBothKeys. F1 does not reach the application on Terminator
+// and others, so a button naming only F1 names a key that does nothing there.
+func TestTheButtonNamesBothKeys(t *testing.T) {
+	m := helpModel()
+
+	wide := stripAnsiForTest(m.ViewTabBar(100))
+	assert.Contains(t, wide, "Help (F1/Alt+H)")
+}
+
+// TestTheLabelShortensBeforeTheButtonGoes: a terminal with room for "Help" but
+// not for both keys keeps the button.
+func TestTheLabelShortensBeforeTheButtonGoes(t *testing.T) {
+	m := helpModel()
+
+	for _, width := range []int{70, 50, 44} {
+		bar := stripAnsiForTest(m.ViewTabBar(width))
+		assert.Contains(t, bar, "Help", "width %d should still offer the button: %q", width, bar)
+	}
+}
+
+// TestTheTabsDoNotGiveUpTheirNamesForALabelThatWillNotBeDrawn.
+//
+// The room reserved for the button is its shortest useful label, not its
+// longest: reserving for "Help (F1/Alt+H)" on a terminal that was only ever
+// going to fit "Help" would shorten the tab names for nothing.
+func TestTheTabsDoNotGiveUpTheirNamesForALabelThatWillNotBeDrawn(t *testing.T) {
+	m := helpModel()
+
+	bar := stripAnsiForTest(m.ViewTabBar(44))
+	assert.Contains(t, bar, "Console", "the names should survive here")
+	assert.Contains(t, bar, "Help")
 }
 
 // TestTheTabLineNeverWrapsWithTheButtonOnIt, at any width.

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -181,9 +181,17 @@ func (m *MainModel) layoutTabs(width int) []tabSpan {
 	return spans
 }
 
-// helpReserve is the room the Help button wants: its longest label plus the
-// space either side of it.
-var helpReserve = lipgloss.Width(" Help (F1) ")
+// helpLabels are the Help button's labels, longest first.
+//
+// Both keys, because F1 does not reach the application on Terminator, Konsole
+// and others - they take it for their own help - so a button naming only F1
+// names a key that does nothing on those terminals.
+var helpLabels = []string{"Help (F1/Alt+H)", "Help", "?"}
+
+// helpReserve is the room the tabs give up for the button: its *shortest*
+// useful label, not its longest. Reserving for the longest would shorten the
+// tab names on a terminal that was only ever going to fit "Help".
+var helpReserve = lipgloss.Width(" Help ")
 
 // helpMode is the pseudo-mode the Help button reports. It is not a view: it
 // opens a window over whichever view you are in and leaves it there.
@@ -195,7 +203,7 @@ const helpMode = "help"
 // top of a tab: losing the button is better than a line where a click lands on
 // whatever happens to be underneath it.
 func helpSpan(width, tabsEnd int) (tabSpan, bool) {
-	for _, label := range []string{"Help (F1)", "Help", "?"} {
+	for _, label := range helpLabels {
 		start := width - lipgloss.Width(label) - 2
 		if start > tabsEnd {
 			return tabSpan{


### PR DESCRIPTION
The button read `Help (F1)`, but F1 does not reach the application on Terminator, Konsole and others - they take it for their own help. On those terminals it named a key that does nothing.

```
100: [ Console (F2)   Results (F3)   Trace (F4)   AI (F5)          Help (F1/Alt+H) ]
 70: [ Console (F2)   Results (F3)   Trace (F4)   AI (F5)                     Help ]
 60: [ Console   Results   Trace   AI                              Help (F1/Alt+H) ]
 44: [ Console   Results   Trace   AI                                         Help ]
 40: [ Console   Results   Trace   AI                                              ]
```

## Reserve the shortest, draw the longest that fits

The room the tabs give up for the button was the width of its longest label. Reserving for `Help (F1/Alt+H)` would have shortened the tab names on a terminal that was only ever going to fit `Help` - names given up for a label that would never be drawn.

It reserves the width of `Help` now and `helpSpan` picks the longest label that actually fits, so the button survives at widths where it used to be dropped. At 44 columns you now get the names *and* the button; before, neither the long label nor the button.

One consequence worth knowing: the label is not monotonic in width. At 70 the tabs keep their key hints and only `Help` fits beside them; at 60 the tabs drop the hints, which frees enough room for the full label. Each width is individually right - it just means widening the terminal can shorten the button's label.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

Tests cover the full label appearing when there is room, the label shortening before the button is dropped, the tab names surviving at 44 where the button also fits, and the existing guarantees - the line never wrapping and the button never overlapping a tab, at every width from 1 to 200.

Closes #126