### PR TITLE
feat(ui): add a Capture control, and complete file paths

### DIFF
--- a/internal/router/capture.go
+++ b/internal/router/capture.go
@@ -8,12 +8,34 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
 )
+
+// captureFormats are the formats CAPTURE takes in front of a filename. Without
+// one it writes text.
+var captureFormats = []string{"CSV", "JSON", "PARQUET"}
+
+// captureOptions are the options CAPTURE takes after WITH.
+var captureOptions = []string{"COMPRESSION", "MAX_FILE_SIZE", "PARTITION"}
+
+// CaptureOptions names the options CAPTURE accepts after WITH.
+func CaptureOptions() []string {
+	return slices.Clone(captureOptions)
+}
+
+// CaptureFormats names the formats CAPTURE accepts.
+//
+// Anything offering a choice of format reads this rather than writing the list
+// out again. The consistency levels, the output formats and the key column
+// markers were each spelled out in several places and each drifted.
+func CaptureFormats() []string {
+	return slices.Clone(captureFormats)
+}
 
 // handleCapture handles CAPTURE command to save output to file
 func (h *MetaCommandHandler) handleCapture(command string) interface{} {
@@ -49,8 +71,7 @@ func (h *MetaCommandHandler) handleCapture(command string) interface{} {
 	// Check for format specifier
 	if len(parts) >= 2 {
 		upperFormat := strings.ToUpper(parts[1])
-		switch upperFormat {
-		case "JSON", "CSV", "PARQUET":
+		if slices.Contains(captureFormats, upperFormat) {
 			format = strings.ToLower(upperFormat)
 			filenameStart = 2
 		}

--- a/internal/ui/capture_panel.go
+++ b/internal/ui/capture_panel.go
@@ -1,0 +1,505 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/router"
+)
+
+// The window behind Capture on the bottom line: pick a format, then type where
+// to write it.
+//
+// Two steps, which is one more than the settings lists do, so it is its own
+// window rather than another commandList. It anchors above the field that
+// opened it, the way those lists do.
+//
+// SAVE has the same shape and its own copy of it. #129 tracks moving SAVE onto
+// this one; two of them will drift, which is how five separate bugs happened
+// this week.
+
+// captureStep is which half of the window is showing.
+type captureStep int
+
+const (
+	captureChooseFormat captureStep = iota
+	captureEnterPath
+)
+
+// capturePanel is the open window, if any.
+type capturePanel struct {
+	active  bool
+	step    captureStep
+	formats []string
+	format  int // index into formats
+	anchorX int // column the field starts at, when opened from it
+
+	// centred says to put the window in the middle of the screen rather than
+	// above the field. Typing CAPTURE has no field to point at, and a window
+	// hugging the bottom right corner for a command typed at the prompt looks
+	// like it belongs to something you did not touch.
+	centred bool
+
+	input textinput.Model
+
+	// matches are the candidates from the last Tab, shown when more than one
+	// name fits what has been typed. They are a list you pick from, not a note
+	// under the box: joined onto one line they ran off the right-hand edge with
+	// no way to see or reach the rest.
+	matches     []string
+	match       int // which candidate is highlighted
+	matchScroll int // first candidate shown
+}
+
+// captureMatchRows is the most candidates shown at once. Anything longer
+// scrolls, so a directory with a hundred files does not fill the screen.
+const captureMatchRows = 8
+
+// captureStopping is the entry that turns capture off, offered only while it
+// is running.
+const captureStopping = "OFF"
+
+// openCapturePanel opens the window above the Capture field, for a click on it.
+func (m *MainModel) openCapturePanel(anchorX int) (*MainModel, tea.Cmd) {
+	return m.showCapturePanel(anchorX, false)
+}
+
+// openCapturePanelCentred opens it in the middle of the screen, for the typed
+// CAPTURE command, which has no field to point at.
+func (m *MainModel) openCapturePanelCentred() (*MainModel, tea.Cmd) {
+	return m.showCapturePanel(0, true)
+}
+
+func (m *MainModel) showCapturePanel(anchorX int, centred bool) (*MainModel, tea.Cmd) {
+	if m.capture.active {
+		m.capture = capturePanel{}
+		return m, nil
+	}
+
+	// The formats the command parses, so the list cannot offer one it will
+	// refuse. CAPTURE with no format at all writes text; that is still there
+	// if you type it, but it is not one of the choices, because the usage does
+	// not list it as one.
+	formats := router.CaptureFormats()
+	if handler := router.GetMetaHandler(); handler != nil && handler.IsCapturing() {
+		// Stopping is the thing you want while it is running, so it goes first.
+		formats = append([]string{captureStopping}, formats...)
+	}
+
+	input := textinput.New()
+	input.Prompt = "> "
+	input.CharLimit = 512
+	input.SetWidth(48)
+
+	m.capture = capturePanel{
+		active:  true,
+		formats: formats,
+		anchorX: anchorX,
+		centred: centred,
+		input:   input,
+	}
+	return m, nil
+}
+
+// closeCapturePanel dismisses the window without changing anything.
+func (m *MainModel) closeCapturePanel() {
+	m.capture = capturePanel{}
+}
+
+// captureGeometry is where the window sits.
+//
+// Drawing and clicking both come through here, so a click cannot land on a
+// different row from the one drawn there.
+type captureGeometry struct {
+	x, y          int
+	width, height int
+	rows          []string // the lines inside the border
+}
+
+// captureRows builds what the window shows at the step it is on.
+func (m *MainModel) captureRows() []string {
+	c := m.capture
+
+	if c.step == captureChooseFormat {
+		rows := make([]string, 0, len(c.formats)+2)
+		rows = append(rows, "Capture output to a file", "")
+		for i, format := range c.formats {
+			marker := "  "
+			if i == c.format {
+				marker = "> "
+			}
+			rows = append(rows, marker+captureFormatLabel(format))
+		}
+		return append(rows, "", "↑↓: Move   Enter: Choose   Esc: Close")
+	}
+
+	rows := []string{
+		fmt.Sprintf("Capture as %s", c.formats[c.format]),
+		"",
+		c.input.View(),
+		"",
+	}
+
+	if len(c.matches) == 0 {
+		return append(rows, "Tab: Complete   Enter: Start   Esc: Back")
+	}
+
+	// The candidates from the last Tab, as a list to pick from.
+	first, last := c.matchWindow()
+	width := 0
+	for _, name := range c.matches {
+		width = max(width, lipgloss.Width(name))
+	}
+
+	for i := first; i < last; i++ {
+		marker := "  "
+		if i == c.match {
+			marker = "> "
+		}
+		rows = append(rows, marker+pad(c.matches[i], width))
+	}
+
+	return append(rows, "", "↑↓: Move   Enter: Use   Tab: Complete   Esc: Back")
+}
+
+// matchWindow is the slice of candidates showing, so a long list scrolls with
+// the highlighted one in view.
+func (c capturePanel) matchWindow() (first, last int) {
+	if len(c.matches) <= captureMatchRows {
+		return 0, len(c.matches)
+	}
+
+	first = min(max(c.matchScroll, 0), len(c.matches)-captureMatchRows)
+	return first, first + captureMatchRows
+}
+
+// captureMatchesStart is how many rows sit above the candidates inside the
+// border: the title, a blank line, the path box, and another blank.
+const captureMatchesStart = 4
+
+// matchAt returns the candidate under a screen position.
+func (m *MainModel) matchAt(screenWidth, screenHeight, col, row int) (int, bool) {
+	g, ok := m.captureGeometry(screenWidth, screenHeight)
+	if !ok || m.capture.step != captureEnterPath || len(m.capture.matches) == 0 {
+		return 0, false
+	}
+	if col <= g.x || col >= g.x+g.width-1 {
+		return 0, false
+	}
+
+	first, last := m.capture.matchWindow()
+	i := first + (row - g.y - 1 - captureMatchesStart)
+	if i < first || i >= last {
+		return 0, false
+	}
+	return i, true
+}
+
+// showMatch highlights a candidate and keeps it in view.
+func (m *MainModel) showMatch(i int) {
+	m.capture.match = min(max(i, 0), len(m.capture.matches)-1)
+
+	m.capture.matchScroll = min(m.capture.matchScroll, m.capture.match)
+	m.capture.matchScroll = max(m.capture.matchScroll, m.capture.match-captureMatchRows+1)
+	m.capture.matchScroll = max(m.capture.matchScroll, 0)
+}
+
+// useMatch puts the highlighted candidate into the path.
+//
+// A directory keeps the list open on what is inside it, so you can walk down a
+// tree without retyping any of it.
+func (m *MainModel) useMatch() (*MainModel, tea.Cmd) {
+	if len(m.capture.matches) == 0 {
+		return m, nil
+	}
+
+	dir, _ := splitPath(m.capture.input.Value())
+	chosen := dir + m.capture.matches[m.capture.match]
+
+	m.capture.input.SetValue(chosen)
+	m.capture.input.CursorEnd()
+	m.clearMatches()
+
+	if strings.HasSuffix(chosen, string(filepath.Separator)) {
+		return m.completeCapturePath()
+	}
+	return m, nil
+}
+
+// clearMatches takes the list down.
+func (m *MainModel) clearMatches() {
+	m.capture.matches = nil
+	m.capture.match = 0
+	m.capture.matchScroll = 0
+}
+
+// captureHeaderRows is how many rows sit above the format entries inside the
+// border: the title and the blank line under it.
+const captureHeaderRows = 2
+
+// formatAt returns the format under a screen position, if the click is on one.
+//
+// It counts from the same rows captureRows builds, so a click cannot land on
+// the row above the one you pointed at. There is a test that the row it names
+// really does hold that format.
+func (m *MainModel) formatAt(screenWidth, screenHeight, col, row int) (int, bool) {
+	g, ok := m.captureGeometry(screenWidth, screenHeight)
+	if !ok || m.capture.step != captureChooseFormat {
+		return 0, false
+	}
+
+	// Inside the border, not on it.
+	if col <= g.x || col >= g.x+g.width-1 {
+		return 0, false
+	}
+
+	i := row - g.y - 1 - captureHeaderRows
+	if i < 0 || i >= len(m.capture.formats) {
+		return 0, false
+	}
+	return i, true
+}
+
+// inCapturePanel reports whether a position is inside the window.
+func (m *MainModel) inCapturePanel(screenWidth, screenHeight, col, row int) bool {
+	g, ok := m.captureGeometry(screenWidth, screenHeight)
+	return ok && col >= g.x && col < g.x+g.width && row >= g.y && row < g.y+g.height
+}
+
+// captureFormatLabel says what each entry does, since OFF and TEXT are not
+// self-explanatory next to CSV and JSON.
+func captureFormatLabel(format string) string {
+	switch format {
+	case captureStopping:
+		return "OFF       stop capturing"
+	case "CSV":
+		return "CSV       comma separated"
+	case "JSON":
+		return "JSON      one object per row"
+	case "PARQUET":
+		return "PARQUET   columnar, for analysis"
+	}
+	return format
+}
+
+func (m *MainModel) captureGeometry(screenWidth, screenHeight int) (captureGeometry, bool) {
+	if !m.capture.active {
+		return captureGeometry{}, false
+	}
+
+	rows := m.captureRows()
+
+	inner := 0
+	for _, row := range rows {
+		if w := lipgloss.Width(row); w > inner {
+			inner = w
+		}
+	}
+	inner = min(inner+2, max(screenWidth-2, 0))
+
+	width := inner + 2
+	height := len(rows) + 2
+	if width < 20 || height > screenHeight-1 {
+		return captureGeometry{}, false
+	}
+
+	x := min(m.capture.anchorX, max(screenWidth-width, 0))
+	y := max(screenHeight-1-height, 0)
+	if m.capture.centred {
+		x = max((screenWidth-width)/2, 0)
+		y = max((screenHeight-height)/2, 0)
+	}
+
+	return captureGeometry{x: x, y: y, width: width, height: height, rows: rows}, true
+}
+
+// viewCapturePanel renders the window and says where to put it.
+func (m *MainModel) viewCapturePanel(screenWidth, screenHeight int) (Layer, bool) {
+	g, ok := m.captureGeometry(screenWidth, screenHeight)
+	if !ok {
+		return Layer{}, false
+	}
+
+	titleStyle := lipgloss.NewStyle().Foreground(m.styles.Accent).Bold(true)
+	chosenStyle := lipgloss.NewStyle().Foreground(m.styles.Accent).Bold(true)
+	textStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#D0D0D0"))
+	quietStyle := lipgloss.NewStyle().Foreground(m.styles.MutedText.GetForeground())
+
+	inner := g.width - 2
+
+	// The scrollbar goes against the right-hand edge, which is only known once
+	// the box has been sized from its widest row. Appending it to the row text
+	// left it floating in the middle of the box.
+	first, last := m.capture.matchWindow()
+	scrolls := m.capture.step == captureEnterPath && len(m.capture.matches) > captureMatchRows
+	thumb := scrollbarColumn(last-first, first, len(m.capture.matches))
+	thumbStyle := lipgloss.NewStyle().Foreground(m.styles.Accent)
+	trackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
+
+	var b strings.Builder
+	for i, row := range g.rows {
+		style := textStyle
+		switch {
+		case i == 0:
+			style = titleStyle
+		case i == len(g.rows)-1:
+			style = quietStyle
+		case strings.HasPrefix(row, "> "):
+			style = chosenStyle
+		}
+
+		candidate := i - captureMatchesStart
+		if scrolls && candidate >= 0 && candidate < last-first {
+			b.WriteString(style.Render(pad(" "+row, inner-1)))
+			if thumb[candidate] {
+				b.WriteString(thumbStyle.Render("█"))
+			} else {
+				b.WriteString(trackStyle.Render("░"))
+			}
+		} else {
+			b.WriteString(style.Render(pad(" "+row, inner)))
+		}
+
+		if i < len(g.rows)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return Layer{
+		Content: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(m.styles.Accent).
+			Render(b.String()),
+		X:      g.x,
+		Y:      g.y,
+		Width:  g.width,
+		Height: g.height,
+		ZIndex: 200,
+	}, true
+}
+
+// handleCaptureKey takes a keypress while the window is open.
+func (m *MainModel) handleCaptureKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
+	switch m.capture.step {
+	case captureChooseFormat:
+		switch msg.String() {
+		case "esc":
+			m.closeCapturePanel()
+		case "up":
+			m.capture.format = max(m.capture.format-1, 0)
+		case "down":
+			m.capture.format = min(m.capture.format+1, len(m.capture.formats)-1)
+		case "enter":
+			return m.chooseCaptureFormat()
+		}
+		return m, nil
+
+	default:
+		// While the candidates are showing they are what the arrows and Enter
+		// are aimed at; Escape puts them away and leaves the path alone.
+		if len(m.capture.matches) > 0 {
+			switch msg.String() {
+			case "up":
+				m.showMatch(m.capture.match - 1)
+				return m, nil
+			case "down":
+				m.showMatch(m.capture.match + 1)
+				return m, nil
+			case "enter":
+				return m.useMatch()
+			case "esc":
+				m.clearMatches()
+				return m, nil
+			}
+		}
+
+		switch msg.String() {
+		case "esc":
+			// Back a step rather than closing, so a mistyped path does not
+			// cost you the format as well.
+			m.capture.step = captureChooseFormat
+			m.clearMatches()
+			return m, nil
+		case "tab":
+			return m.completeCapturePath()
+		case "enter":
+			return m.startCapture()
+		}
+
+		var cmd tea.Cmd
+		m.capture.input, cmd = m.capture.input.Update(msg)
+		m.clearMatches() // what was listed no longer describes what is typed
+		return m, cmd
+	}
+}
+
+// chooseCaptureFormat moves on to the path, or stops capturing if that is what
+// was picked.
+func (m *MainModel) chooseCaptureFormat() (*MainModel, tea.Cmd) {
+	if m.capture.formats[m.capture.format] == captureStopping {
+		m.closeCapturePanel()
+		return m.runCommand("CAPTURE OFF")
+	}
+
+	m.capture.step = captureEnterPath
+	m.capture.input.SetValue(m.defaultCaptureName())
+	m.capture.input.CursorEnd()
+	m.capture.input.Focus()
+	return m, nil
+}
+
+// defaultCaptureName is a filename to start from, so there is something to edit
+// rather than an empty box.
+func (m *MainModel) defaultCaptureName() string {
+	ext := ".txt"
+	switch m.capture.formats[m.capture.format] {
+	case "CSV":
+		ext = ".csv"
+	case "JSON":
+		ext = ".json"
+	case "PARQUET":
+		ext = ".parquet"
+	}
+
+	return fmt.Sprintf("capture_%s%s", time.Now().Format("20060102_150405"), ext)
+}
+
+// completeCapturePath fills in as much of the path as the candidates agree on.
+func (m *MainModel) completeCapturePath() (*MainModel, tea.Cmd) {
+	got := completePath(m.capture.input.Value())
+
+	m.capture.input.SetValue(got.Completed)
+	m.capture.input.CursorEnd()
+
+	// List them only when filling in was not enough to pick one.
+	m.clearMatches()
+	if len(got.Matches) > 1 {
+		m.capture.matches = got.Matches
+	}
+	return m, nil
+}
+
+// startCapture runs the CAPTURE command the window describes.
+func (m *MainModel) startCapture() (*MainModel, tea.Cmd) {
+	path := strings.TrimSpace(m.capture.input.Value())
+	if path == "" {
+		return m, nil
+	}
+
+	command := captureCommand(m.capture.formats[m.capture.format], path)
+	m.closeCapturePanel()
+	return m.runCommand(command)
+}
+
+// captureCommand is the CAPTURE the window describes.
+//
+// It goes through the same command typing it would, so both routes behave the
+// same.
+func captureCommand(format, path string) string {
+	return "CAPTURE " + format + " '" + filepath.Clean(path) + "'"
+}

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -1,0 +1,527 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/axonops/cqlai/internal/router"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureModel() *MainModel {
+	m := chooserModel()
+	m.windowWidth = 120
+	return m
+}
+
+// captureColumn is the middle of the Capture field on the status line.
+func captureColumn(m *MainModel) int {
+	for _, seg := range placeSegments(m.statusBar.segments(), m.windowWidth) {
+		if seg.setting == settingCapture {
+			return (seg.start + seg.end) / 2
+		}
+	}
+	return -1
+}
+
+// TestCaptureSitsAtTheRightOfTheLine, out of the way of the settings.
+func TestCaptureSitsAtTheRightOfTheLine(t *testing.T) {
+	m := captureModel()
+
+	segs := placeSegments(m.statusBar.segments(), m.windowWidth)
+	last := segs[len(segs)-1]
+
+	assert.Equal(t, settingCapture, last.setting)
+	assert.Equal(t, m.windowWidth-statusBarPadding, last.end, "against the right edge")
+
+	// And a click there resolves to it.
+	setting, _, ok := m.statusBar.settingAt(m.windowWidth, captureColumn(m))
+	require.True(t, ok)
+	assert.Equal(t, settingCapture, setting)
+}
+
+// TestCaptureIsDroppedWhenTheLineIsFull rather than sitting on top of a field.
+func TestCaptureIsDroppedWhenTheLineIsFull(t *testing.T) {
+	m := captureModel()
+
+	segs := placeSegments(m.statusBar.segments(), 60)
+	for _, seg := range segs {
+		assert.NotEqual(t, settingCapture, seg.setting, "there is no room for it here")
+	}
+
+	// The fields that remain do not overlap.
+	for i := 1; i < len(segs); i++ {
+		assert.GreaterOrEqual(t, segs[i].start, segs[i-1].end)
+	}
+}
+
+// TestClickingCaptureOpensAndClosesIt.
+func TestClickingCaptureOpensAndClosesIt(t *testing.T) {
+	m := captureModel()
+
+	m.clickStatusSetting(captureColumn(m))
+	require.True(t, m.capture.active)
+	assert.Equal(t, captureChooseFormat, m.capture.step)
+
+	m.clickStatusSetting(captureColumn(m))
+	assert.False(t, m.capture.active)
+}
+
+// TestTheFormatsComeFromTheCommand, so the window cannot offer one CAPTURE
+// will refuse.
+func TestTheFormatsComeFromTheCommand(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+
+	assert.Equal(t, router.CaptureFormats(), m.capture.formats,
+		"the usage lists JSON, CSV and PARQUET; TEXT is not one of the choices")
+}
+
+// TestChoosingAFormatAsksForAPath, with something to edit rather than an empty
+// box.
+func TestChoosingAFormatAsksForAPath(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+
+	m.capture.format = 1 // JSON
+	m.chooseCaptureFormat()
+
+	assert.Equal(t, captureEnterPath, m.capture.step)
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), ".json"),
+		"the default name should match the format: %q", m.capture.input.Value())
+}
+
+// TestTheCommandMatchesWhatTypingItWouldBe.
+func TestTheCommandMatchesWhatTypingItWouldBe(t *testing.T) {
+	assert.Equal(t, "CAPTURE JSON 'out.json'", captureCommand("JSON", "out.json"))
+	assert.Equal(t, "CAPTURE PARQUET 'data.parquet'", captureCommand("PARQUET", "data.parquet"))
+	assert.Equal(t, "CAPTURE CSV 'a/b.csv'", captureCommand("CSV", "a//b.csv"))
+}
+
+// TestEscapeGoesBackAStep, so a mistyped path does not cost you the format.
+func TestEscapeGoesBackAStep(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	require.Equal(t, captureEnterPath, m.capture.step)
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.Equal(t, captureChooseFormat, m.capture.step)
+	assert.True(t, m.capture.active, "back a step, not closed")
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.False(t, m.capture.active)
+}
+
+// TestTheArrowsMoveWithinTheFormats and stop at the ends.
+func TestTheArrowsMoveWithinTheFormats(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+
+	for range 20 {
+		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	assert.Equal(t, len(m.capture.formats)-1, m.capture.format)
+
+	for range 20 {
+		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	assert.Equal(t, 0, m.capture.format)
+}
+
+// TestTabCompletesThePath.
+func TestTabCompletesThePath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	m := captureModel()
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue(filepath.Join(dir, "res"))
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	assert.Equal(t, filepath.Join(dir, "results.csv"), m.capture.input.Value())
+}
+
+// TestTabListsTheCandidatesWhenFillingInIsNotEnough.
+func TestTabListsTheCandidatesWhenFillingInIsNotEnough(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"report.csv", "report.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := captureModel()
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue(filepath.Join(dir, "rep"))
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	assert.Equal(t, filepath.Join(dir, "report."), m.capture.input.Value())
+	assert.Equal(t, []string{"report.csv", "report.json"}, m.capture.matches)
+
+	// A list, one per row, not a line running off the edge.
+	layer, ok := m.viewCapturePanel(m.windowWidth, 30)
+	require.True(t, ok)
+	rows := strings.Split(stripAnsiForTest(layer.Content), "\n")
+	assert.Contains(t, rows[1+captureMatchesStart], "report.csv")
+	assert.Contains(t, rows[2+captureMatchesStart], "report.json")
+}
+
+// TestTypingClearsTheListedCandidates, since they no longer describe what is
+// in the box.
+func TestTypingClearsTheListedCandidates(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.matches = []string{"a", "b"}
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: 'x', Text: "x"})
+
+	assert.Empty(t, m.capture.matches)
+}
+
+// TestAnEmptyPathStartsNothing.
+func TestAnEmptyPathStartsNothing(t *testing.T) {
+	m := captureModel()
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue("   ")
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.True(t, m.capture.active, "it should still be asking for a path")
+}
+
+// TestTheWindowSitsAboveTheField it was opened from.
+func TestTheWindowSitsAboveTheField(t *testing.T) {
+	const screenHeight = 30
+	m := captureModel()
+	m.openCapturePanel(captureColumn(m))
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, screenHeight)
+	require.True(t, ok)
+
+	assert.Equal(t, screenHeight-1, layer.Y+layer.Height, "it should sit on the status line")
+	assert.LessOrEqual(t, layer.X+layer.Width, m.windowWidth, "and stay on the screen")
+}
+
+// TestEveryFormatIsClickable, and the row that answers a click is the row
+// showing that format.
+func TestEveryFormatIsClickable(t *testing.T) {
+	const screenHeight = 30
+	m := captureModel()
+	m.openCapturePanel(4)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, screenHeight)
+	require.True(t, ok)
+	rows := strings.Split(stripAnsiForTest(layer.Content), "\n")
+
+	for i, format := range m.capture.formats {
+		row := layer.Y + 1 + captureHeaderRows + i
+
+		got, hit := m.formatAt(m.windowWidth, screenHeight, layer.X+3, row)
+		require.True(t, hit, "row %d should be format %q", row, format)
+		assert.Equal(t, i, got)
+
+		// The row the click resolves to is the row that shows it.
+		assert.Contains(t, rows[row-layer.Y], format,
+			"row %d answers for %q but does not show it", row, format)
+	}
+}
+
+// TestClickingAFormatMovesOnToThePath.
+func TestClickingAFormatMovesOnToThePath(t *testing.T) {
+	const screenHeight = 30
+	m := captureModel()
+	m.windowHeight = screenHeight
+	m.openCapturePanel(4)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, screenHeight)
+	require.True(t, ok)
+
+	// The JSON row.
+	json := 1
+	require.Equal(t, "JSON", m.capture.formats[json])
+	pressAt(m, layer.X+3, layer.Y+1+captureHeaderRows+json)
+
+	assert.Equal(t, captureEnterPath, m.capture.step)
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), ".json"))
+}
+
+// TestClickingTheTitleOrHintsPicksNothing: the box has rows that are not
+// formats, and a click on one must not apply the nearest.
+func TestClickingTheTitleOrHintsPicksNothing(t *testing.T) {
+	const screenHeight = 30
+	m := captureModel()
+	m.openCapturePanel(4)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, screenHeight)
+	require.True(t, ok)
+
+	for _, row := range []int{
+		layer.Y,     // the border
+		layer.Y + 1, // the title
+		layer.Y + 1 + captureHeaderRows + len(m.capture.formats), // the blank line after
+		layer.Y + layer.Height - 2,                               // the hints
+	} {
+		_, hit := m.formatAt(m.windowWidth, screenHeight, layer.X+3, row)
+		assert.False(t, hit, "row %d is not a format", row-layer.Y)
+	}
+}
+
+// TestClickingOutsideClosesIt.
+func TestClickingOutsideClosesIt(t *testing.T) {
+	m := captureModel()
+	m.windowHeight = 30
+	m.openCapturePanel(4)
+	require.True(t, m.capture.active)
+
+	pressAt(m, 100, 5)
+
+	assert.False(t, m.capture.active)
+}
+
+// TestClickingInThePathBoxLeavesTheTypingAlone.
+func TestClickingInThePathBoxLeavesTheTypingAlone(t *testing.T) {
+	const screenHeight = 30
+	m := captureModel()
+	m.windowHeight = screenHeight
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue("half-typed-path")
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, screenHeight)
+	require.True(t, ok)
+	pressAt(m, layer.X+3, layer.Y+2)
+
+	assert.True(t, m.capture.active, "a press in the box should not close it")
+	assert.Equal(t, "half-typed-path", m.capture.input.Value())
+}
+
+// TestClickingCaptureAgainDoesNotReopenIt in the same press.
+func TestClickingCaptureAgainDoesNotReopenIt(t *testing.T) {
+	m := captureModel()
+	m.windowHeight = 30
+	m.openCapturePanel(captureColumn(m))
+	require.True(t, m.capture.active)
+
+	pressAt(m, captureColumn(m), m.windowHeight-1)
+
+	assert.False(t, m.capture.active)
+}
+
+// manyFiles makes a directory with n candidates, more than the list shows.
+func manyFiles(t *testing.T, n int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for i := range n {
+		name := filepath.Join(dir, fmt.Sprintf("file%02d.csv", i))
+		require.NoError(t, os.WriteFile(name, nil, 0o600))
+	}
+	return dir
+}
+
+// listingModel opens the capture window with a directory listed.
+func listingModel(t *testing.T, files int) *MainModel {
+	t.Helper()
+
+	m := captureModel()
+	m.windowHeight = 30
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue(manyFiles(t, files) + string(filepath.Separator))
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Len(t, m.capture.matches, files)
+	return m
+}
+
+// TestTheCandidatesAreAListNotALine. Joined onto one line they ran off the
+// right-hand edge with no way to see or reach the rest.
+func TestTheCandidatesAreAListNotALine(t *testing.T) {
+	m := listingModel(t, 4)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, 30)
+	require.True(t, ok)
+
+	rows := strings.Split(stripAnsiForTest(layer.Content), "\n")
+	for i, name := range m.capture.matches {
+		assert.Contains(t, rows[1+captureMatchesStart+i], name,
+			"candidate %d should be on its own row", i)
+	}
+	for _, row := range rows {
+		assert.LessOrEqual(t, lipgloss.Width(row), layer.Width, "row runs past the box: %q", row)
+	}
+}
+
+// TestALongListScrollsRatherThanFillingTheScreen.
+func TestALongListScrollsRatherThanFillingTheScreen(t *testing.T) {
+	m := listingModel(t, 40)
+
+	first, last := m.capture.matchWindow()
+	assert.Equal(t, captureMatchRows, last-first)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, 30)
+	require.True(t, ok)
+	assert.Less(t, layer.Height, 20, "the window should not grow with the listing")
+}
+
+// TestTheArrowsWalkTheWholeList, with the window following.
+func TestTheArrowsWalkTheWholeList(t *testing.T) {
+	m := listingModel(t, 40)
+
+	seen := map[int]bool{}
+	for range 60 {
+		first, last := m.capture.matchWindow()
+		require.GreaterOrEqual(t, m.capture.match, first, "the highlight left the window")
+		require.Less(t, m.capture.match, last, "the highlight left the window")
+		seen[m.capture.match] = true
+		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+
+	assert.Equal(t, 39, m.capture.match, "it should stop at the last candidate")
+	assert.Len(t, seen, 40, "every candidate should be reachable")
+
+	for range 60 {
+		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	assert.Equal(t, 0, m.capture.match)
+	assert.Equal(t, 0, m.capture.matchScroll)
+}
+
+// TestEnterUsesTheHighlightedCandidate rather than starting the capture.
+func TestEnterUsesTheHighlightedCandidate(t *testing.T) {
+	m := listingModel(t, 4)
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), "file01.csv"),
+		"got %q", m.capture.input.Value())
+	assert.Empty(t, m.capture.matches, "the list should have gone")
+	assert.True(t, m.capture.active, "and it should not have started capturing")
+}
+
+// TestClickingACandidateUsesIt.
+func TestClickingACandidateUsesIt(t *testing.T) {
+	m := listingModel(t, 4)
+
+	layer, ok := m.viewCapturePanel(m.windowWidth, m.windowHeight)
+	require.True(t, ok)
+	pressAt(m, layer.X+3, layer.Y+1+captureMatchesStart+2)
+
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), "file02.csv"),
+		"got %q", m.capture.input.Value())
+}
+
+// TestChoosingADirectoryOpensIt, so a tree can be walked without retyping.
+func TestChoosingADirectoryOpensIt(t *testing.T) {
+	dir := t.TempDir()
+	inner := filepath.Join(dir, "exports")
+	require.NoError(t, os.Mkdir(inner, 0o750))
+	for _, name := range []string{"one.csv", "two.csv"} {
+		require.NoError(t, os.WriteFile(filepath.Join(inner, name), nil, 0o600))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "other.csv"), nil, 0o600))
+
+	m := captureModel()
+	m.windowHeight = 30
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue(dir + string(filepath.Separator))
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	// The directory sorts first.
+	require.Equal(t, "exports"+string(filepath.Separator), m.capture.matches[0])
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.Equal(t, inner+string(filepath.Separator), m.capture.input.Value())
+	assert.Equal(t, []string{"one.csv", "two.csv"}, m.capture.matches,
+		"it should be listing what is inside")
+}
+
+// TestEscapePutsTheListAwayWithoutLosingThePath.
+func TestEscapePutsTheListAwayWithoutLosingThePath(t *testing.T) {
+	m := listingModel(t, 4)
+	path := m.capture.input.Value()
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	assert.Empty(t, m.capture.matches)
+	assert.Equal(t, path, m.capture.input.Value())
+	assert.Equal(t, captureEnterPath, m.capture.step, "still asking for a path")
+}
+
+// TestTheWheelMovesTheList.
+func TestTheWheelMovesTheList(t *testing.T) {
+	m := listingModel(t, 40)
+
+	m.handleMouseInput(tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 10, Y: 10})
+
+	assert.Equal(t, wheelLines, m.capture.match)
+}
+
+// TestTypingCaptureCentresTheWindow.
+//
+// A window hugging the bottom right corner for a command typed at the prompt
+// looks like it belongs to something you did not touch.
+func TestTypingCaptureCentresTheWindow(t *testing.T) {
+	const w, h = 120, 30
+	m := captureModel()
+	m.windowHeight = h
+	m.statusBar = testStatusBar()
+
+	_, _, handled := m.handleSpecialCommands("CAPTURE")
+	require.True(t, handled)
+	require.True(t, m.capture.active)
+
+	layer, ok := m.viewCapturePanel(w, h)
+	require.True(t, ok)
+
+	assert.Equal(t, max((w-layer.Width)/2, 0), layer.X, "centred across")
+	assert.Equal(t, max((h-layer.Height)/2, 0), layer.Y, "and down")
+}
+
+// TestClickingCaptureKeepsTheWindowOnTheField, since that is what it points at.
+func TestClickingCaptureKeepsTheWindowOnTheField(t *testing.T) {
+	const w, h = 120, 30
+	m := captureModel()
+	m.windowHeight = h
+	m.clickStatusSetting(captureColumn(m))
+	require.True(t, m.capture.active)
+
+	layer, ok := m.viewCapturePanel(w, h)
+	require.True(t, ok)
+
+	assert.Equal(t, h-1, layer.Y+layer.Height, "sitting on the status line")
+	assert.NotEqual(t, max((w-layer.Width)/2, 0), layer.X, "not centred")
+}
+
+// TestBothRoutesGiveTheSameWindow, only in a different place.
+func TestBothRoutesGiveTheSameWindow(t *testing.T) {
+	const w, h = 120, 30
+
+	clicked := captureModel()
+	clicked.windowHeight = h
+	clicked.clickStatusSetting(captureColumn(clicked))
+	clickedLayer, ok := clicked.viewCapturePanel(w, h)
+	require.True(t, ok)
+
+	typed := captureModel()
+	typed.windowHeight = h
+	typed.statusBar = testStatusBar()
+	typed.handleSpecialCommands("CAPTURE")
+	typedLayer, ok := typed.viewCapturePanel(w, h)
+	require.True(t, ok)
+
+	assert.Equal(t, clickedLayer.Content, typedLayer.Content, "the same window")
+	assert.Equal(t, clickedLayer.Width, typedLayer.Width)
+}

--- a/internal/ui/completion/paths.go
+++ b/internal/ui/completion/paths.go
@@ -1,0 +1,156 @@
+package completion
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Completing a file path at the prompt.
+//
+// Every command that takes a file had the same gap: completion knew the
+// keyword and offered nothing after it, so paths had to be typed out in full
+// and correctly. One rule covers all of them, because doing it for one command
+// is how the next one becomes a bug.
+
+// pathContexts match a command up to the point where a file path begins.
+//
+// The path itself is left out of the match deliberately: what has been typed so
+// far is whatever follows, quoted or not.
+var pathContexts = []*regexp.Regexp{
+	// CAPTURE takes a format and then a file. Without the format there is
+	// nothing to complete a path against yet - the formats are what is wanted
+	// there, and getCaptureCompletions offers them.
+	// The space after the format is optional: once the format is complete the
+	// next thing is a file, whether or not you have pressed space yet.
+	regexp.MustCompile(`(?i)^\s*CAPTURE\s+(?:CSV|JSON|PARQUET)\b\s*`),
+	regexp.MustCompile(`(?i)^\s*SOURCE\s+`),
+	regexp.MustCompile(`(?i)^\s*SAVE\s+`),
+	// COPY takes a table first, then TO or FROM, then the file.
+	regexp.MustCompile(`(?i)\s(?:TO|FROM)\s+`),
+}
+
+// withClause matches the start of a WITH clause, after which the filename is
+// finished and options are being typed.
+var withClause = regexp.MustCompile(`(?i)\sWITH\b`)
+
+// captureWord matches CAPTURE and the space after it, with nothing said about
+// what follows.
+var captureWord = regexp.MustCompile(`(?i)^\s*CAPTURE\s+`)
+
+// pathStart are the characters that mean what is being typed is a path rather
+// than a keyword.
+const pathStart = `'"/~.`
+
+// PathPrefix reports whether the input is at a point where a file path is
+// expected, and returns what has been typed of it.
+//
+// The quote is reported separately so the completion can be put back inside it
+// rather than completed against a leading apostrophe.
+func PathPrefix(input string) (prefix, quote string, ok bool) {
+	// Once WITH appears the filename is behind us and the options are what is
+	// being typed, so the path completer has no business here.
+	if withClause.MatchString(input) {
+		return "", "", false
+	}
+
+	// CAPTURE takes a format and then a file, so after the word itself the
+	// formats are what is wanted - unless what is being typed already looks
+	// like a path, since CAPTURE 'file' with no format is still valid.
+	if loc := captureWord.FindStringIndex(input); loc != nil {
+		rest := input[loc[1]:]
+		if rest != "" && strings.ContainsRune(pathStart, rune(rest[0])) {
+			return unquote(rest)
+		}
+	}
+
+	for _, context := range pathContexts {
+		loc := context.FindStringIndex(input)
+		if loc == nil {
+			continue
+		}
+
+		// COPY's TO/FROM has to belong to a COPY, not to a SELECT ... FROM.
+		if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(input)), "COPY") &&
+			context == pathContexts[len(pathContexts)-1] {
+			continue
+		}
+
+		rest := input[loc[1]:]
+
+		// Only the last one counts: COPY t TO 'a' has a TO before the file.
+		if next := lastContext(rest); next != "" {
+			rest = next
+		}
+
+		if finishedPath(rest) {
+			return "", "", false
+		}
+		return unquote(rest)
+	}
+	return "", "", false
+}
+
+// finishedPath reports whether the quoted filename is closed and something
+// follows it, which means what is being typed is no longer the path.
+func finishedPath(rest string) bool {
+	for _, q := range []string{"'", `"`} {
+		if !strings.HasPrefix(rest, q) {
+			continue
+		}
+		if i := strings.Index(rest[1:], q); i >= 0 {
+			return strings.TrimSpace(rest[i+2:]) != "" || strings.HasSuffix(rest, " ")
+		}
+	}
+	return false
+}
+
+// unquote separates a path from the quotes it was typed inside, so the
+// completion can be put back between them.
+//
+// A closing quote is stripped as well as an opening one: the pair is what the
+// usage shows, and without this the closing quote would be taken as part of
+// the path and nothing would ever match.
+func unquote(rest string) (prefix, quote string, ok bool) {
+	for _, q := range []string{"'", `"`} {
+		if !strings.HasPrefix(rest, q) {
+			continue
+		}
+		return strings.TrimSuffix(rest[1:], q), q, true
+	}
+	return rest, "", true
+}
+
+// lastContext handles a second TO or FROM further along the line, so the path
+// being completed is the one under the cursor rather than an earlier one.
+func lastContext(rest string) string {
+	last := pathContexts[len(pathContexts)-1].FindAllStringIndex(rest, -1)
+	if len(last) == 0 {
+		return ""
+	}
+	return rest[last[len(last)-1][1]:]
+}
+
+// ReplacePath puts a completed path back into the input, keeping whatever came
+// before it and the quotes it was between.
+func ReplacePath(input, prefix, quote, completed string) string {
+	if quote == "" {
+		i := strings.LastIndex(input, prefix)
+		if i < 0 {
+			return input
+		}
+		return input[:i] + completed
+	}
+
+	// The closing quote, when there is one, has to survive: the completion
+	// goes between the pair rather than replacing the end of the line.
+	tail, closing := quote+prefix, ""
+	if strings.HasSuffix(input, quote+prefix+quote) {
+		tail, closing = quote+prefix+quote, quote
+	}
+
+	i := strings.LastIndex(input, tail)
+	if i < 0 {
+		return input
+	}
+	return input[:i] + quote + completed + closing
+}

--- a/internal/ui/completion/paths_test.go
+++ b/internal/ui/completion/paths_test.go
@@ -1,0 +1,216 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/axonops/cqlai/internal/router"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAPathIsExpectedAfterEveryCommandThatTakesOne. Doing it for one command
+// is how the next one becomes a bug.
+func TestAPathIsExpectedAfterEveryCommandThatTakesOne(t *testing.T) {
+	tests := []struct{ input, prefix, quote string }{
+		{"CAPTURE JSON /tmp/rep", "/tmp/rep", ""},
+		{"capture json /tmp/rep", "/tmp/rep", ""},
+		{"CAPTURE PARQUET /tmp/", "/tmp/", ""},
+		{"SOURCE /tmp/setup", "/tmp/setup", ""},
+		{"SAVE /tmp/out", "/tmp/out", ""},
+		{"COPY users TO /tmp/out", "/tmp/out", ""},
+		{"COPY users FROM /tmp/in", "/tmp/in", ""},
+
+		// Quoted, which is how these are usually written. A quote means a
+		// path even without a format, since CAPTURE 'file' is still valid.
+		{"CAPTURE '/tmp/rep", "/tmp/rep", "'"},
+		{"CAPTURE /tmp/rep", "/tmp/rep", ""},
+		{`SOURCE "/tmp/rep`, "/tmp/rep", `"`},
+		{"COPY users TO '/tmp/out", "/tmp/out", "'"},
+
+		// Nothing typed yet.
+		{"CAPTURE JSON ", "", ""},
+		{"SOURCE ", "", ""},
+	}
+
+	for _, tt := range tests {
+		prefix, quote, ok := PathPrefix(tt.input)
+		if !assert.True(t, ok, "%q should expect a path", tt.input) {
+			continue
+		}
+		assert.Equal(t, tt.prefix, prefix, "prefix of %q", tt.input)
+		assert.Equal(t, tt.quote, quote, "quote of %q", tt.input)
+	}
+}
+
+// TestSelectFromIsNotAPath. COPY's FROM takes a file; SELECT's does not.
+func TestSelectFromIsNotAPath(t *testing.T) {
+	for _, input := range []string{
+		"CAPTURE",
+		"CAPTURE ",
+		"CAPTURE JS",
+		"SELECT * FROM users",
+		"select id from myks.users where x = 1",
+		"DESCRIBE TABLE users",
+		"CONSISTENCY QUORUM",
+		"",
+	} {
+		_, _, ok := PathPrefix(input)
+		assert.False(t, ok, "%q should not expect a path", input)
+	}
+}
+
+// TestOnceWITHStartsTheFilenameIsBehindUs, so what is being typed is an option
+// rather than a path.
+func TestOnceWITHStartsTheFilenameIsBehindUs(t *testing.T) {
+	for _, input := range []string{
+		"CAPTURE CSV 'out.csv' WITH ",
+		"CAPTURE CSV 'out.csv' WITH COMPRESSION=",
+		"COPY users TO '/tmp/a.csv' WITH HEADER=",
+	} {
+		_, _, ok := PathPrefix(input)
+		assert.False(t, ok, "%q is past the filename", input)
+	}
+}
+
+// TestAFinishedFilenameIsNotStillBeingTyped.
+func TestAFinishedFilenameIsNotStillBeingTyped(t *testing.T) {
+	_, _, ok := PathPrefix("CAPTURE CSV 'out.csv' ")
+	assert.False(t, ok, "the filename is closed and done with")
+}
+
+// TestTheCompletionGoesBackWhereItCameFrom, keeping the command in front of it
+// and the quote around it.
+func TestTheCompletionGoesBackWhereItCameFrom(t *testing.T) {
+	assert.Equal(t, "CAPTURE JSON '/tmp/report.json",
+		ReplacePath("CAPTURE JSON '/tmp/rep", "/tmp/rep", "'", "/tmp/report.json"))
+
+	assert.Equal(t, "COPY users TO '/tmp/out.csv",
+		ReplacePath("COPY users TO '/tmp/o", "/tmp/o", "'", "/tmp/out.csv"))
+
+	// Nothing typed yet: the completion is simply appended.
+	assert.Equal(t, "CAPTURE CSV /tmp/", ReplacePath("CAPTURE CSV ", "", "", "/tmp/"))
+}
+
+// TestCaptureOffersItsFormatsBeforeAPath.
+//
+// The syntax is CAPTURE <format> <file>, so after the word itself the formats
+// are what is wanted - completing a path there was offering the wrong thing.
+func TestCaptureOffersItsFormatsBeforeAPath(t *testing.T) {
+	sce := &SimpleCompletionEngine{}
+
+	after := sce.GetTokenCompletions("CAPTURE ")
+	assert.Contains(t, after, "JSON")
+	assert.Contains(t, after, "CSV")
+	assert.Contains(t, after, "PARQUET")
+	assert.Contains(t, after, "OFF", "stopping is one of the things you can do")
+
+	partial := sce.GetTokenCompletions("CAPTURE PAR")
+	assert.Equal(t, []string{"PARQUET"}, partial)
+}
+
+// TestTheFormatsComeFromTheCommandThatParsesThem.
+func TestTheFormatsComeFromTheCommandThatParsesThem(t *testing.T) {
+	sce := &SimpleCompletionEngine{}
+
+	for _, format := range router.CaptureFormats() {
+		assert.Contains(t, sce.getCaptureFormats(), format)
+	}
+}
+
+// TestAFileIsExpectedWithOrWithoutASpaceAfterTheFormat.
+//
+// Once the format is complete the next thing is a file, whether or not the
+// space has been typed yet.
+func TestAFileIsExpectedWithOrWithoutASpaceAfterTheFormat(t *testing.T) {
+	for _, input := range []string{"CAPTURE CSV", "CAPTURE CSV ", "capture json", "CAPTURE PARQUET"} {
+		prefix, _, ok := PathPrefix(input)
+		assert.True(t, ok, "%q should expect a file", input)
+		assert.Empty(t, prefix, "nothing has been typed of it yet")
+	}
+}
+
+// TestAPartialFormatIsStillAFormat, not a file.
+func TestAPartialFormatIsStillAFormat(t *testing.T) {
+	for _, input := range []string{"CAPTURE CS", "CAPTURE JSO", "CAPTURE P"} {
+		_, _, ok := PathPrefix(input)
+		assert.False(t, ok, "%q is still being typed", input)
+	}
+}
+
+// TestSomethingThatOnlyStartsLikeAFormatIsNot.
+func TestSomethingThatOnlyStartsLikeAFormatIsNot(t *testing.T) {
+	_, _, ok := PathPrefix("CAPTURE CSVX")
+	assert.False(t, ok, "CSVX is not a format")
+}
+
+// TestCompletingBetweenAPairOfQuotes.
+//
+// The usage shows the filename quoted, so the pair is what gets typed. The
+// closing quote must not be taken as part of the path, and must survive the
+// completion.
+func TestCompletingBetweenAPairOfQuotes(t *testing.T) {
+	prefix, quote, ok := PathPrefix("CAPTURE CSV ''")
+	require.True(t, ok)
+	assert.Empty(t, prefix, "there is nothing between them yet")
+	assert.Equal(t, "'", quote)
+
+	assert.Equal(t, "CAPTURE CSV '/tmp/'",
+		ReplacePath("CAPTURE CSV ''", "", "'", "/tmp/"))
+
+	prefix, quote, ok = PathPrefix("CAPTURE CSV '/tmp/rep'")
+	require.True(t, ok)
+	assert.Equal(t, "/tmp/rep", prefix, "the closing quote is not part of the path")
+
+	assert.Equal(t, "CAPTURE CSV '/tmp/report.csv'",
+		ReplacePath("CAPTURE CSV '/tmp/rep'", "/tmp/rep", quote, "/tmp/report.csv"))
+}
+
+// TestAnUnclosedQuoteStillWorks, since people type one and carry on.
+func TestAnUnclosedQuoteStillWorks(t *testing.T) {
+	prefix, quote, ok := PathPrefix("CAPTURE CSV '/tmp/rep")
+	require.True(t, ok)
+	assert.Equal(t, "/tmp/rep", prefix)
+
+	assert.Equal(t, "CAPTURE CSV '/tmp/report.csv",
+		ReplacePath("CAPTURE CSV '/tmp/rep", prefix, quote, "/tmp/report.csv"))
+}
+
+// TestTheWholeCaptureGrammarCompletes:
+//
+//	CAPTURE [JSON|CSV|PARQUET] 'filename' [WITH option=value AND ...]
+//	CAPTURE OFF
+func TestTheWholeCaptureGrammarCompletes(t *testing.T) {
+	sce := &SimpleCompletionEngine{}
+
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"CAPTURE ", append(router.CaptureFormats(), "OFF")},
+		{"CAPTURE PAR", []string{"PARQUET"}},
+		{"CAPTURE OF", []string{"OFF"}},
+
+		// After the filename, the only thing that follows is WITH.
+		{"CAPTURE CSV 'out.csv' ", []string{"WITH"}},
+
+		// The options, then a value, then AND.
+		{"CAPTURE CSV 'out.csv' WITH ", router.CaptureOptions()},
+		{"CAPTURE CSV 'out.csv' WITH COMP", []string{"COMPRESSION"}},
+		{"CAPTURE CSV 'out.csv' WITH COMPRESSION=", ParquetCompressionTypes},
+		{"CAPTURE CSV 'out.csv' WITH MAX_FILE_SIZE=1000", []string{"AND"}},
+		{"CAPTURE CSV 'out.csv' WITH COMPRESSION='snappy'", []string{"AND"}},
+		{"CAPTURE CSV 'out.csv' WITH COMPRESSION='snappy' AND ", router.CaptureOptions()},
+
+		// Nothing follows OFF.
+		{"CAPTURE OFF ", nil},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, sce.GetTokenCompletions(tt.input), "after %q", tt.input)
+	}
+}
+
+// TestTheOptionsComeFromTheCommandThatParsesThem.
+func TestTheOptionsComeFromTheCommandThatParsesThem(t *testing.T) {
+	assert.Equal(t, []string{"COMPRESSION", "MAX_FILE_SIZE", "PARTITION"}, router.CaptureOptions())
+}

--- a/internal/ui/completion/simple_parser.go
+++ b/internal/ui/completion/simple_parser.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/axonops/cqlai/internal/logger"
+	"github.com/axonops/cqlai/internal/router"
 )
 
 // SimpleCompletionEngine provides completions without using ANTLR
@@ -73,6 +74,8 @@ func (sce *SimpleCompletionEngine) GetTokenCompletions(input string) []string {
 		return sce.getListCompletions(words, endsWithSpace)
 	case "SHOW":
 		return sce.getShowCompletions(words, endsWithSpace)
+	case "CAPTURE":
+		return sce.getCaptureCompletions(words, endsWithSpace)
 	case "CONSISTENCY":
 		return sce.getConsistencyCompletions(words, endsWithSpace)
 	case "OUTPUT":
@@ -626,6 +629,127 @@ func (sce *SimpleCompletionEngine) getTopLevelKeywords() []string {
 		"QUIT", "REVOKE", "SELECT", "SHOW", "SOURCE", "TRACING", "TRUNCATE",
 		"UPDATE", "USE",
 	}
+}
+
+// getCaptureCompletions walks the whole CAPTURE grammar:
+//
+//	CAPTURE [JSON|CSV|PARQUET] 'filename' [WITH option=value AND ...]
+//	CAPTURE OFF
+//
+// The filename itself is completed against the filesystem rather than from a
+// list, which the prompt handles; everything else is here.
+func (sce *SimpleCompletionEngine) getCaptureCompletions(words []string, endsWithSpace bool) []string {
+	// CAPTURE <format|OFF>
+	if len(words) == 1 {
+		if endsWithSpace {
+			return sce.getCaptureFormats()
+		}
+		return nil
+	}
+	if len(words) == 2 && !endsWithSpace {
+		return matching(sce.getCaptureFormats(), words[1])
+	}
+	if strings.EqualFold(words[1], "OFF") {
+		return nil // nothing follows OFF
+	}
+
+	// WITH option=value AND ...
+	with := -1
+	for i, word := range words {
+		if strings.EqualFold(word, "WITH") {
+			with = i
+			break
+		}
+	}
+
+	last := words[len(words)-1]
+
+	if with < 0 {
+		// The filename. Once it is closed, WITH is what can follow.
+		if endsWithSpace && isQuoted(last) {
+			return []string{"WITH"}
+		}
+		return nil
+	}
+
+	switch {
+	case endsWithSpace && (strings.EqualFold(last, "WITH") || strings.EqualFold(last, "AND")):
+		return router.CaptureOptions()
+
+	case strings.HasSuffix(last, "="):
+		return sce.captureOptionValues(strings.TrimSuffix(last, "="))
+
+	case strings.Contains(last, "="):
+		name, value, _ := strings.Cut(last, "=")
+		if endsWithSpace || isCompleteValue(value) {
+			return []string{"AND"}
+		}
+		return matching(sce.captureOptionValues(name), value)
+
+	case !endsWithSpace:
+		return matching(router.CaptureOptions(), last)
+	}
+	return router.CaptureOptions()
+}
+
+// captureOptionValues are the values an option takes, where they are known.
+// PARTITION takes column names and MAX_FILE_SIZE a number, so neither has a
+// list to offer.
+func (sce *SimpleCompletionEngine) captureOptionValues(option string) []string {
+	if strings.EqualFold(option, "COMPRESSION") {
+		return ParquetCompressionTypes
+	}
+	return nil
+}
+
+// getCaptureFormats are the words CAPTURE takes after itself, from the command
+// that parses them, plus OFF which stops it.
+func (sce *SimpleCompletionEngine) getCaptureFormats() []string {
+	return append(router.CaptureFormats(), "OFF")
+}
+
+// matching keeps the candidates that start with what has been typed, leaving
+// out the one that is already complete.
+func matching(candidates []string, typed string) []string {
+	kept := []string{}
+	for _, candidate := range candidates {
+		if strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(typed)) &&
+			!strings.EqualFold(candidate, typed) {
+			kept = append(kept, candidate)
+		}
+	}
+	return kept
+}
+
+// isQuoted reports whether a word is a finished quoted string.
+func isQuoted(word string) bool {
+	for _, q := range []string{"'", `"`} {
+		if len(word) > 1 && strings.HasPrefix(word, q) && strings.HasSuffix(word, q) {
+			return true
+		}
+	}
+	return false
+}
+
+// isCompleteValue reports whether an option has been given a value, so what
+// follows is AND rather than more of the value.
+func isCompleteValue(value string) bool {
+	switch {
+	case value == "":
+		return false
+	case isQuoted(value):
+		return true
+	case strings.EqualFold(value, "TRUE"), strings.EqualFold(value, "FALSE"):
+		return true
+	}
+
+	// A number, which is what MAX_FILE_SIZE takes.
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // getConsistencyLevels returns valid consistency levels

--- a/internal/ui/connection_panel_test.go
+++ b/internal/ui/connection_panel_test.go
@@ -90,10 +90,10 @@ func TestConnectionIsClickable(t *testing.T) {
 	m := testStatusBar()
 
 	var found bool
-	for _, seg := range m.segments() {
+	for _, seg := range placeSegments(m.segments(), statusTestWidth) {
 		if seg.setting == settingConnection {
 			found = true
-			setting, _, ok := m.settingAt((seg.start + seg.end) / 2)
+			setting, _, ok := m.settingAt(statusTestWidth, (seg.start+seg.end)/2)
 			require.True(t, ok)
 			assert.Equal(t, settingConnection, setting)
 		}

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -43,6 +43,12 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 		}
 	}
 
+	// The capture window takes keys while it is open: it was opened by a click
+	// a moment ago and it has a text field in it.
+	if m.capture.active {
+		return m.handleCaptureKey(msg)
+	}
+
 	// The settings chooser takes keys while it is open: it was opened by a
 	// click a moment ago, so it is what the next keypress is aimed at.
 	if m.chooser.active {

--- a/internal/ui/keyboard_handler_enter_completion.go
+++ b/internal/ui/keyboard_handler_enter_completion.go
@@ -11,6 +11,12 @@ func (m *MainModel) handleCompletionSelection() (*MainModel, tea.Cmd) {
 	// Get the selected completion (just the next word)
 	selectedCompletion := m.completions[m.completionIndex]
 
+	// A filename is not a word: the directory in front of it has to survive.
+	if m.completingPath {
+		m.applyPathCompletion(selectedCompletion)
+		return m, nil
+	}
+
 	// Apply the completion by appending to current input
 	currentInput := m.input.Value()
 	newValue := ""

--- a/internal/ui/keyboard_handler_enter_special.go
+++ b/internal/ui/keyboard_handler_enter_special.go
@@ -24,6 +24,18 @@ func (m *MainModel) handleSpecialCommands(command string) (*MainModel, tea.Cmd, 
 		return m.handleMouseCommand(upperCommand)
 	}
 
+	// CAPTURE on its own opens the window rather than reporting the status.
+	// The bottom line already says whether capture is running, so the status
+	// was telling you something you could see; the window is what you wanted.
+	// CAPTURE with a file, or OFF, still goes to the command.
+	if upperCommand == "CAPTURE" {
+		m.input.Reset()
+		// Centred, not above the field: you typed it at the prompt, so there
+		// is nothing on the bottom line for it to be pointing at.
+		updated, cmd := m.openCapturePanelCentred()
+		return updated, cmd, true
+	}
+
 	if upperCommand == "CLEAR" || upperCommand == "CLS" {
 		m.fullHistoryContent = ""
 		m.updateHistoryWrapping()

--- a/internal/ui/keyboard_handler_tab.go
+++ b/internal/ui/keyboard_handler_tab.go
@@ -19,6 +19,13 @@ func (m *MainModel) handleTabKey() (*MainModel, tea.Cmd) {
 
 	currentInput := m.input.Value()
 
+	// A file path completes against the filesystem rather than the schema.
+	// Every command that takes a file used to offer nothing after the keyword,
+	// so paths had to be typed out in full and correctly.
+	if updated, cmd, handled := m.completePathAtPrompt(currentInput); handled {
+		return updated, cmd
+	}
+
 	// If in multi-line mode, combine the buffer with current input for completion
 	fullInput := currentInput
 	if m.multiLineMode && len(m.multiLineBuffer) > 0 {
@@ -172,6 +179,7 @@ func (m *MainModel) handleTabKey() (*MainModel, tea.Cmd) {
 	} else {
 		// Multiple completions - show modal
 		m.showCompletions = true
+		m.completingPath = false     // these are CQL words, not filenames
 		m.completionIndex = 0        // Start with first item selected
 		m.completionScrollOffset = 0 // Reset scroll position
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -114,17 +114,22 @@ type MainModel struct {
 	// applies to a boxed table. ASCII art and JSON lines are text, and running
 	// them through it draws a header over content that has none and replaces
 	// what you are reading with a table the moment you scroll sideways.
-	resultFormat       config.OutputFormat
-	cachedTableLines   []string       // Cache rendered table lines for fast scrolling
-	navigationMode     bool           // Toggle between navigation keys and input mode
-	mouseEnabled       bool           // Whether to ask the terminal for mouse reporting
-	chooser            settingChooser // Open list of values for a status bar setting
-	help               helpWindow     // Open help window, if any
-	selection          textSelection  // Text being dragged out with the mouse, if any
-	viewMode           string         // "history", "table", "trace", or "ai_info"
-	showDataTypes      bool           // Whether to show column data types in table headers
-	columnTypes        []string       // Store column data types
-	tableRowBoundaries []int          // Line numbers where table rows start
+	resultFormat     config.OutputFormat
+	cachedTableLines []string       // Cache rendered table lines for fast scrolling
+	navigationMode   bool           // Toggle between navigation keys and input mode
+	mouseEnabled     bool           // Whether to ask the terminal for mouse reporting
+	chooser          settingChooser // Open list of values for a status bar setting
+	help             helpWindow     // Open help window, if any
+	capture          capturePanel   // Open capture window, if any
+	// completingPath says the candidates on offer are filenames rather than
+	// CQL words. Applying one has to keep the directory in front of it; the
+	// word-based path would replace /tmp/rep with report.csv and lose the /tmp.
+	completingPath     bool
+	selection          textSelection // Text being dragged out with the mouse, if any
+	viewMode           string        // "history", "table", "trace", or "ai_info"
+	showDataTypes      bool          // Whether to show column data types in table headers
+	columnTypes        []string      // Store column data types
+	tableRowBoundaries []int         // Line numbers where table rows start
 
 	// AI conversation view
 	aiConversationActive   bool            // Whether AI conversation view is active

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -38,6 +38,17 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 		return m.endSelection()
 
 	case tea.MouseWheelMsg:
+		// The candidate list has the wheel while it is showing.
+		if m.capture.active && len(m.capture.matches) > 0 {
+			switch mouse.Button {
+			case tea.MouseWheelUp:
+				m.showMatch(m.capture.match - wheelLines)
+			case tea.MouseWheelDown:
+				m.showMatch(m.capture.match + wheelLines)
+			}
+			return m, nil
+		}
+
 		// The help window is over everything, so it has the wheel first.
 		if m.help.active {
 			switch mouse.Button {
@@ -94,6 +105,32 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 		}
 		m.help = helpWindow{}
 		return m, nil
+	}
+
+	// A press inside the capture window picks a format; anywhere else closes
+	// it, rather than acting on something underneath it.
+	if m.capture.active {
+		if i, hit := m.formatAt(m.windowWidth, m.windowHeight, mouse.X, mouse.Y); hit {
+			m.capture.format = i
+			return m.chooseCaptureFormat()
+		}
+		if i, hit := m.matchAt(m.windowWidth, m.windowHeight, mouse.X, mouse.Y); hit {
+			m.capture.match = i
+			return m.useMatch()
+		}
+		if m.inCapturePanel(m.windowWidth, m.windowHeight, mouse.X, mouse.Y) {
+			// The path step: a press in the box is aimed at the text field, so
+			// leave what has been typed alone.
+			return m, nil
+		}
+
+		m.closeCapturePanel()
+		// Clicking Capture again should not reopen it in the same press.
+		if mouse.Y == m.windowHeight-1 {
+			if setting, _, ok := m.statusBar.settingAt(m.windowWidth, mouse.X); ok && setting == settingCapture {
+				return m, nil
+			}
+		}
 	}
 
 	// A press inside the open list picks that value.
@@ -369,7 +406,7 @@ func (m *MainModel) clickStatusSetting(col int) (*MainModel, tea.Cmd) {
 	wasOpen, openSetting := m.chooser.active, m.chooser.setting
 	m.closeSettingChooser()
 
-	setting, anchorX, ok := m.statusBar.settingAt(col)
+	setting, anchorX, ok := m.statusBar.settingAt(m.windowWidth, col)
 	if !ok {
 		return m, nil
 	}
@@ -387,6 +424,12 @@ func (m *MainModel) clickStatusSetting(col int) (*MainModel, tea.Cmd) {
 	if setting == settingConnection {
 		m.openConnectionPanel(anchorX)
 		return m, nil
+	}
+
+	// Capture is not one either: it takes a format and then a path, which is a
+	// step more than a list of values can do.
+	if setting == settingCapture {
+		return m.openCapturePanel(anchorX)
 	}
 
 	current := m.currentSettingValue(setting)

--- a/internal/ui/path_complete.go
+++ b/internal/ui/path_complete.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Tab completion for file paths.
+//
+// There was none anywhere in cqlai: every path - SAVE, CAPTURE, COPY, SOURCE -
+// had to be typed out in full and correctly, with no way to find out what was
+// there without leaving the program.
+//
+// It behaves the way a shell does. The first Tab fills in as far as the
+// candidates agree; if that is not far enough to pick one, the candidates are
+// listed and a second Tab does nothing new.
+
+// pathCompletion is what Tab found for a partially typed path.
+type pathCompletion struct {
+	// Completed is the path with as much filled in as the candidates agree on.
+	// It is the input unchanged when nothing matched.
+	Completed string
+
+	// Matches are the candidates, for showing when there is more than one.
+	// Directories carry a trailing separator.
+	Matches []string
+}
+
+// completePath completes a partially typed file path.
+//
+// It never fails: a directory that cannot be read, or does not exist, simply
+// offers nothing. Tab is not the place to learn that a path is wrong.
+func completePath(input string) pathCompletion {
+	none := pathCompletion{Completed: input}
+
+	dir, prefix := splitPath(input)
+
+	entries, err := os.ReadDir(expandHome(dir))
+	if err != nil {
+		return none
+	}
+
+	matches := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		// Hidden files only when they were asked for, as a shell does.
+		if strings.HasPrefix(name, ".") && !strings.HasPrefix(prefix, ".") {
+			continue
+		}
+		if entry.IsDir() {
+			name += string(filepath.Separator)
+		}
+		matches = append(matches, name)
+	}
+
+	if len(matches) == 0 {
+		return none
+	}
+	sort.Strings(matches)
+
+	// Fill in as far as they agree. With one match that is the whole name, and
+	// a directory ends in a separator so the next Tab carries on inside it.
+	return pathCompletion{
+		Completed: dir + commonPrefix(matches),
+		Matches:   matches,
+	}
+}
+
+// splitPath divides what has been typed into the directory to look in and the
+// prefix to match, keeping the directory exactly as it was written so
+// completing does not rewrite the rest of the path.
+func splitPath(input string) (dir, prefix string) {
+	i := strings.LastIndex(input, string(filepath.Separator))
+	if i < 0 {
+		return "", input
+	}
+	return input[:i+1], input[i+1:]
+}
+
+// expandHome turns a leading ~ into the home directory.
+func expandHome(dir string) string {
+	switch {
+	case dir == "":
+		return "."
+	case dir == "~"+string(filepath.Separator), dir == "~":
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	case strings.HasPrefix(dir, "~"+string(filepath.Separator)):
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, dir[2:])
+		}
+	}
+	return dir
+}
+
+// commonPrefix is the longest start the names share.
+func commonPrefix(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+
+	prefix := names[0]
+	for _, name := range names[1:] {
+		for !strings.HasPrefix(name, prefix) {
+			prefix = prefix[:len(prefix)-1]
+			if prefix == "" {
+				return ""
+			}
+		}
+	}
+	return prefix
+}

--- a/internal/ui/path_complete_test.go
+++ b/internal/ui/path_complete_test.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pathFixture builds a directory to complete against.
+func pathFixture(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, name := range []string{"report.csv", "report.json", "results.csv", ".hidden"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "exports"), 0o750))
+	return dir
+}
+
+// TestOneMatchIsCompletedWhole.
+func TestOneMatchIsCompletedWhole(t *testing.T) {
+	dir := pathFixture(t)
+
+	got := completePath(filepath.Join(dir, "results"))
+
+	assert.Equal(t, filepath.Join(dir, "results.csv"), got.Completed)
+	assert.Equal(t, []string{"results.csv"}, got.Matches)
+}
+
+// TestSeveralMatchesFillInAsFarAsTheyAgree, which is what a shell does.
+func TestSeveralMatchesFillInAsFarAsTheyAgree(t *testing.T) {
+	dir := pathFixture(t)
+
+	got := completePath(filepath.Join(dir, "rep"))
+
+	assert.Equal(t, filepath.Join(dir, "report."), got.Completed,
+		"it should fill in up to where the names differ")
+	assert.Equal(t, []string{"report.csv", "report.json"}, got.Matches)
+}
+
+// TestADirectoryEndsWithASeparator, so the next Tab carries on inside it.
+func TestADirectoryEndsWithASeparator(t *testing.T) {
+	dir := pathFixture(t)
+
+	got := completePath(filepath.Join(dir, "exp"))
+
+	assert.Equal(t, filepath.Join(dir, "exports")+string(filepath.Separator), got.Completed)
+	assert.Equal(t, []string{"exports" + string(filepath.Separator)}, got.Matches)
+}
+
+// TestEverythingInADirectoryIsOffered when nothing has been typed after it.
+func TestEverythingInADirectoryIsOffered(t *testing.T) {
+	dir := pathFixture(t)
+
+	got := completePath(dir + string(filepath.Separator))
+
+	assert.Len(t, got.Matches, 4, "three files and a directory, not the hidden one: %v", got.Matches)
+	assert.Contains(t, got.Matches, "exports"+string(filepath.Separator))
+}
+
+// TestHiddenFilesOnlyWhenAskedFor, as a shell does.
+func TestHiddenFilesOnlyWhenAskedFor(t *testing.T) {
+	dir := pathFixture(t)
+
+	assert.NotContains(t, completePath(dir+string(filepath.Separator)).Matches, ".hidden")
+
+	// Built by hand: filepath.Join would clean the "." away.
+	got := completePath(dir + string(filepath.Separator) + ".")
+	assert.Equal(t, []string{".hidden"}, got.Matches)
+}
+
+// TestNothingMatchingLeavesTheInputAlone rather than emptying what was typed.
+func TestNothingMatchingLeavesTheInputAlone(t *testing.T) {
+	dir := pathFixture(t)
+	input := filepath.Join(dir, "nothing-like-this")
+
+	got := completePath(input)
+
+	assert.Equal(t, input, got.Completed)
+	assert.Empty(t, got.Matches)
+}
+
+// TestAnUnreadableDirectoryOffersNothing rather than failing. Tab is not the
+// place to learn that a path is wrong.
+func TestAnUnreadableDirectoryOffersNothing(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "no", "such", "dir", "x")
+
+	got := completePath(input)
+
+	assert.Equal(t, input, got.Completed)
+	assert.Empty(t, got.Matches)
+}
+
+// TestTheRestOfThePathIsNotRewritten: completing the last part must leave the
+// directory in front of it exactly as it was typed.
+func TestTheRestOfThePathIsNotRewritten(t *testing.T) {
+	dir := pathFixture(t)
+	messy := dir + string(filepath.Separator) + "." + string(filepath.Separator) + "results"
+
+	got := completePath(messy)
+
+	assert.True(t, len(got.Completed) > len(messy), "it should have completed something")
+	assert.Contains(t, got.Completed, "."+string(filepath.Separator),
+		"the path in front should be untouched: %q", got.Completed)
+}
+
+// TestHomeIsExpanded, so ~/ completes against the home directory.
+func TestHomeIsExpanded(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, home, expandHome("~"))
+	assert.Equal(t, home, expandHome("~"+string(filepath.Separator)))
+	assert.Equal(t, filepath.Join(home, "docs"), expandHome("~"+string(filepath.Separator)+"docs"))
+
+	// Everything else is left alone.
+	assert.Equal(t, ".", expandHome(""))
+	assert.Equal(t, "/etc", expandHome("/etc"))
+	assert.Equal(t, "~notauser", expandHome("~notauser"))
+}
+
+func TestCommonPrefix(t *testing.T) {
+	assert.Equal(t, "report.", commonPrefix([]string{"report.csv", "report.json"}))
+	assert.Equal(t, "only", commonPrefix([]string{"only"}))
+	assert.Equal(t, "", commonPrefix([]string{"alpha", "beta"}))
+	assert.Equal(t, "", commonPrefix(nil))
+}

--- a/internal/ui/path_prompt.go
+++ b/internal/ui/path_prompt.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/axonops/cqlai/internal/ui/completion"
+)
+
+// pathHint is shown where a filename is expected but none has been typed.
+//
+// It is a note rather than a candidate: there is nothing to complete against
+// yet, and listing the whole working directory is noise. The wording matches
+// the usage the commands print - CAPTURE [JSON|CSV|PARQUET] 'filename' - so the
+// two say the same thing.
+const pathHint = "'filename'"
+
+// Completing a file path at the prompt.
+//
+// The engine cannot do this itself: it would have to reach back into the UI for
+// the filesystem, and the UI already imports it. So the Tab handler asks the
+// engine only where a path is expected, and does the completing here.
+
+// completePathAtPrompt completes a file path if the cursor is somewhere one is
+// expected. It reports whether it handled the keypress.
+func (m *MainModel) completePathAtPrompt(input string) (*MainModel, tea.Cmd, bool) {
+	prefix, quote, ok := completion.PathPrefix(input)
+	if !ok {
+		return m, nil, false
+	}
+
+	// With nothing typed there is nothing to complete against, and listing the
+	// whole working directory is noise - the binary and the log file are not
+	// what you are looking for. Say what is expected instead.
+	//
+	// Once there is a quote you have committed to typing a path, so the
+	// listing is what you want and the hint would be in the way.
+	if strings.TrimSpace(prefix) == "" && quote == "" {
+		m.showCompletions = true
+		m.completions = []string{pathHint}
+		m.completionIndex = 0
+		m.completionScrollOffset = 0
+		m.completingPath = true
+		return m, nil, true
+	}
+
+	got := completePath(prefix)
+
+	m.input.SetValue(completion.ReplacePath(input, prefix, quote, got.Completed))
+	m.input.CursorEnd()
+
+	// Show the candidates only when filling in was not enough to pick one,
+	// which is what the shell does and what the capture window does.
+	m.showCompletions = false
+	m.completions = nil
+	m.completionIndex = -1
+	m.completionScrollOffset = 0
+
+	m.completingPath = false
+	if len(got.Matches) > 1 {
+		m.completions = got.Matches
+		m.completionIndex = 0
+		m.showCompletions = true
+		m.completingPath = true
+	}
+	return m, nil, true
+}
+
+// applyPathCompletion puts a chosen filename into the path being typed.
+//
+// The candidates are bare names - "report.csv", "exports/" - so the directory
+// in front of them has to be kept. Applying one the way a CQL word is applied
+// replaces the last word, which for /tmp/rep means losing the /tmp.
+func (m *MainModel) applyPathCompletion(name string) {
+	// Choosing the hint starts the quoted filename off, so it is worth
+	// selecting rather than being a dead row in the list. The next Tab
+	// completes inside the quote.
+	if name == pathHint {
+		started := m.input.Value()
+		if !strings.HasSuffix(started, " ") {
+			started += " "
+		}
+
+		m.input.SetValue(started + "''")
+		m.input.SetCursor(len(started) + 1) // between the quotes
+		m.clearCompletions()
+		return
+	}
+
+	input := m.input.Value()
+
+	prefix, quote, ok := completion.PathPrefix(input)
+	if !ok {
+		return
+	}
+
+	dir, _ := splitPath(prefix)
+	m.input.SetValue(completion.ReplacePath(input, prefix, quote, dir+name))
+	m.input.CursorEnd()
+	m.clearCompletions()
+}
+
+// clearCompletions takes the list of candidates down.
+func (m *MainModel) clearCompletions() {
+	m.showCompletions = false
+	m.completions = nil
+	m.completionIndex = -1
+	m.completionScrollOffset = 0
+	m.completingPath = false
+}

--- a/internal/ui/path_prompt_test.go
+++ b/internal/ui/path_prompt_test.go
@@ -1,0 +1,325 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func promptModel(t *testing.T) *MainModel {
+	t.Helper()
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		windowWidth:     120,
+		windowHeight:    30,
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+}
+
+// TestTabCompletesAPathAtThePrompt. Completion knew CAPTURE as a keyword and
+// offered nothing after it, so paths had to be typed out in full.
+func TestTabCompletesAPathAtThePrompt(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	for _, command := range []string{
+		"CAPTURE JSON ",
+		"CAPTURE CSV ",
+		"SOURCE ",
+		"SAVE ",
+		"COPY users TO ",
+		"COPY users FROM ",
+	} {
+		m := promptModel(t)
+		m.input.SetValue(command + filepath.Join(dir, "res"))
+
+		m.handleTabKey()
+
+		assert.Equal(t, command+filepath.Join(dir, "results.csv"), m.input.Value(),
+			"after %q", command)
+	}
+}
+
+// TestTheQuoteIsKept, since these paths are usually written inside one.
+func TestTheQuoteIsKept(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE '" + filepath.Join(dir, "res"))
+
+	m.handleTabKey()
+
+	assert.Equal(t, "CAPTURE '"+filepath.Join(dir, "results.csv"), m.input.Value())
+}
+
+// TestTheCandidatesAreOfferedWhenFillingInIsNotEnough.
+func TestTheCandidatesAreOfferedWhenFillingInIsNotEnough(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"report.csv", "report.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE " + filepath.Join(dir, "rep"))
+
+	m.handleTabKey()
+
+	assert.True(t, strings.HasSuffix(m.input.Value(), "report."), "got %q", m.input.Value())
+	assert.True(t, m.showCompletions)
+	assert.Equal(t, []string{"report.csv", "report.json"}, m.completions)
+}
+
+// TestOneCandidateIsJustCompleted, with nothing to choose from.
+func TestOneCandidateIsJustCompleted(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "only.csv"), nil, 0o600))
+
+	m := promptModel(t)
+	m.input.SetValue("SOURCE " + filepath.Join(dir, "on"))
+
+	m.handleTabKey()
+
+	assert.False(t, m.showCompletions)
+	assert.True(t, strings.HasSuffix(m.input.Value(), "only.csv"))
+}
+
+// TestSelectIsNotAPath: COPY's FROM takes a file, SELECT's does not, and Tab
+// there must still complete schema.
+func TestSelectIsNotAPath(t *testing.T) {
+	m := promptModel(t)
+	m.input.SetValue("SELECT * FROM sys")
+
+	_, _, handled := m.completePathAtPrompt(m.input.Value())
+
+	assert.False(t, handled)
+}
+
+// TestBareCaptureOpensTheWindow rather than reporting a status the bottom line
+// already shows.
+func TestBareCaptureOpensTheWindow(t *testing.T) {
+	m := promptModel(t)
+	m.statusBar = testStatusBar()
+
+	for _, command := range []string{"CAPTURE", "capture", "Capture"} {
+		m.capture = capturePanel{}
+		_, _, handled := m.handleSpecialCommands(command)
+
+		assert.True(t, handled, "%q should be taken here", command)
+		assert.True(t, m.capture.active, "%q should open the window", command)
+		assert.Equal(t, captureChooseFormat, m.capture.step)
+	}
+}
+
+// TestCaptureWithArgumentsStillGoesToTheCommand.
+func TestCaptureWithArgumentsStillGoesToTheCommand(t *testing.T) {
+	m := promptModel(t)
+
+	for _, command := range []string{"CAPTURE OFF", "CAPTURE 'out.txt'", "CAPTURE JSON 'a.json'"} {
+		_, _, handled := m.handleSpecialCommands(command)
+
+		assert.False(t, handled, "%q belongs to the command, not the window", command)
+		assert.False(t, m.capture.active)
+	}
+}
+
+// TestChoosingAFilenameKeepsTheDirectory.
+//
+// The candidates are bare names, and applying one the way a CQL word is
+// applied replaces the last word - which for "/tmp/rep" would lose the "/tmp".
+func TestChoosingAFilenameKeepsTheDirectory(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"report.csv", "report.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV " + filepath.Join(dir, "rep"))
+	m.handleTabKey()
+	require.True(t, m.completingPath, "these are filenames")
+	require.Len(t, m.completions, 2)
+
+	m.completionIndex = 1 // report.json
+	m.handleCompletionSelection()
+
+	assert.Equal(t, "CAPTURE CSV "+filepath.Join(dir, "report.json"), m.input.Value())
+	assert.False(t, m.showCompletions, "choosing one should put the list away")
+}
+
+// TestChoosingAFilenameKeepsTheQuote too.
+func TestChoosingAFilenameKeepsTheQuote(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"report.csv", "report.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV '" + filepath.Join(dir, "rep"))
+	m.handleTabKey()
+	require.Len(t, m.completions, 2)
+
+	m.handleCompletionSelection()
+
+	assert.Equal(t, "CAPTURE CSV '"+filepath.Join(dir, "report.csv"), m.input.Value())
+}
+
+// TestChoosingADirectoryKeepsThePathGoing.
+func TestChoosingADirectoryKeepsThePathGoing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "exports"), 0o750))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "exported"), 0o750))
+
+	m := promptModel(t)
+	m.input.SetValue("SOURCE " + filepath.Join(dir, "exp"))
+	m.handleTabKey()
+	require.Len(t, m.completions, 2)
+
+	// The first candidate alphabetically.
+	require.Equal(t, "exported"+string(filepath.Separator), m.completions[0])
+	m.handleCompletionSelection()
+
+	assert.Equal(t, "SOURCE "+filepath.Join(dir, "exported")+string(filepath.Separator),
+		m.input.Value())
+}
+
+// TestCQLWordsAreStillAppliedAsWords, not as paths.
+func TestCQLWordsAreStillAppliedAsWords(t *testing.T) {
+	m := promptModel(t)
+	m.input.SetValue("SELECT * FROM ")
+	m.completions = []string{"users"}
+	m.completionIndex = 0
+	m.showCompletions = true
+	m.completingPath = false
+
+	m.handleCompletionSelection()
+
+	assert.Equal(t, "SELECT * FROM users", m.input.Value())
+}
+
+// TestNothingTypedSaysWhatIsExpected rather than listing the whole directory.
+//
+// After "CAPTURE CSV " there is nothing to complete against, and the working
+// directory is noise - the binary and the log file are not what you are after.
+func TestNothingTypedSaysWhatIsExpected(t *testing.T) {
+	for _, command := range []string{"CAPTURE CSV ", "SOURCE ", "SAVE ", "COPY users TO "} {
+		m := promptModel(t)
+		m.input.SetValue(command)
+
+		m.handleTabKey()
+
+		assert.Equal(t, []string{pathHint}, m.completions, "after %q", command)
+		assert.Equal(t, command, m.input.Value(), "%q should be left alone", command)
+	}
+}
+
+// TestOnceSomethingIsTypedItCompletesAgain.
+func TestOnceSomethingIsTypedItCompletesAgain(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV " + filepath.Join(dir, "res"))
+
+	m.handleTabKey()
+
+	assert.Equal(t, "CAPTURE CSV "+filepath.Join(dir, "results.csv"), m.input.Value())
+}
+
+// TestTheHintShowsWithOrWithoutASpaceAfterTheFormat.
+func TestTheHintShowsWithOrWithoutASpaceAfterTheFormat(t *testing.T) {
+	for _, command := range []string{"CAPTURE CSV", "CAPTURE CSV ", "capture json", "CAPTURE PARQUET"} {
+		m := promptModel(t)
+		m.input.SetValue(command)
+
+		m.handleTabKey()
+
+		assert.Equal(t, []string{pathHint}, m.completions, "after %q", command)
+		assert.Equal(t, command, m.input.Value(), "%q should be left alone", command)
+	}
+}
+
+// TestAPartialFormatStillCompletesTheFormat.
+func TestAPartialFormatStillCompletesTheFormat(t *testing.T) {
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE PARQ")
+
+	_, _, handled := m.completePathAtPrompt(m.input.Value())
+
+	assert.False(t, handled, "PARQ is a format being typed, not a file")
+}
+
+// TestChoosingTheHintStartsTheFilename. A row you cannot select is worse than
+// no row at all.
+func TestChoosingTheHintStartsTheFilename(t *testing.T) {
+	for _, command := range []string{"CAPTURE CSV", "CAPTURE CSV "} {
+		m := promptModel(t)
+		m.input.SetValue(command)
+		m.handleTabKey()
+		require.Equal(t, []string{pathHint}, m.completions, "after %q", command)
+
+		m.handleCompletionSelection()
+
+		assert.Equal(t, "CAPTURE CSV ''", m.input.Value(), "after %q", command)
+		assert.Equal(t, len("CAPTURE CSV '"), m.input.Position(),
+			"the cursor should be between the quotes")
+		assert.False(t, m.showCompletions, "the list should have gone")
+	}
+}
+
+// TestInsideTheQuoteItListsTheDirectory: by then you have committed to typing
+// a path, so the hint would be in the way.
+func TestInsideTheQuoteItListsTheDirectory(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.csv", "b.csv"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV '" + dir + string(filepath.Separator))
+
+	m.handleTabKey()
+
+	assert.Equal(t, []string{"a.csv", "b.csv"}, m.completions)
+	assert.NotContains(t, m.completions, pathHint)
+}
+
+// TestCompletingBetweenTheQuotesKeepsThem, so the command stays valid.
+func TestCompletingBetweenTheQuotesKeepsThem(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV '" + filepath.Join(dir, "res") + "'")
+
+	m.handleTabKey()
+
+	assert.Equal(t, "CAPTURE CSV '"+filepath.Join(dir, "results.csv")+"'", m.input.Value())
+}
+
+// TestTheWholeFlowFromTheFormatToTheFile.
+func TestTheWholeFlowFromTheFormatToTheFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV")
+
+	// The hint, then the quotes.
+	m.handleTabKey()
+	require.Equal(t, []string{pathHint}, m.completions)
+	m.handleCompletionSelection()
+	require.Equal(t, "CAPTURE CSV ''", m.input.Value())
+
+	// Type a path between them, then complete it.
+	m.input.SetValue("CAPTURE CSV '" + filepath.Join(dir, "res") + "'")
+	m.handleTabKey()
+
+	assert.Equal(t, "CAPTURE CSV '"+filepath.Join(dir, "results.csv")+"'", m.input.Value())
+}

--- a/internal/ui/setting_chooser.go
+++ b/internal/ui/setting_chooser.go
@@ -339,8 +339,19 @@ func (m *MainModel) applySettingChoice(choice string) (*MainModel, tea.Cmd) {
 		return m, nil
 	}
 
-	// Same path as typing it, so the transcript shows what changed and the
-	// status line updates the way it always has.
+	return m.runCommand(command)
+}
+
+// runCommand runs a meta-command the way typing it would, for the controls on
+// the bottom line.
+//
+// Same path as the prompt, so the transcript records what happened and the
+// status line updates as it always has. Doing the effects here instead is how
+// the two routes end up behaving differently.
+//
+// It does not switch view: you clicked a control, so whatever you were reading
+// should still be in front of you.
+func (m *MainModel) runCommand(command string) (*MainModel, tea.Cmd) {
 	result := router.ProcessCommand(command, m.session, m.sessionManager)
 
 	m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
@@ -348,9 +359,7 @@ func (m *MainModel) applySettingChoice(choice string) (*MainModel, tea.Cmd) {
 		m.fullHistoryContent += "\n" + text
 
 		// A USE leaves three places tracking the keyspace to be told, the same
-		// as when one is typed at the prompt. Not switching to the console
-		// view, though: you clicked a setting, so whatever you were reading
-		// should still be in front of you.
+		// as when one is typed at the prompt.
 		m.adoptKeyspace(text)
 	}
 	m.updateHistoryWrapping()

--- a/internal/ui/setting_chooser_test.go
+++ b/internal/ui/setting_chooser_test.go
@@ -28,7 +28,7 @@ func TestClickingASettingOpensItsChoices(t *testing.T) {
 	m := chooserModel()
 
 	var col int
-	for _, seg := range m.statusBar.segments() {
+	for _, seg := range placeSegments(m.statusBar.segments(), m.windowWidth) {
 		if seg.setting == settingConsistency {
 			col = (seg.start + seg.end) / 2
 		}
@@ -46,7 +46,7 @@ func TestClickingASettingOpensItsChoices(t *testing.T) {
 func TestClickingPastTheEndOfTheLineOpensNothing(t *testing.T) {
 	m := chooserModel()
 
-	last := m.statusBar.segments()[len(m.statusBar.segments())-1]
+	last := placeSegments(m.statusBar.segments(), m.windowWidth)[len(placeSegments(m.statusBar.segments(), m.windowWidth))-1]
 	m.clickStatusSetting(last.end + 4)
 
 	assert.False(t, m.chooser.active, "there is no field out there")
@@ -310,7 +310,7 @@ func TestKeyspacesAreNotAConstantList(t *testing.T) {
 func TestClickingKSWithNoConnectionOpensNothing(t *testing.T) {
 	m := chooserModel()
 
-	for _, seg := range m.statusBar.segments() {
+	for _, seg := range placeSegments(m.statusBar.segments(), m.windowWidth) {
 		if seg.setting == settingKeyspace {
 			m.clickStatusSetting((seg.start + seg.end) / 2)
 		}
@@ -514,7 +514,7 @@ func TestTheWheelScrollsTheListNotTheViewBehindIt(t *testing.T) {
 
 // settingColumn is the middle of a setting's field on the status line.
 func settingColumn(m *MainModel, setting string) int {
-	for _, seg := range m.statusBar.segments() {
+	for _, seg := range placeSegments(m.statusBar.segments(), m.windowWidth) {
 		if seg.setting == setting {
 			return (seg.start + seg.end) / 2
 		}
@@ -561,7 +561,7 @@ func TestClickingEmptyStatusLineClosesTheList(t *testing.T) {
 	pressAt(m, settingColumn(m, settingConsistency), m.windowHeight-1)
 	require.True(t, m.chooser.active)
 
-	segs := m.statusBar.segments()
+	segs := placeSegments(m.statusBar.segments(), m.windowWidth)
 	pressAt(m, segs[len(segs)-1].end+4, m.windowHeight-1)
 
 	assert.False(t, m.chooser.active)

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"strings"
+
 	"charm.land/lipgloss/v2"
 )
 
@@ -19,6 +21,7 @@ type StatusBarModel struct {
 	Keyspace     string
 	Version      string
 	OutputFormat string
+	Capturing    bool
 }
 
 // NewStatusBarModel creates a new StatusBarModel.
@@ -88,12 +91,19 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 		return hostStyle
 	}
 
+	segs := placeSegments(m.segments(), width)
+
 	statusText := ""
-	for i, seg := range m.segments() {
-		if i > 0 {
+	col := statusBarPadding
+	for i, seg := range segs {
+		switch {
+		case seg.right:
+			statusText += strings.Repeat(" ", max(seg.start-col, 0))
+		case i > 0:
 			statusText += separatorStyle.Render(statusSeparator)
 		}
 		statusText += labelStyle.Render(seg.label) + styleFor(seg).Render(seg.value)
+		col = seg.end
 	}
 
 	// Apply style to the entire bar without forced background

--- a/internal/ui/statusbar_fields.go
+++ b/internal/ui/statusbar_fields.go
@@ -24,6 +24,7 @@ const (
 	settingPaging      = "Pg"
 	settingTracing     = "Trace"
 	settingAutoFetch   = "Fetch"
+	settingCapture     = "Capture"
 )
 
 // statusSegment is one "Label: value" pair on the status line.
@@ -34,7 +35,8 @@ type statusSegment struct {
 	setting    string // one of the setting constants, or "" if not clickable
 	label      string
 	value      string
-	start, end int // column range covering label and value, end exclusive
+	start, end int  // column range covering label and value, end exclusive
+	right      bool // placed against the right-hand edge rather than in the flow
 }
 
 // clickable reports whether this segment changes something.
@@ -75,11 +77,24 @@ func (m StatusBarModel) segments() []statusSegment {
 		{setting: settingAutoFetch, label: "Fetch: ", value: onOff(m.AutoFetch)},
 	}
 
+	// Capture sits against the right-hand edge rather than in the flow, like
+	// the Help button on the tab line: it is a thing you do, not a fact about
+	// the session, and the line is already busy on the left.
+	segs = append(segs, statusSegment{
+		setting: settingCapture,
+		label:   "Capture: ",
+		value:   onOff(m.Capturing),
+		right:   true,
+	})
+
 	// Columns, not bytes. The separator is three columns wide but five bytes,
 	// because of the box-drawing character, and lipgloss.Width also gets
 	// double-width characters right, which a keyspace name can contain.
 	col := statusBarPadding
 	for i := range segs {
+		if segs[i].right {
+			continue
+		}
 		if i > 0 {
 			col += lipgloss.Width(statusSeparator)
 		}
@@ -90,10 +105,42 @@ func (m StatusBarModel) segments() []statusSegment {
 	return segs
 }
 
+// place gives the right-anchored segments their columns, once the width of the
+// line is known.
+//
+// Rendering and hit testing both call this, so a click on Capture lands on
+// Capture however wide the terminal is. It is dropped rather than overlapped
+// when the line is too full, for the same reason the Help button is.
+func placeSegments(segs []statusSegment, width int) []statusSegment {
+	end := statusBarPadding
+	for _, seg := range segs {
+		if !seg.right {
+			end = max(end, seg.end)
+		}
+	}
+
+	placed := make([]statusSegment, 0, len(segs))
+	for _, seg := range segs {
+		if !seg.right {
+			placed = append(placed, seg)
+			continue
+		}
+
+		w := lipgloss.Width(seg.label) + lipgloss.Width(seg.value)
+		seg.start = width - w - statusBarPadding
+		seg.end = seg.start + w
+		if seg.start <= end+lipgloss.Width(statusSeparator) {
+			continue // no room; leave it off rather than on top of a field
+		}
+		placed = append(placed, seg)
+	}
+	return placed
+}
+
 // settingAt returns the setting whose segment covers a column, and where that
 // segment starts, so a chooser can be anchored to it.
-func (m StatusBarModel) settingAt(col int) (setting string, at int, ok bool) {
-	for _, seg := range m.segments() {
+func (m StatusBarModel) settingAt(width, col int) (setting string, at int, ok bool) {
+	for _, seg := range placeSegments(m.segments(), width) {
 		if col >= seg.start && col < seg.end {
 			if !seg.clickable() {
 				return "", 0, false

--- a/internal/ui/statusbar_fields_test.go
+++ b/internal/ui/statusbar_fields_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// statusTestWidth is the terminal width the status line tests render at. It has
+// to be wide enough for the right-anchored fields to fit.
+const statusTestWidth = 140
+
+// placedStatus is the status line's segments with their columns worked out,
+// which is what both rendering and hit testing use.
+func placedStatus(m StatusBarModel) []statusSegment {
+	return placeSegments(m.segments(), statusTestWidth)
+}
+
 func testStatusBar() StatusBarModel {
 	return StatusBarModel{
 		Username:    "cassandra",
@@ -31,7 +41,7 @@ func TestSegmentsMatchTheRenderedLine(t *testing.T) {
 
 	rendered := []rune(stripAnsiForTest(m.View(140, DefaultStyles(), "history")))
 
-	for _, seg := range m.segments() {
+	for _, seg := range placedStatus(m) {
 		require.LessOrEqual(t, seg.end, len(rendered),
 			"segment %q runs past the end of the line", seg.label)
 
@@ -46,12 +56,12 @@ func TestSegmentsMatchTheRenderedLine(t *testing.T) {
 func TestSettingAtResolvesClicks(t *testing.T) {
 	m := testStatusBar()
 
-	for _, seg := range m.segments() {
+	for _, seg := range placedStatus(m) {
 		if !seg.clickable() {
 			continue
 		}
 		for _, col := range []int{seg.start, (seg.start + seg.end) / 2, seg.end - 1} {
-			setting, at, ok := m.settingAt(col)
+			setting, at, ok := m.settingAt(statusTestWidth, col)
 			assert.True(t, ok, "column %d is inside %q and should be clickable", col, seg.setting)
 			assert.Equal(t, seg.setting, setting)
 			assert.Equal(t, seg.start, at, "the chooser anchors to the start of the field")
@@ -65,11 +75,11 @@ func TestSettingAtResolvesClicks(t *testing.T) {
 func TestConnectionFactsAreNotClickable(t *testing.T) {
 	m := testStatusBar()
 
-	for _, seg := range m.segments() {
+	for _, seg := range placedStatus(m) {
 		if seg.clickable() {
 			continue
 		}
-		_, _, ok := m.settingAt((seg.start + seg.end) / 2)
+		_, _, ok := m.settingAt(statusTestWidth, (seg.start+seg.end)/2)
 		assert.False(t, ok, "%q is a fact, not a setting", seg.label)
 	}
 }
@@ -77,16 +87,16 @@ func TestConnectionFactsAreNotClickable(t *testing.T) {
 func TestSettingAtOutsideAnyField(t *testing.T) {
 	m := testStatusBar()
 
-	_, _, ok := m.settingAt(0) // the padding column
+	_, _, ok := m.settingAt(statusTestWidth, 0) // the padding column
 	assert.False(t, ok)
 
-	_, _, ok = m.settingAt(10000) // past the end
+	_, _, ok = m.settingAt(statusTestWidth, 10000) // past the end
 	assert.False(t, ok)
 }
 
 // TestSegmentsDoNotOverlap: overlapping ranges would make a click ambiguous.
 func TestSegmentsDoNotOverlap(t *testing.T) {
-	segs := testStatusBar().segments()
+	segs := placedStatus(testStatusBar())
 	require.NotEmpty(t, segs)
 
 	for i := 1; i < len(segs); i++ {
@@ -145,7 +155,7 @@ func TestOutputFormatIsOnTheLineAndClickable(t *testing.T) {
 
 	var seg statusSegment
 	var found bool
-	for _, s := range m.segments() {
+	for _, s := range placedStatus(m) {
 		if s.setting == settingOutput {
 			seg, found = s, true
 		}
@@ -153,7 +163,7 @@ func TestOutputFormatIsOnTheLineAndClickable(t *testing.T) {
 	require.True(t, found, "there is no Output field on the status line")
 	assert.Equal(t, "ASCII", seg.value)
 
-	setting, _, ok := m.settingAt((seg.start + seg.end) / 2)
+	setting, _, ok := m.settingAt(statusTestWidth, (seg.start+seg.end)/2)
 	require.True(t, ok)
 	assert.Equal(t, settingOutput, setting)
 }
@@ -161,7 +171,7 @@ func TestOutputFormatIsOnTheLineAndClickable(t *testing.T) {
 // TestOutputSitsAfterConsistency, where it was asked for.
 func TestOutputSitsAfterConsistency(t *testing.T) {
 	order := []string{}
-	for _, s := range testStatusBar().segments() {
+	for _, s := range placedStatus(testStatusBar()) {
 		order = append(order, s.setting)
 	}
 

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/axonops/cqlai/internal/config"
+	"github.com/axonops/cqlai/internal/router"
 )
 
 // newView wraps rendered content in the terminal state cqlai wants.
@@ -99,6 +100,10 @@ func (m *MainModel) View() tea.View {
 		} else {
 			m.statusBar.OutputFormat = "TABLE"
 		}
+	}
+
+	if handler := router.GetMetaHandler(); handler != nil {
+		m.statusBar.Capturing = handler.IsCapturing()
 	}
 
 	// Get the active viewport for scroll info
@@ -393,6 +398,9 @@ func (m *MainModel) View() tea.View {
 	// Apply all layers to the final view
 	// The settings chooser sits above everything: it is the thing just clicked.
 	if layer, ok := m.viewSettingChooser(screenWidth, screenHeight); ok {
+		layerManager.AddLayer(layer)
+	}
+	if layer, ok := m.viewCapturePanel(screenWidth, screenHeight); ok {
 		layerManager.AddLayer(layer)
 	}
 


### PR DESCRIPTION
```
 Connection │ KS: myks │ CL: LOCAL_ONE │ Output: TABLE │ ...          Capture: OFF

╭───────────────────────────────────────╮   ╭──────────────────────────────────╮
│ Capture output to a file              │   │ Capture as CSV                   │
│                                       │   │                                  │
│ > CSV       comma separated           │   │ > /tmp/exports/                  │
│   JSON      one object per row        │   │                                  │
│   PARQUET   columnar, for analysis    │   │   delta.csv                     ░│
│                                       │   │   epsilon.csv                   █│
│ ↑↓: Move   Enter: Choose   Esc: Close │   │ > gamma.csv                     █│
╰───────────────────────────────────────╯   │                                  │
                                            │ ↑↓: Move  Enter: Use  Esc: Back  │
                                            ╰──────────────────────────────────╯
```

## The control

At the right-hand end of the bottom line. Clicking it offers the formats, then asks where to write the file. Clicking it while capturing offers to stop.

Two steps, which is one more than the settings lists do, so it is its own window rather than another `commandList`. It anchors above the field when opened from it, and sits in the middle of the screen when opened by typing `CAPTURE`, which has no field to point at. Both routes draw the same window - there is a test that they render identical content.

Typing `CAPTURE` on its own opens it rather than reporting the status. The bottom line already says whether capture is running, so the status was telling you something you could see. `CAPTURE 'file'` and `CAPTURE OFF` still go to the command.

## Path completion

There was none anywhere in cqlai. Every path had to be typed out in full and correctly, with no way to find out what was there without leaving the program.

It behaves the way a shell does: the first Tab fills in as far as the candidates agree, and if that is not enough to pick one they are listed, one per row, capped with a scrollbar so a directory of a hundred files does not fill the screen. Directories carry a separator so the next Tab carries on inside them. `~` expands. Hidden files appear only when the dot is typed. A directory that cannot be read offers nothing rather than failing - Tab is not where you learn a path is wrong.

It covers **every** command that takes a file - `CAPTURE`, `SOURCE`, `SAVE`, `COPY ... TO|FROM` - because doing it for one is how the next one becomes a bug. These paths are usually quoted, so it completes inside the quotes and puts the result back between them.

## The whole CAPTURE grammar

```
CAPTURE ⇥                                → CSV  JSON  PARQUET  OFF
CAPTURE CSV⇥                             → 'filename'
CAPTURE CSV '/tmp/re⇥                    → completes the path
CAPTURE CSV 'out.csv' ⇥                  → WITH
CAPTURE CSV 'out.csv' WITH ⇥             → COMPRESSION  MAX_FILE_SIZE  PARTITION
CAPTURE CSV 'out.csv' WITH COMPRESSION=⇥ → snappy  gzip  ...
CAPTURE CSV 'out.csv' WITH ...=1000⇥     → AND
```

Modelled on what `COPY` already did. The formats and options both come from the command that parses them, so completion cannot offer one it will refuse, and the window offers exactly the formats the usage lists.

The path completer has to let go once `WITH` appears or the filename is closed, or it treats the options as part of the path. Both are tested.

## A right-anchored status field

The status line laid its segments out left to right. The right-hand ones get their columns once the width is known, and both drawing and hit testing read that placement, so a click on `Capture` lands on `Capture` whatever the terminal is doing. It is dropped rather than overlapped when the line is too full, the same as the Help button.

`runCommand` is shared with the settings chooser now, so both routes run the real command and neither can drift from what typing it does.

## Not in this change

`SAVE` has the same two-step shape and its own copy of it. #129 tracks moving it onto this window; it was left out to keep this reviewable, and because `SAVE` has no tests of its own to port against.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: the completion rules for every path-taking command, quoted and unquoted, with and without a space after the format; the whole `CAPTURE` grammar through `WITH ... AND`; the candidate list being one per row, scrolling, every entry reachable, and none running past the box; choosing a filename keeping the directory and the quotes; choosing a directory listing what is inside it; the control's placement and it being dropped rather than overlapped; both routes drawing the same window in different places; and every format row answering the click that lands on it.

Closes #128
Closes #130