### PR TITLE
feat(ui): scrollbars for the Command History list and the Console

### DIFF
--- a/internal/ui/command_list.go
+++ b/internal/ui/command_list.go
@@ -30,13 +30,8 @@ type commandList struct {
 // searching reports whether this is the Ctrl+R box rather than the plain list.
 func (c commandList) searching() bool { return c.search != "" }
 
-// scrolls reports whether there are more commands than the box can show.
-//
-// When there are, both the "older" and "newer" rows are drawn, blank at the
-// ends rather than left out. Leaving them out is what made the box grow and
-// shrink by a row as you wheeled through it: at the top there was nothing
-// above, in the middle there was something both ways, and the height changed
-// under the pointer.
+// scrolls reports whether there are more commands than the box can show, and
+// so whether the scrollbar has anything to say.
 func (c commandList) scrolls() bool { return len(c.items) > c.rows }
 
 // last is the index one past the final command shown.
@@ -59,9 +54,6 @@ func (c commandList) firstItemRow() int {
 	row := 2 // the top border, then the title
 	if c.searching() {
 		row++ // the query line
-	}
-	if c.scrolls() {
-		row++ // the "older" row, which is drawn blank at the top
 	}
 	return row
 }
@@ -95,27 +87,39 @@ func (c commandList) render(styles *Styles) string {
 		lines = append(lines, searchStyle.Render(pad(" Search: "+query, inner)))
 	}
 
-	if c.scrolls() {
-		lines = append(lines, quietStyle.Render(centre(arrowRow("▲ (older)", c.scroll > 0), inner)))
-	}
+	// A scrollbar down the right-hand edge rather than an arrow above and
+	// below. The arrows said only whether there was more that way; the bar
+	// says how much of the list is showing and where in it you are, which is
+	// what you want when the history runs to hundreds of commands.
+	thumb := scrollbarColumn(c.last()-c.scroll, c.scroll, len(c.items))
+	thumbStyle := lipgloss.NewStyle().Foreground(styles.Accent)
+	trackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
 
 	switch {
 	case len(c.items) == 0:
 		lines = append(lines, quietStyle.Render(centre("No matching commands", inner)))
 	default:
-		// Two columns for the marker, so selected and unselected rows line up.
+		// Two columns for the marker, so selected and unselected rows line up,
+		// and one at the end for the bar.
 		for i := c.scroll; i < c.last(); i++ {
-			text := ansi.Truncate(c.items[i], max(inner-3, 0), "…")
-			if i == c.selected {
-				lines = append(lines, selectedStyle.Render(pad(" → "+text, inner)))
-			} else {
-				lines = append(lines, itemStyle.Render(pad("   "+text, inner)))
-			}
-		}
-	}
+			text := ansi.Truncate(c.items[i], max(inner-4, 0), "…")
 
-	if c.scrolls() {
-		lines = append(lines, quietStyle.Render(centre(arrowRow("▼ (newer)", c.last() < len(c.items)), inner)))
+			row := pad("   "+text, inner-1)
+			style := itemStyle
+			if i == c.selected {
+				row = pad(" → "+text, inner-1)
+				style = selectedStyle
+			}
+
+			bar := trackStyle.Render("░")
+			switch {
+			case !c.scrolls():
+				bar = " "
+			case thumb[i-c.scroll]:
+				bar = thumbStyle.Render("█")
+			}
+			lines = append(lines, style.Render(row)+bar)
+		}
 	}
 
 	lines = append(lines, quietStyle.Render(strings.Repeat("─", max(inner, 0))))
@@ -125,15 +129,6 @@ func (c commandList) render(styles *Styles) string {
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(styles.Accent).
 		Render(strings.Join(lines, "\n"))
-}
-
-// arrowRow returns the arrow, or nothing when there is no more list that way.
-// The row is drawn either way, so the box keeps its height as you scroll.
-func arrowRow(arrow string, more bool) string {
-	if more {
-		return arrow
-	}
-	return ""
 }
 
 // centre pads a string to width with the text in the middle.

--- a/internal/ui/console_scrollbar.go
+++ b/internal/ui/console_scrollbar.go
@@ -1,0 +1,73 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// The scrollbar down the right-hand edge of the Console.
+//
+// The scroll position was already worked out - [TOP], [42%], [BOTTOM] - and
+// appended to the status line, where it is pushed past the right-hand edge and
+// has never once been visible. So a long transcript gave no sign of where you
+// were in it, or that there was anything above.
+//
+// The settings lists, the command history and the help window all draw one
+// through scrollbarColumn; this is the same bar beside the view you spend the
+// most time in.
+
+// scrollbarWidth is the column the bar takes. The Console viewport is that much
+// narrower than the window, and its content is wrapped to the narrower width,
+// so no line loses a character to it.
+const scrollbarWidth = 1
+
+// consoleWidth is the width the Console viewport is given.
+func consoleWidth(windowWidth int) int {
+	return max(windowWidth-scrollbarWidth, 0)
+}
+
+// withScrollbar draws a scrollbar down the right of a rendered viewport.
+//
+// It is drawn whether or not the content scrolls. The column is reserved
+// either way - the viewport is a column narrower than the window - so leaving
+// it blank wastes the space and leaves you unsure whether there is nothing
+// above or no scrollbar at all. A full thumb says the whole transcript is on
+// screen, which is worth knowing.
+func withScrollbar(content string, total, height, offset int, styles *Styles) string {
+	rows := strings.Split(content, "\n")
+	if height <= 0 {
+		return content
+	}
+
+	thumb := scrollbarColumn(min(height, len(rows)), offset, total)
+	if total <= height {
+		// Everything fits: the thumb fills the bar.
+		for i := range thumb {
+			thumb[i] = true
+		}
+	}
+	thumbStyle := lipgloss.NewStyle().Foreground(styles.Accent)
+	trackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
+
+	for i := range rows {
+		if i >= len(thumb) {
+			break
+		}
+		if thumb[i] {
+			rows[i] += thumbStyle.Render("█")
+		} else {
+			rows[i] += trackStyle.Render("░")
+		}
+	}
+	return strings.Join(rows, "\n")
+}
+
+// consoleScrollbar draws the bar beside the Console.
+func (m *MainModel) consoleScrollbar(content string) string {
+	return withScrollbar(content,
+		m.historyViewport.TotalLineCount(),
+		m.historyViewport.Height(),
+		m.historyViewport.YOffset(),
+		m.styles)
+}

--- a/internal/ui/console_scrollbar_test.go
+++ b/internal/ui/console_scrollbar_test.go
@@ -1,0 +1,132 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// consoleModel builds a Console holding n lines in a viewport showing height.
+func consoleModel(n, height int) *MainModel {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	vp := viewport.New(viewport.WithWidth(40), viewport.WithHeight(height))
+	vp.SetContent(strings.Join(lines, "\n"))
+
+	return &MainModel{
+		styles:          DefaultStyles(),
+		viewMode:        "history",
+		windowWidth:     41,
+		windowHeight:    height + 4,
+		historyViewport: vp,
+	}
+}
+
+// bar is the scrollbar column of a rendered Console.
+func bar(t *testing.T, m *MainModel) string {
+	t.Helper()
+
+	drawn := m.consoleScrollbar(m.historyViewport.View())
+	var col []rune
+	for _, row := range strings.Split(stripAnsiForTest(drawn), "\n") {
+		runes := []rune(row)
+		require.NotEmpty(t, runes)
+		col = append(col, runes[len(runes)-1])
+	}
+	return string(col)
+}
+
+// TestTheScrollbarSaysWhereYouAreInTheTranscript.
+//
+// The scroll position was already worked out and appended to the status line,
+// where it is pushed past the right-hand edge and has never been visible.
+func TestTheScrollbarSaysWhereYouAreInTheTranscript(t *testing.T) {
+	m := consoleModel(60, 10)
+
+	atTop := bar(t, m)
+	assert.Equal(t, '█', []rune(atTop)[0], "the thumb starts at the top: %q", atTop)
+	assert.Contains(t, atTop, "░", "with track below it")
+
+	m.historyViewport.GotoBottom()
+	atBottom := bar(t, m)
+	runes := []rune(atBottom)
+	assert.Equal(t, '█', runes[len(runes)-1], "and reaches the bottom: %q", atBottom)
+	assert.Equal(t, '░', runes[0], "with track above it")
+}
+
+// TestAFullBarWhenItAllFits.
+//
+// The column is reserved whether or not there is anything to scroll, so
+// leaving it blank wastes the space and leaves you unsure whether there is
+// nothing above or no scrollbar at all.
+func TestAFullBarWhenItAllFits(t *testing.T) {
+	m := consoleModel(3, 10)
+
+	drawn := stripAnsiForTest(m.consoleScrollbar(m.historyViewport.View()))
+
+	assert.Contains(t, drawn, "█", "the thumb fills the bar")
+	assert.NotContains(t, drawn, "░", "with no track, because there is nowhere to go")
+}
+
+// TestNoLineLosesACharacterToIt: the viewport is a column narrower than the
+// window and its content is wrapped to that width, so the bar sits beside the
+// text rather than on top of it.
+func TestNoLineLosesACharacterToIt(t *testing.T) {
+	const window = 41
+	assert.Equal(t, window-1, consoleWidth(window))
+
+	m := consoleModel(60, 10)
+
+	// Long lines, and enough of them to scroll - with everything showing there
+	// is no bar to make room for.
+	long := make([]string, 60)
+	for i := range long {
+		long[i] = strings.Repeat("x", 40)
+	}
+	m.historyViewport.SetContent(strings.Join(long, "\n"))
+
+	drawn := stripAnsiForTest(m.consoleScrollbar(m.historyViewport.View()))
+	rows := strings.Split(drawn, "\n")
+
+	assert.True(t, strings.HasPrefix(rows[0], strings.Repeat("x", 40)),
+		"the line should survive whole: %q", rows[0])
+	assert.Equal(t, window, lipgloss.Width(rows[0]), "text plus the bar fills the window")
+}
+
+// TestTheConsoleThumbGrowsWithTheProportionShowing.
+func TestTheConsoleThumbGrowsWithTheProportionShowing(t *testing.T) {
+	count := func(m *MainModel) int {
+		return strings.Count(bar(t, m), "█")
+	}
+
+	assert.Greater(t, count(consoleModel(20, 10)), count(consoleModel(200, 10)),
+		"showing half should give a bigger thumb than showing a twentieth")
+}
+
+// TestAVeryLongTranscriptStillHasAVisibleThumb.
+func TestAVeryLongTranscriptStillHasAVisibleThumb(t *testing.T) {
+	m := consoleModel(5000, 10)
+
+	assert.GreaterOrEqual(t, strings.Count(bar(t, m), "█"), 1)
+}
+
+// TestTheBarIsNotSelectable: the selection reads the viewport's own content,
+// which the bar is not part of.
+func TestTheBarIsNotSelectable(t *testing.T) {
+	m := consoleModel(60, 10)
+	m.input = newTestInput()
+	m.mouseEnabled = true
+
+	// Drag across the whole of the first visible line.
+	m.beginSelection(0, tabBarHeight)
+	m.extendSelection(60, tabBarHeight)
+
+	assert.Equal(t, "line", m.selectedText(), "the bar is not part of the text")
+}

--- a/internal/ui/history_overlay_test.go
+++ b/internal/ui/history_overlay_test.go
@@ -561,20 +561,44 @@ func TestTheBoxKeepsItsHeightWhileScrolling(t *testing.T) {
 	require.Equal(t, 39, m.historySearchIndex, "this should have reached the end")
 }
 
-// TestTheArrowsStillSayWhichWayThereIsMore, even though both rows are always
-// drawn.
-func TestTheArrowsStillSayWhichWayThereIsMore(t *testing.T) {
+// TestTheScrollbarSaysWhereYouAreInTheList.
+//
+// It replaced an arrow above and below, which said only whether there was more
+// that way. The bar says how much is showing and where you are, which is what
+// you want when the history runs to hundreds of commands.
+func TestTheScrollbarSaysWhereYouAreInTheList(t *testing.T) {
 	m := historyModel(40)
 	openList(m, 0, 0)
 
-	atTop := stripAnsiForTest(mustOverlay(t, m).Content)
-	assert.NotContains(t, atTop, "▲", "nothing is above the first command")
-	assert.Contains(t, atTop, "▼")
+	// The rows the bar runs down, from the same place the click test reads.
+	bar := func() (first, last string) {
+		list, layer, ok := m.historyOverlay(m.windowWidth, m.windowHeight)
+		require.True(t, ok)
+
+		rows := strings.Split(stripAnsiForTest(layer.Content), "\n")
+		return rows[list.firstItemRow()], rows[list.firstItemRow()+list.visibleItems()-1]
+	}
+
+	top, bottom := bar()
+	assert.Contains(t, top, "█", "the thumb starts at the top: %q", top)
+	assert.Contains(t, bottom, "░", "with track below it: %q", bottom)
 
 	m.moveHistorySelection(100)
-	atBottom := stripAnsiForTest(mustOverlay(t, m).Content)
-	assert.Contains(t, atBottom, "▲")
-	assert.NotContains(t, atBottom, "▼", "nothing is below the last command")
+	top, bottom = bar()
+	assert.Contains(t, bottom, "█", "and reaches the bottom: %q", bottom)
+	assert.Contains(t, top, "░", "with track above it: %q", top)
+}
+
+// TestNoBarWhenTheWholeListFits: there is nowhere to go, so the column stays
+// blank rather than showing a bar that cannot move.
+func TestNoBarWhenTheWholeListFits(t *testing.T) {
+	m := historyModel(4)
+	openList(m, 0, 0)
+
+	drawn := stripAnsiForTest(mustOverlay(t, m).Content)
+
+	assert.NotContains(t, drawn, "█")
+	assert.NotContains(t, drawn, "░")
 }
 
 func mustOverlay(t *testing.T, m *MainModel) Layer {

--- a/internal/ui/layers.go
+++ b/internal/ui/layers.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Layer represents a renderable layer with position and size
@@ -64,55 +65,55 @@ func (lm *LayerManager) Render(base string) string {
 }
 
 // applyLayer applies a single layer to the view
+// applyLayer draws one layer over the lines beneath it.
+//
+// The background either side of the layer keeps its styling. It used to be
+// stripped of ANSI and pasted back as plain text, so anything coloured beside
+// a modal lost its colour for as long as the modal was up - most visibly the
+// Console scrollbar, which turned white for exactly the rows the modal
+// covered.
 func (lm *LayerManager) applyLayer(lines []string, layer Layer) []string {
 	contentLines := strings.Split(layer.Content, "\n")
 
 	for i, contentLine := range contentLines {
 		lineIdx := layer.Y + i
-		if lineIdx >= 0 && lineIdx < len(lines) {
-			bgLine := lines[lineIdx]
-
-			// Calculate the actual visual width of this specific content line
-			contentLineWidth := lipgloss.Width(contentLine)
-
-			// Create the new line with proper positioning
-			var result string
-
-			// Add padding before the modal content to position it at layer.X
-			if layer.X > 0 {
-				// Try to preserve background content before the modal
-				bgPlain := stripAnsi(bgLine)
-				bgRunes := []rune(bgPlain)
-				if layer.X < len(bgRunes) {
-					result = string(bgRunes[:layer.X])
-				} else {
-					result = strings.Repeat(" ", layer.X)
-				}
-			}
-
-			// Add the modal content
-			result += contentLine
-
-			// Get the visual width of the background line
-			bgWidth := lipgloss.Width(bgLine)
-
-			// If the background extends beyond the modal, preserve it
-			if layer.X+contentLineWidth < bgWidth {
-				// Extract the part of background that's after the modal
-				bgPlain := stripAnsi(bgLine)
-				bgRunes := []rune(bgPlain)
-				startPos := layer.X + contentLineWidth
-				if startPos < len(bgRunes) {
-					result += string(bgRunes[startPos:])
-				}
-			}
-
-			lines[lineIdx] = result
+		if lineIdx < 0 || lineIdx >= len(lines) {
+			continue
 		}
+
+		bgLine := lines[lineIdx]
+		bgWidth := lipgloss.Width(bgLine)
+		contentWidth := lipgloss.Width(contentLine)
+
+		// What is in front of the layer, styling and all. Past the end of the
+		// background there is nothing to keep, so pad.
+		var result string
+		if layer.X > 0 {
+			result = ansi.Cut(bgLine, 0, layer.X)
+			if pad := layer.X - lipgloss.Width(result); pad > 0 {
+				result += strings.Repeat(" ", pad)
+			}
+			// The layer draws its own colours; the background's must not run
+			// on into it.
+			result += ansiReset
+		}
+
+		result += contentLine
+
+		// And what is behind it, from where the layer ends.
+		if end := layer.X + contentWidth; end < bgWidth {
+			result += ansiReset + ansi.Cut(bgLine, end, bgWidth)
+		}
+
+		lines[lineIdx] = result
 	}
 
 	return lines
 }
+
+// ansiReset closes any styling still in effect, so one piece of a composited
+// line cannot colour the next.
+const ansiReset = "\x1b[0m"
 
 // RenderModal renders a modal as a centered overlay
 func RenderModal(content string, width, height int) Layer {

--- a/internal/ui/layers_test.go
+++ b/internal/ui/layers_test.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTheBackgroundKeepsItsColourBesideALayer.
+//
+// It used to be stripped of ANSI and pasted back as plain text, so anything
+// coloured beside a modal lost its colour for as long as the modal was up -
+// most visibly the Console scrollbar, which turned white for exactly the rows
+// the modal covered.
+func TestTheBackgroundKeepsItsColourBesideALayer(t *testing.T) {
+	red := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	background := "left" + strings.Repeat(" ", 16) + red.Render("█")
+	require.Equal(t, 21, lipgloss.Width(background))
+
+	lm := NewLayerManager(21, 1)
+	lm.AddLayer(Layer{Content: "MODAL", X: 6, Y: 0, Width: 5, Height: 1})
+
+	got := lm.Render(background)
+
+	assert.Equal(t, "left  MODAL         █", stripAnsiForTest(got), "the row should be intact")
+	assert.Contains(t, got, red.Render("█"), "the scrollbar keeps its colour")
+}
+
+// TestTheLayerIsNotColouredByWhatIsBehindIt.
+func TestTheLayerIsNotColouredByWhatIsBehindIt(t *testing.T) {
+	green := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	background := green.Render("coloured background text here")
+
+	lm := NewLayerManager(29, 1)
+	lm.AddLayer(Layer{Content: "PLAIN", X: 4, Y: 0, Width: 5, Height: 1})
+
+	got := lm.Render(background)
+
+	before, _, found := strings.Cut(got, "PLAIN")
+	require.True(t, found)
+	assert.True(t, strings.HasSuffix(before, ansiReset),
+		"the background's colour should be closed before the layer: %q", before)
+}
+
+// TestALayerPastTheEndOfTheLineIsPadded rather than jammed against the text.
+func TestALayerPastTheEndOfTheLineIsPadded(t *testing.T) {
+	lm := NewLayerManager(20, 1)
+	lm.AddLayer(Layer{Content: "X", X: 10, Y: 0, Width: 1, Height: 1})
+
+	got := stripAnsiForTest(lm.Render("short"))
+
+	assert.Equal(t, "short     X", got)
+}
+
+// TestTheWidthIsUnchangedByALayer, so nothing is pushed off the screen.
+func TestTheWidthIsUnchangedByALayer(t *testing.T) {
+	background := strings.Repeat("x", 40)
+
+	lm := NewLayerManager(40, 1)
+	lm.AddLayer(Layer{Content: "MODAL", X: 10, Y: 0, Width: 5, Height: 1})
+
+	assert.Equal(t, 40, lipgloss.Width(stripAnsiForTest(lm.Render(background))))
+}
+
+// TestALayerOnlyTouchesItsOwnRows.
+func TestALayerOnlyTouchesItsOwnRows(t *testing.T) {
+	background := strings.Join([]string{"row0", "row1", "row2", "row3"}, "\n")
+
+	lm := NewLayerManager(10, 4)
+	lm.AddLayer(Layer{Content: "AA", X: 0, Y: 1, Width: 2, Height: 1})
+
+	rows := strings.Split(stripAnsiForTest(lm.Render(background)), "\n")
+	assert.Equal(t, "row0", rows[0])
+	assert.Equal(t, "AAw1", rows[1])
+	assert.Equal(t, "row2", rows[2])
+	assert.Equal(t, "row3", rows[3])
+}
+
+// TestTheConsoleScrollbarSurvivesAModal, which is the case that started this.
+func TestTheConsoleScrollbarSurvivesAModal(t *testing.T) {
+	m := consoleModel(200, 6)
+	drawn := m.consoleScrollbar(m.historyViewport.View())
+
+	lm := NewLayerManager(41, 6)
+	lm.AddLayer(Layer{Content: strings.Join([]string{"┌────┐", "│ hi │", "└────┘"}, "\n"),
+		X: 5, Y: 1, Width: 6, Height: 3})
+
+	got := lm.Render(drawn)
+
+	thumb := lipgloss.NewStyle().Foreground(m.styles.Accent).Render("█")
+	track := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a")).Render("░")
+
+	for i, row := range strings.Split(got, "\n") {
+		plain := []rune(stripAnsiForTest(row))
+		require.NotEmpty(t, plain)
+
+		last := plain[len(plain)-1]
+		assert.True(t, last == '█' || last == '░', "row %d lost its bar: %q", i, stripAnsiForTest(row))
+
+		// And it is still the coloured one, not a bare character that renders
+		// white - which is what the modal used to leave behind.
+		assert.True(t, strings.HasSuffix(row, thumb) || strings.HasSuffix(row, track),
+			"row %d lost the bar's colour: %q", i, row)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -495,18 +495,21 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !m.ready {
 			// Initialize viewports
-			m.historyViewport = viewport.New(viewport.WithWidth(newWidth), viewport.WithHeight(newHeight))
+			// One column narrower than the window: the scrollbar lives there,
+			// and the content is wrapped to the narrower width so no line
+			// loses a character to it.
+			m.historyViewport = viewport.New(viewport.WithWidth(consoleWidth(newWidth)), viewport.WithHeight(newHeight))
 			m.tableViewport = viewport.New(viewport.WithWidth(newWidth), viewport.WithHeight(newHeight))
 			m.traceViewport = viewport.New(viewport.WithWidth(newWidth), viewport.WithHeight(newHeight))
 			welcomeMsg := m.getWelcomeMessage()
 			m.fullHistoryContent = welcomeMsg
 			// Wrap content for initial display
-			wrapped := m.wrapHistoryContent(newWidth)
+			wrapped := m.wrapHistoryContent(consoleWidth(newWidth))
 			m.historyViewport.SetContent(wrapped)
 			m.ready = true
 		} else {
 			// Resize viewports
-			m.historyViewport.SetWidth(newWidth)
+			m.historyViewport.SetWidth(consoleWidth(newWidth))
 			m.historyViewport.SetHeight(newHeight)
 			m.tableViewport.SetWidth(newWidth)
 			m.tableViewport.SetHeight(newHeight)

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -295,7 +295,9 @@ func (m *MainModel) View() tea.View {
 		}
 	default:
 		viewportContent = m.historyViewport.View()
-		viewportWidth = m.historyViewport.Width()
+		// The window's width, not the viewport's: the scrollbar column makes
+		// up the difference, and everything else on screen is this wide.
+		viewportWidth = m.historyViewport.Width() + scrollbarWidth
 	}
 
 	// Build the main view with proper sticky header overlay
@@ -329,6 +331,15 @@ func (m *MainModel) View() tea.View {
 	// Paint the mouse selection on last, so it covers whatever styling the
 	// content already had.
 	viewportSection = m.highlightSelection(viewportSection)
+
+	// The scrollbar goes on after the highlight, or a selection running to the
+	// end of a line would paint over the bar.
+	//
+	// selectionTarget names the view being drawn, which is the same question,
+	// so the two cannot disagree about which viewport is on screen.
+	if _, view := m.selectionTarget(); view == "history" {
+		viewportSection = m.consoleScrollbar(viewportSection)
+	}
 
 	// Build the final view. The tabs get their own line above the status bar so
 	// the modes and their keys are always on screen, rather than something you


### PR DESCRIPTION
```
╭──────────────────────────────────────────────────────╮   > SELECT * FROM users;        █
│              Command History (12-21 of 40)           │   id  name                     █
│ Search:                                              │   1   alice                    █
│   SELECT 11 FROM system.local                       ░│   2   bob                      ░
│   SELECT 12 FROM system.local                       ░│   > CONSISTENCY QUORUM         ░
│   SELECT 13 FROM system.local                       █│   Consistency level set        ░
│   SELECT 14 FROM system.local                       █│
│ → SELECT 20 FROM system.local                       ░│
╰──────────────────────────────────────────────────────╯
```

## The history list

It had an `▲ (older)` row above and a `▼ (newer)` row below, saying only whether there was more that way. The bar says how much of the list is showing and where in it you are, and takes a column at the side rather than two rows of the box - so two more commands fit.

## The Console

Nothing at all before. Its scroll position was already worked out - `[TOP]`, `[42%]`, `[BOTTOM]` - and appended to the status line, where it is pushed past the right-hand edge and has never once been visible.

The bar has a column of its own rather than being drawn over the text: the viewport is a column narrower than the window now and the transcript is wrapped to the narrower width, so no line loses its last character. It is drawn whether or not there is anything to scroll, because the column is reserved either way - a blank one leaves you unsure whether there is nothing above or no scrollbar at all.

It goes on after the selection highlight, or a selection running to the end of a line paints over it. The selection reads the viewport's own content, which the bar is not part of, so dragging across a line still copies just the line.

## A modal turned the scrollbar white

Found while testing this, and much older than it. The layer compositor took the background either side of a layer, stripped the ANSI out of it, and pasted it back as plain text:

```go
bgPlain := stripAnsi(bgLine)          // colour thrown away
result += string(bgRunes[startPos:])
```

An uncoloured block renders in the terminal's default bright foreground, so the scrollbar went white for exactly the rows a modal covered. It slices with `ansi.Cut` now, keeping the styling, with a reset between the pieces so neither can colour the other.

**That was never only about the scrollbar.** Anything coloured beside any modal lost its colour - the highlighted tab, the values on the status line, styled query output. The scrollbar is a solid block against a dark background, so it is the one that showed.

## Not in this change

Results, Trace and AI scroll too and should follow. The Results view has horizontal scrolling and a frozen header keyed to its width, so giving it a column is a bigger change than it looks.

## Testing

`go build`, `go test ./internal/...` and `make lint` (0 issues) all clean.

New tests cover: the thumb at the top, at the bottom, and growing with the proportion showing; a full bar when everything fits and no bar in the list when the whole list fits; no line losing a character; the bar not being selectable; and for the compositor - the background keeping its colour beside a layer, the layer not inheriting the background's, padding when a layer starts past the end of a short line, the width being unchanged, only the layer's own rows being touched, and the exact case reported.

Closes #133