### PR TITLE
fix(ui): delete scrollInfo, drawn past the right edge of the screen

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -530,11 +530,17 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Reduced margin for better scrolling. Clamped because v2's textinput
-		// sizes its placeholder buffer from the width and panics on a negative
-		// one; v1 tolerated it. A terminal that reports no size, or one only a
-		// couple of columns wide, is enough to hit that.
-		inputWidth := max(newWidth-2, 0)
+		// The prompt and the trailing cursor cell are drawn outside the width
+		// the textinput is given, so it renders three columns wider than it is
+		// told. At newWidth-2 the input row was a column wider than the
+		// terminal and wrapped onto the next one. Measured from the prompt
+		// rather than written as a number, so the two cannot drift.
+		//
+		// Clamped because v2's textinput sizes its placeholder buffer from the
+		// width and panics on a negative one; v1 tolerated it. A terminal that
+		// reports no size, or one only a couple of columns wide, is enough to
+		// hit that.
+		inputWidth := max(newWidth-lipgloss.Width(m.input.Prompt)-1, 0)
 		m.input.SetWidth(inputWidth)
 		// Also update AI conversation input width if initialized
 		if m.aiConversationInput.Value() != "" || m.aiConversationActive {

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -433,9 +433,6 @@ func TestF5IsNotAdvertisedWhenAIIsNotConfigured(t *testing.T) {
 	without := &MainModel{styles: DefaultStyles()}
 	with := &MainModel{styles: DefaultStyles(), aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
 
-	assert.Empty(t, aiKeyHint(without))
-	assert.Contains(t, aiKeyHint(with), "F5")
-
 	assert.NotContains(t, stripAnsiForTest(without.getWelcomeMessage()), "F5")
 	assert.Contains(t, stripAnsiForTest(with.getWelcomeMessage()), "F5")
 }

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -41,16 +41,6 @@ func (m *MainModel) newView(content string) tea.View {
 	return v
 }
 
-// aiKeyHint is the "F5: AI" part of the key hints, or nothing when there is no
-// provider configured. Advertising a key that then tells you it cannot do
-// anything is the same defect as showing the tab.
-func aiKeyHint(m *MainModel) string {
-	if !m.aiAvailable() {
-		return ""
-	}
-	return " | F5: AI"
-}
-
 // View renders the main model.
 func (m *MainModel) View() tea.View {
 	if !m.ready {
@@ -104,126 +94,6 @@ func (m *MainModel) View() tea.View {
 
 	if handler := router.GetMetaHandler(); handler != nil {
 		m.statusBar.Capturing = handler.IsCapturing()
-	}
-
-	// Get the active viewport for scroll info
-	activeViewport := m.historyViewport
-	switch m.viewMode {
-	case "table":
-		if m.hasTable {
-			activeViewport = m.tableViewport
-		}
-	case "trace":
-		if m.hasTrace {
-			activeViewport = m.traceViewport
-		}
-	}
-
-	// Add mode indicator and available view keys
-	var scrollInfo string
-	switch m.viewMode {
-	case "ai":
-		// No need to show navigation keys in AI view since they're less relevant
-		scrollInfo = ""
-	case "trace":
-		modeIndicator := m.styles.AccentText.Render("[TRACE VIEW]")
-		scrollInfo = " " + modeIndicator
-		scrollInfo += " " + m.styles.MutedText.Render("[F2: History"+aiKeyHint(m)+"]")
-		if m.hasTable {
-			scrollInfo += " " + m.styles.MutedText.Render("[F3: Table]")
-		}
-	case "table":
-		modeIndicator := m.styles.AccentText.Render("[TABLE VIEW]")
-		scrollInfo = " " + modeIndicator
-		scrollInfo += " " + m.styles.MutedText.Render("[F2: History"+aiKeyHint(m)+" | F6: Toggle Types]")
-		if m.hasTrace {
-			scrollInfo += " " + m.styles.MutedText.Render("[F4: Trace]")
-		}
-	default: // history view
-		modeIndicator := m.styles.MutedText.Render("[CQL VIEW]")
-		scrollInfo = " " + modeIndicator
-		if hint := aiKeyHint(m); hint != "" {
-			scrollInfo += " " + m.styles.MutedText.Render("["+strings.TrimPrefix(hint, " | ")+"]")
-		}
-		if m.hasTable {
-			scrollInfo += " " + m.styles.MutedText.Render("[F3: Table]")
-		}
-		if m.hasTrace {
-			scrollInfo += " " + m.styles.MutedText.Render("[F4: Trace]")
-		}
-	}
-
-	// Add scroll indicator if content is scrollable
-	if activeViewport.TotalLineCount() > activeViewport.Height() {
-		scrollPercent := activeViewport.ScrollPercent()
-		if scrollPercent == 0 { //nolint:gocritic // more readable as if
-			scrollInfo += " [TOP]"
-		} else if scrollPercent >= 0.99 {
-			scrollInfo += " [BOTTOM]"
-		} else {
-			scrollInfo += fmt.Sprintf(" [%d%%]", int(scrollPercent*100))
-		}
-	}
-
-	// Add horizontal scroll indicator if table/trace is wider than viewport
-	switch {
-	case m.viewMode == "trace" && m.hasTrace && m.traceTableWidth > m.traceViewport.Width():
-		if m.traceHorizontalOffset == 0 { //nolint:gocritic // more readable as if
-			scrollInfo += " | H:LEFT"
-		} else if m.traceHorizontalOffset >= m.traceTableWidth-m.traceViewport.Width() {
-			scrollInfo += " | H:RIGHT"
-		} else {
-			// Calculate horizontal scroll percentage
-			maxOffset := m.traceTableWidth - m.traceViewport.Width()
-			hScrollPercent := float64(m.traceHorizontalOffset) / float64(maxOffset)
-			scrollInfo += fmt.Sprintf(" | H:%d%%", int(hScrollPercent*100))
-		}
-	case m.hasTable && m.viewMode == "table" && m.tableWidth > m.tableViewport.Width():
-		if m.horizontalOffset == 0 { //nolint:gocritic // more readable as if
-			scrollInfo += " | H:LEFT"
-		} else if m.horizontalOffset >= m.tableWidth-m.tableViewport.Width() {
-			scrollInfo += " | H:RIGHT"
-		} else {
-			// Calculate horizontal scroll percentage
-			maxOffset := m.tableWidth - m.tableViewport.Width()
-			hScrollPercent := float64(m.horizontalOffset) / float64(maxOffset)
-			scrollInfo += fmt.Sprintf(" | H:%d%%", int(hScrollPercent*100))
-		}
-	}
-
-	// Add sliding window indicator if data has been dropped
-	if m.slidingWindow != nil && m.slidingWindow.DataDroppedAtStart {
-		warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
-		scrollInfo += " " + warningStyle.Render(fmt.Sprintf("[Rows %d-%d, earlier rows dropped]",
-			m.slidingWindow.FirstRowIndex+1,
-			m.slidingWindow.FirstRowIndex+int64(len(m.slidingWindow.Rows))))
-	}
-
-	// Add output format indicator
-	if m.sessionManager != nil {
-		outputFormat := m.sessionManager.GetOutputFormat()
-		switch outputFormat {
-		case config.OutputFormatExpand:
-			expandStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF")).Bold(true)
-			scrollInfo += " " + expandStyle.Render("[EXPAND ON]")
-		case config.OutputFormatASCII:
-			asciiStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF"))
-			scrollInfo += " " + asciiStyle.Render("[ASCII]")
-		case config.OutputFormatJSON:
-			jsonStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF"))
-			scrollInfo += " " + jsonStyle.Render("[JSON]")
-		}
-	}
-
-	// Say which way the mouse is set. Without this, someone who has turned it
-	// off, or run into a terminal that will not report it, just finds that
-	// clicking the tabs does nothing, with nothing on screen explaining why.
-	if m.mouseEnabled {
-		mouseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#87D7FF"))
-		scrollInfo += " " + mouseStyle.Render("[MOUSE]")
-	} else {
-		mouseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#5F5F5F"))
-		scrollInfo += " " + mouseStyle.Render("[MOUSE OFF]")
 	}
 
 	// Build the input section
@@ -349,7 +219,7 @@ func (m *MainModel) View() tea.View {
 		viewportSection,
 		inputSection,
 		infoBar,
-		m.statusBar.View(viewportWidth, m.styles, m.viewMode)+scrollInfo,
+		m.statusBar.View(viewportWidth, m.styles, m.viewMode),
 	)
 
 	// Calculate the actual screen dimensions

--- a/internal/ui/view_width_test.go
+++ b/internal/ui/view_width_test.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// widthModel is a Console at the given terminal width, sized the way the app
+// sizes it: through a WindowSizeMsg, so the widths under test are the ones the
+// program computes rather than ones the test picked.
+func widthModel(t *testing.T, width int) *MainModel {
+	t.Helper()
+
+	input := textinput.New()
+
+	m := &MainModel{
+		input:     input,
+		styles:    DefaultStyles(),
+		viewMode:  "history",
+		statusBar: NewStatusBarModel(),
+		topBar:    NewTopBarModel(),
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: width, Height: 24})
+	m, ok := updated.(*MainModel)
+	require.True(t, ok, "Update returns the model")
+	require.True(t, m.ready, "a window size makes it ready to draw")
+
+	m.fullHistoryContent = strings.Repeat("line\n", 40)
+	m.historyViewport.SetContent(m.wrapHistoryContent(consoleWidth(width)))
+
+	return m
+}
+
+// widest returns the widest row of a rendered view, and how wide it is.
+func widest(view string) (string, int) {
+	var row string
+	var width int
+	for _, line := range strings.Split(view, "\n") {
+		if w := lipgloss.Width(line); w > width {
+			row, width = line, w
+		}
+	}
+	return row, width
+}
+
+// TestNoRowIsWiderThanTheTerminal is the defect behind #135.
+//
+// View built a string called scrollInfo every frame - the current view, the
+// scroll position, the output format, the mouse state - and appended it to the
+// status line. StatusBarModel.View ends with Width(width), so the bar always
+// comes back exactly the terminal's width whatever it holds, and the append
+// therefore started one column past the right-hand edge.
+//
+// None of it was ever on screen. Both halves are in the initial commit, so it
+// had never worked in any version of the program: it read as live code, nothing
+// errored, no test failed, and there was no moment where something visible
+// stopped being visible. What it left behind was rows wider than the terminal -
+// 109 columns on an 80-column terminal - which is why the Console rows came out
+// over-wide.
+//
+// Measuring the rendered view is the check that would have caught it on the day
+// it was written, and it holds for anything else appended past the edge later.
+func TestNoRowIsWiderThanTheTerminal(t *testing.T) {
+	for _, width := range []int{40, 80, 120, 200} {
+		m := widthModel(t, width)
+
+		row, got := widest(m.View().Content)
+
+		assert.LessOrEqual(t, got, width,
+			"at %d columns the widest row is %d: %q", width, got, stripAnsiForTest(row))
+	}
+}
+
+// TestTheStatusLineIsExactlyTheTerminalWidth. The bar pads itself to the full
+// width, which is what left no room for anything concatenated onto it.
+func TestTheStatusLineIsExactlyTheTerminalWidth(t *testing.T) {
+	m := widthModel(t, 80)
+
+	rows := strings.Split(m.View().Content, "\n")
+	require.NotEmpty(t, rows)
+
+	last := rows[len(rows)-1]
+	assert.Equal(t, 80, lipgloss.Width(last),
+		"the status line fills the width: %q", stripAnsiForTest(last))
+}
+
+// TestTheInputRowFitsTheTerminal.
+//
+// The textinput draws its prompt and a trailing cursor cell outside the width
+// it is given, so it renders three columns wider than it is told. It was being
+// given newWidth-2, so the input row was a column wider than the terminal and
+// wrapped onto the next one.
+func TestTheInputRowFitsTheTerminal(t *testing.T) {
+	for _, width := range []int{40, 80, 120} {
+		m := widthModel(t, width)
+
+		assert.LessOrEqual(t, lipgloss.Width(m.input.View()), width,
+			"the input row fits in %d columns", width)
+	}
+}
+
+// TestATinyTerminalDoesNotPanic. v2's textinput sizes its placeholder buffer
+// from the width and panics on a negative one, and a terminal that reports no
+// size at all is enough to reach that.
+func TestATinyTerminalDoesNotPanic(t *testing.T) {
+	for _, width := range []int{0, 1, 2, 3, 4} {
+		assert.NotPanics(t, func() { widthModel(t, width).View() },
+			"a %d-column terminal must still draw", width)
+	}
+}


### PR DESCRIPTION
`View` built a string called `scrollInfo` every frame - the current view and the
keys to the others, the scroll position, the output format, the mouse state, the
sliding window warning - and appended it to the status line.
`StatusBarModel.View` ends with `Width(width)`, so the bar always comes back
exactly the terminal's width whatever it holds, and the append therefore started
one column past the right-hand edge.

None of it has ever been on screen. Both halves are in the initial commit, so
this has never worked in any version of the program. It survived because it
reads as live code: indicators get built carefully, nothing errors, no test
fails, and there was never a moment where something that used to be visible
stopped being visible. The `[MOUSE]` indicator was added this week with a
comment explaining that without it someone whose mouse is off just finds
clicking does nothing with nothing on screen to explain why - written to solve
the problem it still had.

Most of what it computed is on screen elsewhere now: the view and its keys are
the tab bar, vertical scroll position is the Console scrollbar, the output
format is already a status bar field. Two are not - horizontal scroll position,
and the sliding window warning that is the only place the program admits it has
dropped rows. #136 tracks finding them homes. Neither is a regression from this;
both have been missing since the first commit.

A hundred lines go, and with them the rows wider than the terminal that made the
Console come out over-wide.

### The test

It measures the rendered screen and asserts no row is wider than the terminal -
the check that would have caught this on the day it was written, and one that
holds for anything appended past the edge later. It sizes the model through a
`WindowSizeMsg` rather than setting widths by hand, so what it measures is what
the program computes.

It failed twice more.

**The input row was a column too wide at every width.** The textinput draws its
prompt and a trailing cursor cell outside the width it is given, so it renders
three columns wider than it is told, and it was being handed `newWidth-2`. It
reads the prompt now rather than carrying a number that can drift from it. That
fix is in this PR because the test cannot pass without it.

**The status line wraps to two rows below about a hundred columns** - 25 rows
for a 24-row terminal at 80 - because `Width` wraps rather than truncates and
the fields come to 94 columns. Left alone here: which fields give way first is a
decision, not a deletion. Raised as #137.

Closes #135

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
