### PR TITLE
feat(save): write Parquet, and convert values from their displayed form

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,17 +643,20 @@ Meta-commands provide additional functionality beyond standard CQL:
   SELECT * FROM users WHERE status = 'active';
 
   -- Then save the displayed results in various formats:
-  SAVE                           -- Interactive dialog (choose format & filename)
-  SAVE 'users.csv'               -- Save to CSV (format auto-detected)
-  SAVE 'users.json'              -- Save to JSON (format auto-detected)
-  SAVE 'users.txt' ASCII         -- Save as ASCII table
-  SAVE 'data.csv' CSV            -- Explicitly specify format
+  SAVE                                    -- Interactive dialog (choose format & filename)
+  SAVE TO 'users.csv'                     -- Save to CSV (format auto-detected)
+  SAVE TO 'users.json'                    -- Save to JSON (format auto-detected)
+  SAVE TO 'users.parquet'                 -- Save to Parquet (format auto-detected)
+  SAVE TO 'users.txt' AS ASCII            -- Save as ASCII table
+  SAVE TO 'data.out' AS CSV               -- Explicitly specify format
 
   -- Key differences from CAPTURE:
   -- - SAVE exports the currently displayed results
   -- - No need to re-run the query
   -- - Preserves exact data shown in terminal
   -- - Works with paginated results (saves only loaded pages)
+  -- PARQUET needs the column types of the result, so it is offered for query
+  -- results and not for a DESCRIBE, which arrives without them.
   ```
 
 #### Information Display

--- a/README_jp.md
+++ b/README_jp.md
@@ -597,17 +597,20 @@ Cassandraクラスタがサポートする任意の有効なCQLステートメ�
   SELECT * FROM users WHERE status = 'active';
 
   -- 次に表示された結果をさまざまな形式で保存:
-  SAVE                           -- 対話ダイアログ(形式とファイル名を選択)
-  SAVE 'users.csv'               -- CSVに保存(形式は自動検出)
-  SAVE 'users.json'              -- JSONに保存(形式は自動検出)
-  SAVE 'users.txt' ASCII         -- ASCIIテーブルとして保存
-  SAVE 'data.csv' CSV            -- 明示的に形式を指定
+  SAVE                                    -- 対話ダイアログ(形式とファイル名を選択)
+  SAVE TO 'users.csv'                     -- CSVに保存(形式は自動検出)
+  SAVE TO 'users.json'                    -- JSONに保存(形式は自動検出)
+  SAVE TO 'users.parquet'                 -- Parquetに保存(形式は自動検出)
+  SAVE TO 'users.txt' AS ASCII            -- ASCIIテーブルとして保存
+  SAVE TO 'data.out' AS CSV               -- 明示的に形式を指定
 
   -- CAPTUREとの主な違い:
   -- - SAVEは現在表示されている結果をエクスポート
   -- - クエリを再実行する必要なし
   -- - ターミナルに表示されているデータをそのまま保持
   -- - ページ分割された結果でも動作(ロードされたページのみ保存)
+  -- PARQUETは結果のカラム型を必要とするため、クエリ結果では選択でき、
+  -- 型を持たないDESCRIBEでは選択肢に現れません。
   ```
 
 #### 情報表示

--- a/internal/parquet/string_values_test.go
+++ b/internal/parquet/string_values_test.go
@@ -1,0 +1,75 @@
+package parquet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValuesConvertFromTheirDisplayedForm.
+//
+// WriteStringRows is the path for rows that are already strings: everything
+// SAVE has, since a result is [][]string by the time it can be saved, and
+// CAPTURE's fallback when it has no typed rows to hand. The converters only
+// took Go values, so a string going into anything but a text column failed,
+// and AppendValueToBuilder appends null on a failed conversion. The file came
+// out with the right number of rows and nothing in any column that was not
+// text.
+func TestValuesConvertFromTheirDisplayedForm(t *testing.T) {
+	tm := NewTypeMapper()
+
+	tests := []struct {
+		name  string
+		typ   arrow.DataType
+		given string
+		want  interface{}
+	}{
+		{"tinyint", arrow.PrimitiveTypes.Int8, "3", int8(3)},
+		{"smallint", arrow.PrimitiveTypes.Int16, "-7", int16(-7)},
+		{"int", arrow.PrimitiveTypes.Int32, "42", int32(42)},
+		{"bigint", arrow.PrimitiveTypes.Int64, "9000000000", int64(9000000000)},
+		{"float", arrow.PrimitiveTypes.Float32, "1.5", float32(1.5)},
+		{"double", arrow.PrimitiveTypes.Float64, "2.25", 2.25},
+		{"boolean", arrow.FixedWidthTypes.Boolean, "true", true},
+		{"text", arrow.BinaryTypes.String, "hello", "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tm.ConvertValue(tt.given, tt.typ)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTimestampsConvertFromTheirDisplayedForm. FormatValue renders a time as
+// RFC3339, so that is the shape a saved timestamp arrives in.
+func TestTimestampsConvertFromTheirDisplayedForm(t *testing.T) {
+	tm := NewTypeMapper()
+	want := time.Date(2026, 9, 10, 11, 22, 33, 0, time.UTC)
+
+	for _, given := range []string{
+		"2026-09-10T11:22:33Z",
+		"2026-09-10 11:22:33 +0000 UTC",
+		"2026-09-10 11:22:33",
+	} {
+		got, err := tm.ConvertValue(given, arrow.FixedWidthTypes.Timestamp_ms)
+		require.NoError(t, err, given)
+		assert.Equal(t, arrow.Timestamp(want.UnixMilli()), got, given)
+	}
+}
+
+// TestAnUnparseableValueIsAnError, which the builder turns into a null. One bad
+// cell should cost that cell, not the rest of the row or the rest of the file.
+func TestAnUnparseableValueIsAnError(t *testing.T) {
+	tm := NewTypeMapper()
+
+	for _, given := range []string{"null", "", "not a number"} {
+		_, err := tm.ConvertValue(given, arrow.PrimitiveTypes.Int32)
+		assert.Error(t, err, given)
+	}
+}

--- a/internal/parquet/types.go
+++ b/internal/parquet/types.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/big"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -325,6 +326,16 @@ func extractValue(col arrow.Array, idx int) any {
 
 // Type conversion helper functions
 
+// The converters below take a string as well as a Go value.
+//
+// A value can arrive already rendered: a result reaches SAVE as [][]string,
+// because that is all the UI holds once it is on screen, and it is CAPTURE's
+// fallback when it has no typed rows to hand. Without a string case the
+// conversion failed, AppendValueToBuilder appended null, and the file came out
+// with the right number of rows and nothing in any column that was not text.
+//
+// A value that will not parse stays an error, and so still becomes a null: one
+// unreadable cell should cost that cell and not the rest of the file.
 func (tm *TypeMapper) toInt8(value interface{}) (int8, error) {
 	switch v := value.(type) {
 	case int8:
@@ -349,6 +360,12 @@ func (tm *TypeMapper) toInt8(value interface{}) (int8, error) {
 			return 0, fmt.Errorf("value %d out of range for int8", v)
 		}
 		return int8(v), nil
+	case string:
+		n, err := strconv.ParseInt(v, 10, 8)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as int8: %w", v, err)
+		}
+		return int8(n), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to int8", value)
 	}
@@ -375,6 +392,12 @@ func (tm *TypeMapper) toInt16(value interface{}) (int16, error) {
 			return 0, fmt.Errorf("value %d out of range for int16", v)
 		}
 		return int16(v), nil
+	case string:
+		n, err := strconv.ParseInt(v, 10, 16)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as int16: %w", v, err)
+		}
+		return int16(n), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to int16", value)
 	}
@@ -400,6 +423,12 @@ func (tm *TypeMapper) toInt32(value interface{}) (int32, error) {
 			return 0, fmt.Errorf("value %d out of range for int32", v)
 		}
 		return int32(v), nil
+	case string:
+		n, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as int32: %w", v, err)
+		}
+		return int32(n), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to int32", value)
 	}
@@ -419,6 +448,12 @@ func (tm *TypeMapper) toInt64(value interface{}) (int64, error) {
 		return int64(v), nil
 	case time.Duration:
 		return int64(v), nil
+	case string:
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as int64: %w", v, err)
+		}
+		return n, nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to int64", value)
 	}
@@ -430,6 +465,12 @@ func (tm *TypeMapper) toFloat32(value interface{}) (float32, error) {
 		return v, nil
 	case float64:
 		return float32(v), nil
+	case string:
+		f, err := strconv.ParseFloat(v, 32)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as float32: %w", v, err)
+		}
+		return float32(f), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to float32", value)
 	}
@@ -441,6 +482,12 @@ func (tm *TypeMapper) toFloat64(value interface{}) (float64, error) {
 		return float64(v), nil
 	case float64:
 		return v, nil
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as float64: %w", v, err)
+		}
+		return f, nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to float64", value)
 	}
@@ -450,6 +497,12 @@ func (tm *TypeMapper) toBool(value interface{}) (bool, error) {
 	switch v := value.(type) {
 	case bool:
 		return v, nil
+	case string:
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, fmt.Errorf("cannot parse %q as bool: %w", v, err)
+		}
+		return b, nil
 	default:
 		return false, fmt.Errorf("cannot convert %T to bool", value)
 	}
@@ -529,10 +582,9 @@ func (tm *TypeMapper) toDate32(value interface{}) (arrow.Date32, error) {
 		}
 		return arrow.Date32(days), nil
 	case string:
-		// Try to parse date string
-		t, err := time.Parse("2006-01-02", v)
+		t, err := parseTimeString(v)
 		if err != nil {
-			return 0, fmt.Errorf("cannot parse date: %w", err)
+			return 0, err
 		}
 		days := t.Unix() / 86400
 		if days < math.MinInt32 || days > math.MaxInt32 {
@@ -551,6 +603,12 @@ func (tm *TypeMapper) toTime64(value interface{}) (arrow.Time64, error) {
 		return arrow.Time64(v.Nanoseconds()), nil
 	case int64:
 		return arrow.Time64(v), nil
+	case string:
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as a time: %w", v, err)
+		}
+		return arrow.Time64(d.Nanoseconds()), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to Time64", value)
 	}
@@ -563,6 +621,12 @@ func (tm *TypeMapper) toTimestamp(value interface{}) (arrow.Timestamp, error) {
 		return arrow.Timestamp(v.UnixMilli()), nil
 	case int64:
 		return arrow.Timestamp(v), nil
+	case string:
+		t, err := parseTimeString(v)
+		if err != nil {
+			return 0, err
+		}
+		return arrow.Timestamp(t.UnixMilli()), nil
 	default:
 		return 0, fmt.Errorf("cannot convert %T to Timestamp", value)
 	}
@@ -959,4 +1023,27 @@ func (tm *TypeMapper) ArrowToCassandraType(arrowType arrow.DataType) string {
 	default:
 		return "text" // Default fallback
 	}
+}
+
+// parseTimeString reads a time as it is displayed.
+//
+// A result reaches SAVE as [][]string, so a timestamp arrives as whatever
+// FormatValue rendered - RFC3339 - rather than as a time.Time. The plain date
+// and the space-separated layouts are here because the same strings turn up in
+// a CSV being copied in.
+func parseTimeString(v string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, v); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as a time", v)
 }

--- a/internal/router/save_command.go
+++ b/internal/router/save_command.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
+	"github.com/axonops/cqlai/internal/parquet"
 )
 
 // SaveCommand represents a parsed SAVE command
@@ -24,7 +25,17 @@ type SaveCommand struct {
 }
 
 // saveFormats are the formats SAVE writes.
-var saveFormats = []string{"CSV", "JSON", "ASCII"}
+var saveFormats = []string{"CSV", "JSON", "PARQUET", "ASCII"}
+
+// parquetNeedsTypes is what SAVE ... AS PARQUET says when the column types are
+// not to hand.
+//
+// The Parquet writer builds its schema from the CQL types, and
+// AppendValueToBuilder swallows a conversion it cannot do, so a wrong schema
+// writes a file that opens cleanly and holds nothing. Refusing is the better
+// answer.
+const parquetNeedsTypes = "no column types for the last result, so PARQUET cannot be written. " +
+	"Run the query again and save its results, or choose another format"
 
 // SaveFormats names the formats SAVE accepts after AS.
 //
@@ -206,6 +217,8 @@ func detectFormatFromExtension(filename string) string {
 		return "CSV"
 	case strings.HasSuffix(lower, ".json"):
 		return "JSON"
+	case strings.HasSuffix(lower, ".parquet"):
+		return "PARQUET"
 	case strings.HasSuffix(lower, ".txt") || strings.HasSuffix(lower, ".text"):
 		return "ASCII"
 	default:
@@ -213,8 +226,13 @@ func detectFormatFromExtension(filename string) string {
 	}
 }
 
-// HandleSaveCommand executes the save operation
-func HandleSaveCommand(cmd SaveCommand, tableData [][]string) error {
+// HandleSaveCommand executes the save operation.
+//
+// columnTypes are the CQL types of the columns in tableData, in the same order,
+// and may be empty. Only PARQUET needs them - it builds a schema from them -
+// and it refuses rather than writing a file it cannot type. See
+// ParquetTypesUsable.
+func HandleSaveCommand(cmd SaveCommand, tableData [][]string, columnTypes []string) error {
 	// Validate data availability
 	if len(tableData) == 0 {
 		return fmt.Errorf("no data to export")
@@ -244,6 +262,8 @@ func HandleSaveCommand(cmd SaveCommand, tableData [][]string) error {
 		return exportToJSON(cmd.Filename, tableData, cmd.Options)
 	case "ASCII":
 		return exportToASCII(cmd.Filename, tableData, cmd.Options)
+	case "PARQUET":
+		return exportToParquet(cmd.Filename, tableData, columnTypes, cmd.Options)
 	default:
 		return fmt.Errorf("unsupported format: %s", cmd.Format)
 	}
@@ -469,4 +489,68 @@ func GenerateDefaultFilename(format string) string {
 		ext = ".txt"
 	}
 	return fmt.Sprintf("query_results_%s%s", timestamp, ext)
+}
+
+// ParquetTypesUsable says whether a result can be written as Parquet.
+//
+// The writer builds an Arrow schema from the CQL types, so there has to be one
+// per column. Anything offering PARQUET as a choice asks this first, and
+// exportToParquet asks it again before writing, so the window and the typed
+// command cannot disagree about when it is available.
+func ParquetTypesUsable(tableData [][]string, columnTypes []string) bool {
+	if len(tableData) == 0 {
+		return false
+	}
+	return len(columnTypes) == len(tableData[0])
+}
+
+// exportToParquet writes the displayed results as Parquet.
+//
+// It goes through the writer CAPTURE uses rather than a second one, so a file
+// saved from the results is the same file capturing the query would have
+// produced.
+func exportToParquet(filename string, data [][]string, columnTypes []string, options map[string]interface{}) error {
+	if !ParquetTypesUsable(data, columnTypes) {
+		return fmt.Errorf("%s", parquetNeedsTypes)
+	}
+
+	// Parquet wants the column names Cassandra knows: no key markers, no
+	// styling. Same treatment the CSV export gives them.
+	headers := make([]string, len(data[0]))
+	for i, cell := range data[0] {
+		headers[i] = db.StripKeyMarker(stripAnsi(cell))
+	}
+
+	writerOptions := parquet.DefaultWriterOptions()
+	if val, ok := options["compression"]; ok {
+		if s, ok := val.(string); ok {
+			writerOptions.Compression = parquet.ParseCompression(s)
+		}
+	}
+
+	writer, err := parquet.NewParquetCaptureWriter(filepath.Clean(filename), headers, columnTypes, writerOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create Parquet writer: %w", err)
+	}
+
+	rows := make([][]string, 0, len(data)-1)
+	for _, row := range data[1:] {
+		clean := make([]string, len(row))
+		for i, cell := range row {
+			clean[i] = stripAnsi(cell)
+		}
+		rows = append(rows, clean)
+	}
+
+	if err := writer.WriteStringRows(headers, rows); err != nil {
+		// Close it anyway: a half-written file left open is worse than a
+		// half-written one closed.
+		_ = writer.Close()
+		return fmt.Errorf("failed to write Parquet rows: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close Parquet file: %w", err)
+	}
+	return nil
 }

--- a/internal/router/save_parquet_test.go
+++ b/internal/router/save_parquet_test.go
@@ -1,0 +1,244 @@
+package router
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// savedResult is a result as the UI holds it: the header row, then the rows.
+func savedResult() ([][]string, []string) {
+	data := [][]string{
+		{"id (PK)", "name", "age"},
+		{"1", "alice", "30"},
+		{"2", "bob", "25"},
+	}
+	return data, []string{"int", "text", "int"}
+}
+
+// readParquet returns the column names and the values of a written file, one
+// string per cell.
+//
+// It reads the values rather than only counting rows because that is the
+// failure this is guarding against: a file with the wrong schema opens cleanly
+// and reports the right number of rows, and is empty in every column.
+func readParquet(t *testing.T, path string) ([]string, [][]string) {
+	t.Helper()
+
+	f, err := os.Open(path) //nolint:gosec // a path this test just wrote
+	require.NoError(t, err)
+	defer f.Close()
+
+	reader, err := file.NewParquetReader(f)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	arrowReader, err := pqarrow.NewFileReader(reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+
+	table, err := arrowReader.ReadTable(context.Background())
+	require.NoError(t, err)
+	defer table.Release()
+
+	names := make([]string, 0, table.NumCols())
+	for i := 0; i < int(table.NumCols()); i++ {
+		names = append(names, table.Schema().Field(i).Name)
+	}
+
+	rows := make([][]string, table.NumRows())
+	for r := range rows {
+		rows[r] = make([]string, table.NumCols())
+	}
+	for c := 0; c < int(table.NumCols()); c++ {
+		col := table.Column(c)
+		r := 0
+		for _, chunk := range col.Data().Chunks() {
+			for i := 0; i < chunk.Len(); i++ {
+				if !chunk.IsNull(i) {
+					rows[r][c] = chunk.ValueStr(i)
+				}
+				r++
+			}
+		}
+	}
+	return names, rows
+}
+
+// TestSaveWritesParquet is the reported gap: CAPTURE writes Parquet and SAVE
+// did not, so picking it for a result already on screen meant running the query
+// again under CAPTURE, which is the thing SAVE exists to avoid.
+func TestSaveWritesParquet(t *testing.T) {
+	data, types := savedResult()
+	path := filepath.Join(t.TempDir(), "out.parquet")
+
+	cmd, err := ParseSaveCommand("SAVE TO '" + path + "' AS PARQUET")
+	require.NoError(t, err)
+	require.Equal(t, "PARQUET", cmd.Format)
+
+	require.NoError(t, HandleSaveCommand(*cmd, data, types))
+
+	names, rows := readParquet(t, path)
+	assert.Equal(t, []string{"id", "name", "age"}, names,
+		"the key marker is not part of the column name")
+	assert.Equal(t, [][]string{
+		{"1", "alice", "30"},
+		{"2", "bob", "25"},
+	}, rows, "the values arrive, and the header is not one of them")
+}
+
+// TestTheExtensionIsEnoughToPickParquet, the same as .csv and .json.
+func TestTheExtensionIsEnoughToPickParquet(t *testing.T) {
+	data, types := savedResult()
+	path := filepath.Join(t.TempDir(), "out.parquet")
+
+	cmd, err := ParseSaveCommand("SAVE TO '" + path + "'")
+	require.NoError(t, err)
+	assert.Equal(t, "PARQUET", cmd.Format)
+
+	require.NoError(t, HandleSaveCommand(*cmd, data, types))
+	_, rows := readParquet(t, path)
+	assert.Len(t, rows, 2)
+}
+
+// TestParquetRefusesWithoutTypes.
+//
+// The writer builds an Arrow schema from the CQL types, and
+// AppendValueToBuilder swallows a conversion it cannot do - there is a TODO in
+// the writer saying so - so a wrong schema writes a file that opens cleanly and
+// holds nothing. Refusing is the better answer, and it must leave no file
+// behind for someone to find later and trust.
+func TestParquetRefusesWithoutTypes(t *testing.T) {
+	data, types := savedResult()
+
+	for name, given := range map[string][]string{
+		"none":      nil,
+		"too few":   {"int"},
+		"too many":  append(slices.Clone(types), "text"),
+		"empty set": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "out.parquet")
+			cmd := SaveCommand{Filename: path, Format: "PARQUET"}
+
+			err := HandleSaveCommand(cmd, data, given)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "PARQUET")
+			assert.NoFileExists(t, path, "nothing half-written left behind")
+		})
+	}
+}
+
+// TestEverySaveFormatIsAccepted ties the list offered to the list that works.
+//
+// Five separate bugs this week had this shape: a list written in more than one
+// place with only one copy deciding anything. A format the window offers and
+// the command refuses is that bug again.
+func TestEverySaveFormatIsAccepted(t *testing.T) {
+	data, types := savedResult()
+
+	for _, format := range SaveFormats() {
+		t.Run(format, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "out")
+
+			cmd, err := ParseSaveCommand("SAVE TO '" + path + "' AS " + format)
+			require.NoError(t, err, "the parser accepts every offered format")
+			require.Equal(t, format, cmd.Format)
+
+			require.NoError(t, HandleSaveCommand(*cmd, data, types),
+				"and so does the writer")
+			assert.FileExists(t, path)
+		})
+	}
+}
+
+// TestParquetTypesUsable is the one check the window and the command share, so
+// neither can decide differently about whether Parquet is available.
+func TestParquetTypesUsable(t *testing.T) {
+	data, types := savedResult()
+
+	assert.True(t, ParquetTypesUsable(data, types))
+	assert.False(t, ParquetTypesUsable(data, nil))
+	assert.False(t, ParquetTypesUsable(data, types[:2]))
+	assert.False(t, ParquetTypesUsable(nil, types), "nothing to save")
+}
+
+// TestParquetWritesEveryColumnType is what the feature is actually for.
+//
+// A result reaches SAVE as [][]string - the values as they are displayed - so
+// everything has to be parsed back into its CQL type to build the file. Before
+// this, WriteStringRows put the raw string into a builder expecting a number,
+// the conversion failed, and AppendValueToBuilder swallowed it and appended
+// null. The file opened cleanly, reported the right number of rows, and every
+// column that was not text was empty.
+//
+// That path is CAPTURE's fallback too, for when it has no typed rows to hand.
+func TestParquetWritesEveryColumnType(t *testing.T) {
+	data := [][]string{
+		{"id", "big", "small", "tiny", "f", "d", "ok", "when", "who", "note"},
+		{
+			"42", "9000000000", "7", "3",
+			"1.5", "2.25",
+			"true",
+			"2026-09-10T11:22:33Z",
+			"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			"hello",
+		},
+	}
+	types := []string{
+		"int", "bigint", "smallint", "tinyint",
+		"float", "double",
+		"boolean",
+		"timestamp",
+		"uuid",
+		"text",
+	}
+
+	path := filepath.Join(t.TempDir(), "types.parquet")
+	require.NoError(t, HandleSaveCommand(
+		SaveCommand{Filename: path, Format: "PARQUET"}, data, types))
+
+	names, rows := readParquet(t, path)
+	assert.Equal(t, data[0], names)
+	require.Len(t, rows, 1)
+
+	for i, name := range names {
+		assert.NotEmpty(t, rows[0][i], "column %s (%s) must not be null", name, types[i])
+	}
+
+	assert.Equal(t, "42", rows[0][0])
+	assert.Equal(t, "9000000000", rows[0][1])
+	assert.Equal(t, "7", rows[0][2])
+	assert.Equal(t, "3", rows[0][3])
+	assert.Equal(t, "true", rows[0][6])
+	assert.Equal(t, "hello", rows[0][9])
+}
+
+// TestAValueThatCannotBeParsedBecomesNull rather than failing the whole save.
+// A column that is genuinely empty in Cassandra is displayed as "null", and one
+// bad cell should not cost you the other ten thousand rows.
+func TestAValueThatCannotBeParsedBecomesNull(t *testing.T) {
+	data := [][]string{
+		{"id", "name"},
+		{"1", "alice"},
+		{"null", "bob"},
+	}
+	path := filepath.Join(t.TempDir(), "nulls.parquet")
+
+	require.NoError(t, HandleSaveCommand(
+		SaveCommand{Filename: path, Format: "PARQUET"}, data, []string{"int", "text"}))
+
+	_, rows := readParquet(t, path)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "1", rows[0][0])
+	assert.Empty(t, rows[1][0], "an unparseable id is null")
+	assert.Equal(t, "bob", rows[1][1], "and the rest of the row survives")
+}

--- a/internal/ui/capture_panel.go
+++ b/internal/ui/capture_panel.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -85,11 +86,22 @@ func (c capturePanel) title() string {
 }
 
 // formatsFor is the list a kind offers, from the command that parses them.
-func formatsFor(kind fileKind) []string {
-	if kind == saving {
-		return router.SaveFormats()
+//
+// Saving drops PARQUET when the last result came without column types - a
+// DESCRIBE, most often - because the writer builds its schema from them and
+// there is nothing to build one from. It asks the command rather than deciding
+// for itself, so the window cannot offer a format the command will refuse, the
+// same way SAVE RESULTS dims from the check SAVE makes.
+func (m *MainModel) formatsFor(kind fileKind) []string {
+	if kind != saving {
+		return router.CaptureFormats()
 	}
-	return router.CaptureFormats()
+
+	formats := router.SaveFormats()
+	if router.ParquetTypesUsable(m.lastTableData, m.columnTypes) {
+		return formats
+	}
+	return slices.DeleteFunc(formats, func(f string) bool { return f == "PARQUET" })
 }
 
 // describe says what a format does, since the names alone do not.
@@ -160,7 +172,7 @@ func (m *MainModel) showFilePanel(kind fileKind, anchorX int, centred bool) (*Ma
 
 	// The formats the command parses, so the list cannot offer one it will
 	// refuse.
-	formats := formatsFor(kind)
+	formats := m.formatsFor(kind)
 	if kind == capturing {
 		if handler := router.GetMetaHandler(); handler != nil && handler.IsCapturing() {
 			// Stopping is what you want while it is running, so it goes first.

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -548,6 +549,7 @@ func TestClickingSaveOpensTheWindow(t *testing.T) {
 	m := helpModel()
 	m.windowHeight = 30
 	m.lastTableData = [][]string{{"id"}, {"1"}} // something to save
+	m.columnTypes = []string{"int"}             // typed, so PARQUET is offered
 
 	save := spans(m, saveMode)
 	pressAt(m, (save.start+save.end)/2, 0)
@@ -567,13 +569,54 @@ func TestTheSaveWindowBuildsTheSaveCommand(t *testing.T) {
 	assert.Equal(t, "CAPTURE JSON '/tmp/out.json'", capture.command("JSON", "/tmp/out.json"))
 }
 
-// TestSaveOffersItsOwnFormats: ASCII rather than PARQUET.
+// TestSaveOffersItsOwnFormats. ASCII is SAVE's alone: it writes the table as it
+// appears on screen, which is a thing you want from a result you are looking at
+// and not from a capture running in the background.
 func TestSaveOffersItsOwnFormats(t *testing.T) {
 	m := helpModel()
+	m.lastTableData = [][]string{{"id"}, {"1"}}
+	m.columnTypes = []string{"int"}
 	m.openSavePanel()
 
-	assert.Equal(t, []string{"CSV", "JSON", "ASCII"}, m.capture.formats)
-	assert.NotContains(t, m.capture.formats, "PARQUET", "SAVE does not write Parquet")
+	assert.Equal(t, []string{"CSV", "JSON", "PARQUET", "ASCII"}, m.capture.formats)
+	assert.NotContains(t, m.formatsFor(capturing), "ASCII", "CAPTURE does not write ASCII")
+}
+
+// TestParquetIsOfferedOnlyWithTheTypesToWriteIt.
+//
+// The writer builds an Arrow schema from the CQL types, and
+// AppendValueToBuilder swallows a conversion it cannot do, so a result with no
+// types would write a file that opens cleanly and holds nothing. DESCRIBE is
+// the common way to arrive without them.
+func TestParquetIsOfferedOnlyWithTheTypesToWriteIt(t *testing.T) {
+	m := helpModel()
+	m.lastTableData = [][]string{{"id", "name"}, {"1", "a"}}
+
+	m.columnTypes = nil
+	assert.NotContains(t, m.formatsFor(saving), "PARQUET", "no types, no Parquet")
+
+	m.columnTypes = []string{"int"} // one type for two columns
+	assert.NotContains(t, m.formatsFor(saving), "PARQUET", "a type per column, or none")
+
+	m.columnTypes = []string{"int", "text"}
+	assert.Contains(t, m.formatsFor(saving), "PARQUET")
+}
+
+// TestTheWindowAndTheCommandAgreeAboutParquet. The window asks the command
+// whether it can write Parquet, so it cannot offer a format the command will
+// then refuse.
+func TestTheWindowAndTheCommandAgreeAboutParquet(t *testing.T) {
+	m := helpModel()
+	m.lastTableData = [][]string{{"id"}, {"1"}}
+
+	for _, types := range [][]string{nil, {"int"}, {"int", "text"}} {
+		m.columnTypes = types
+
+		offered := slices.Contains(m.formatsFor(saving), "PARQUET")
+		accepted := router.ParquetTypesUsable(m.lastTableData, m.columnTypes)
+
+		assert.Equal(t, accepted, offered, "types %v", types)
+	}
 }
 
 // TestTheDefaultNameSuitsTheKind.
@@ -581,7 +624,8 @@ func TestTheDefaultNameSuitsTheKind(t *testing.T) {
 	m := helpModel()
 
 	m.openSavePanel()
-	m.capture.format = 2 // ASCII
+	m.capture.format = slices.Index(m.capture.formats, "ASCII")
+	require.GreaterOrEqual(t, m.capture.format, 0, "SAVE offers ASCII")
 	m.chooseCaptureFormat()
 	assert.Contains(t, m.capture.input.Value(), "results_")
 	assert.True(t, strings.HasSuffix(m.capture.input.Value(), ".txt"))

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -45,7 +45,7 @@ func (m *MainModel) processCommandResult(command string, result interface{}, sta
 			}
 			v.Options["already_json"] = true
 		}
-		err := router.HandleSaveCommand(*v, m.lastTableData)
+		err := router.HandleSaveCommand(*v, m.lastTableData, m.columnTypes)
 		if err != nil {
 			m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+err.Error())
 		} else {
@@ -524,6 +524,12 @@ func (m *MainModel) processTableResult(command string, v [][]string) (*MainModel
 		// Store table data and headers
 		m.lastTableData = v
 		m.tableHeaders = v[0] // Store the header row
+		// These results arrive without types - DESCRIBE is the common one - and
+		// the last query's would otherwise be left standing beside a result
+		// they do not describe, with no guarantee even of the same number of
+		// columns. F6 lines them up by index, and PARQUET builds a schema from
+		// them, so both would be quietly wrong.
+		m.columnTypes = nil
 		m.resultFormat = config.OutputFormatTable
 		m.resetHorizontalScroll()
 		m.hasTable = true


### PR DESCRIPTION
`CAPTURE` wrote Parquet and `SAVE` did not, so picking it for a result already on
screen meant running the query again under `CAPTURE` - the thing `SAVE` exists to
avoid. The window has been shared between the two since #129, so the format list
was the only place they differed.

PARQUET goes in `saveFormats`, which the parser, the window and the completion
all read, and `.parquet` joins the extensions that need no `AS`. The export goes
through the writer `CAPTURE` uses rather than a second one, so a file saved from
a result is the file capturing the query would have produced.

### The types

The writer needs the CQL types to build a schema, and `SAVE` is handed
`[][]string`. They come from `m.columnTypes`, which was not always right: every
display path sets it except `processTableResult`, which handles the `[][]string`
that `DESCRIBE` returns and left the previous query's types standing beside a
result they did not describe, possibly with a different number of columns. It
clears them now. That was a bug already - F6 lines the types up by index and was
quietly showing the wrong ones.

PARQUET is then offered only when there is a type per column, and drops out of
the window otherwise, the same way SAVE RESULTS dims with nothing to save.
Typing it without types says so. Both ask `ParquetTypesUsable`, so the window
cannot offer a format the command will refuse.

### What the test found

Writing the file anyway would have been worse than refusing, and that only
became visible when the test read a file back instead of counting its rows.

`WriteStringRows` put the displayed string straight into a builder expecting a
number. The conversion failed, `AppendValueToBuilder` appended null - there is a
TODO in the writer saying it swallows this - and the file opened cleanly,
reported the right number of rows, and was **empty in every column that was not
text**.

So the converters take a string as well as a Go value now: the integers, the
floats, booleans, timestamps and times; and dates parse RFC3339 rather than only
a bare date, since RFC3339 is what `FormatValue` renders. A value that will not
parse is still an error and still becomes a null, so one unreadable cell costs
that cell rather than the file.

**That path is `CAPTURE`'s fallback too**, for when it has no typed rows to hand,
so this fixes it there as well. `CAPTURE`'s usual route passes the gocql values
and was never affected, which is why nobody had seen it.

### Not here

Partitioned Parquet. `CAPTURE` has it through `WITH PARTITION BY` and it writes a
directory; `SAVE` writes one file to one path.

Closes #139

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
