### PR TITLE
feat(save): drop ASCII from the formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,6 @@ Meta-commands provide additional functionality beyond standard CQL:
   SAVE TO 'users.csv'                     -- Save to CSV (format auto-detected)
   SAVE TO 'users.json'                    -- Save to JSON (format auto-detected)
   SAVE TO 'users.parquet'                 -- Save to Parquet (format auto-detected)
-  SAVE TO 'users.txt' AS ASCII            -- Save as ASCII table
   SAVE TO 'data.out' AS CSV               -- Explicitly specify format
 
   -- Key differences from CAPTURE:

--- a/README_jp.md
+++ b/README_jp.md
@@ -601,7 +601,6 @@ Cassandraクラスタがサポートする任意の有効なCQLステートメ�
   SAVE TO 'users.csv'                     -- CSVに保存(形式は自動検出)
   SAVE TO 'users.json'                    -- JSONに保存(形式は自動検出)
   SAVE TO 'users.parquet'                 -- Parquetに保存(形式は自動検出)
-  SAVE TO 'users.txt' AS ASCII            -- ASCIIテーブルとして保存
   SAVE TO 'data.out' AS CSV               -- 明示的に形式を指定
 
   -- CAPTUREとの主な違い:

--- a/internal/router/save_command.go
+++ b/internal/router/save_command.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
@@ -20,12 +19,18 @@ import (
 type SaveCommand struct {
 	Interactive bool                   // true for "SAVE" without arguments
 	Filename    string                 // target filename
-	Format      string                 // CSV, JSON, or ASCII
+	Format      string                 // CSV, JSON, or PARQUET
 	Options     map[string]interface{} // additional options like header=false, pretty=true
 }
 
 // saveFormats are the formats SAVE writes.
-var saveFormats = []string{"CSV", "JSON", "PARQUET", "ASCII"}
+//
+// ASCII was here and is not any more. It wrote the table with its box drawing,
+// padded to the widths the terminal happened to be using: a picture of a
+// result rather than the result, which nothing could read back and which
+// depended on the window it was saved from. The three left all produce a file
+// something else can open.
+var saveFormats = []string{"CSV", "JSON", "PARQUET"}
 
 // parquetNeedsTypes is what SAVE ... AS PARQUET says when the column types are
 // not to hand.
@@ -103,10 +108,6 @@ func ParseSaveCommand(input string) (*SaveCommand, error) {
 		cmd.Format = detectFormatFromExtension(cmd.Filename)
 	}
 
-	// TXT and TEXT are spellings of ASCII.
-	if cmd.Format == "TXT" || cmd.Format == "TEXT" {
-		cmd.Format = "ASCII"
-	}
 	if !slices.Contains(saveFormats, cmd.Format) {
 		return nil, fmt.Errorf("unsupported format: %s. Supported formats: %s",
 			cmd.Format, strings.Join(saveFormats, ", "))
@@ -219,8 +220,6 @@ func detectFormatFromExtension(filename string) string {
 		return "JSON"
 	case strings.HasSuffix(lower, ".parquet"):
 		return "PARQUET"
-	case strings.HasSuffix(lower, ".txt") || strings.HasSuffix(lower, ".text"):
-		return "ASCII"
 	default:
 		return "CSV" // Default to CSV
 	}
@@ -260,8 +259,6 @@ func HandleSaveCommand(cmd SaveCommand, tableData [][]string, columnTypes []stri
 		return exportToCSV(cmd.Filename, tableData, cmd.Options)
 	case "JSON":
 		return exportToJSON(cmd.Filename, tableData, cmd.Options)
-	case "ASCII":
-		return exportToASCII(cmd.Filename, tableData, cmd.Options)
 	case "PARQUET":
 		return exportToParquet(cmd.Filename, tableData, columnTypes, cmd.Options)
 	default:
@@ -396,99 +393,10 @@ func exportToJSON(filename string, data [][]string, options map[string]interface
 	return os.WriteFile(filename, jsonBytes, 0600)
 }
 
-// exportToASCII exports data to ASCII table format
-func exportToASCII(filename string, data [][]string, options map[string]interface{}) error {
-	if len(data) == 0 {
-		return fmt.Errorf("no data to export")
-	}
-
-	// Calculate column widths
-	colWidths := make([]int, len(data[0]))
-	for rowIdx, row := range data {
-		for i, cell := range row {
-			cleanCell := stripAnsi(cell)
-			if rowIdx == 0 {
-				cleanCell = db.StripKeyMarker(cleanCell)
-			}
-			cellWidth := len(cleanCell)
-			if cellWidth > colWidths[i] {
-				colWidths[i] = cellWidth
-			}
-		}
-	}
-
-	var output strings.Builder
-
-	// Top border
-	output.WriteString("+")
-	for _, width := range colWidths {
-		output.WriteString(strings.Repeat("-", width+2) + "+")
-	}
-	output.WriteString("\n")
-
-	// Header row
-	if len(data) > 0 {
-		output.WriteString("|")
-		for i, header := range data[0] {
-			cleanHeader := db.StripKeyMarker(stripAnsi(header))
-			padding := colWidths[i] - len(cleanHeader)
-			output.WriteString(" " + cleanHeader + strings.Repeat(" ", padding) + " |")
-		}
-		output.WriteString("\n")
-
-		// Header separator
-		output.WriteString("+")
-		for _, width := range colWidths {
-			output.WriteString(strings.Repeat("-", width+2) + "+")
-		}
-		output.WriteString("\n")
-	}
-
-	// Data rows
-	for i := 1; i < len(data); i++ {
-		output.WriteString("|")
-		for j, cell := range data[i] {
-			cleanCell := stripAnsi(cell)
-			padding := colWidths[j] - len(cleanCell)
-			if padding < 0 {
-				padding = 0
-			}
-			output.WriteString(" " + cleanCell + strings.Repeat(" ", padding) + " |")
-		}
-		output.WriteString("\n")
-	}
-
-	// Bottom border
-	output.WriteString("+")
-	for _, width := range colWidths {
-		output.WriteString(strings.Repeat("-", width+2) + "+")
-	}
-	output.WriteString("\n")
-
-	// Add row count footer
-	rowCount := len(data) - 1 // Exclude header
-	fmt.Fprintf(&output, "\n(%d rows)\n", rowCount)
-
-	return os.WriteFile(filename, []byte(output.String()), 0600)
-}
-
 // stripAnsi removes ANSI escape codes from a string
 func stripAnsi(s string) string {
 	ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	return ansiRegex.ReplaceAllString(s, "")
-}
-
-// GenerateDefaultFilename generates a default filename with timestamp
-func GenerateDefaultFilename(format string) string {
-	timestamp := time.Now().Format("20060102_150405")
-	ext := ".csv"
-	switch format {
-	case "JSON":
-		ext = ".json"
-	case "ASCII":
-		ext = ".txt"
-	}
-	return fmt.Sprintf("query_results_%s%s", timestamp, ext)
 }
 
 // ParquetTypesUsable says whether a result can be written as Parquet.

--- a/internal/router/save_parquet_test.go
+++ b/internal/router/save_parquet_test.go
@@ -242,3 +242,31 @@ func TestAValueThatCannotBeParsedBecomesNull(t *testing.T) {
 	assert.Empty(t, rows[1][0], "an unparseable id is null")
 	assert.Equal(t, "bob", rows[1][1], "and the rest of the row survives")
 }
+
+// TestSaveNoLongerWritesASCII.
+//
+// It wrote the table with its box drawing, padded to the widths the terminal
+// happened to be using: a picture of a result rather than the result, which
+// nothing could read back. The spellings that mapped onto it go with it.
+func TestSaveNoLongerWritesASCII(t *testing.T) {
+	assert.NotContains(t, SaveFormats(), "ASCII")
+
+	for _, format := range []string{"ASCII", "TXT", "TEXT"} {
+		_, err := ParseSaveCommand("SAVE TO '/tmp/out' AS " + format)
+		assert.Error(t, err, "AS %s is refused", format)
+	}
+}
+
+// TestATextExtensionFallsToTheDefault.
+//
+// .txt used to pick ASCII. With ASCII gone it takes the same route as .dat,
+// .out or no extension at all, which is CSV - the existing rule for anything
+// unrecognised rather than a new one, and AS CSV says so outright when it
+// matters.
+func TestATextExtensionFallsToTheDefault(t *testing.T) {
+	for _, name := range []string{"report.txt", "report.text", "report.dat", "report"} {
+		cmd, err := ParseSaveCommand("SAVE TO '" + name + "'")
+		require.NoError(t, err, name)
+		assert.Equal(t, "CSV", cmd.Format, name)
+	}
+}

--- a/internal/ui/capture_panel.go
+++ b/internal/ui/capture_panel.go
@@ -115,8 +115,6 @@ func (c capturePanel) describe(format string) string {
 		return "JSON      one object per row"
 	case "PARQUET":
 		return "PARQUET   columnar, for analysis"
-	case "ASCII":
-		return "ASCII     a table, as it appears on screen"
 	}
 	return format
 }
@@ -131,7 +129,9 @@ func extensionFor(format string) string {
 	case "PARQUET":
 		return ".parquet"
 	}
-	return ".txt"
+	// Both lists are covered above; this is only reached if a format is added
+	// to one of them and not to here.
+	return ".out"
 }
 
 // command is what the window runs, which is what typing it would run.

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -107,7 +107,7 @@ func TestTheCommandMatchesWhatTypingItWouldBe(t *testing.T) {
 	// SAVE has a different form entirely: SAVE TO 'file' AS FORMAT.
 	save := capturePanel{kind: saving}
 	assert.Equal(t, "SAVE TO 'out.csv' AS CSV", save.command("CSV", "out.csv"))
-	assert.Equal(t, "SAVE TO 'a.txt' AS ASCII", save.command("ASCII", "a.txt"))
+	assert.Equal(t, "SAVE TO 'a.csv' AS CSV", save.command("CSV", "a.csv"))
 }
 
 // TestEscapeGoesBackAStep, so a mistyped path does not cost you the format.
@@ -569,17 +569,19 @@ func TestTheSaveWindowBuildsTheSaveCommand(t *testing.T) {
 	assert.Equal(t, "CAPTURE JSON '/tmp/out.json'", capture.command("JSON", "/tmp/out.json"))
 }
 
-// TestSaveOffersItsOwnFormats. ASCII is SAVE's alone: it writes the table as it
-// appears on screen, which is a thing you want from a result you are looking at
-// and not from a capture running in the background.
-func TestSaveOffersItsOwnFormats(t *testing.T) {
+// TestSaveOffersFormatsSomethingElseCanOpen.
+//
+// ASCII was here and is not any more: it wrote the table with its box drawing,
+// padded to whatever width the terminal happened to be, which nothing could
+// read back.
+func TestSaveOffersFormatsSomethingElseCanOpen(t *testing.T) {
 	m := helpModel()
 	m.lastTableData = [][]string{{"id"}, {"1"}}
 	m.columnTypes = []string{"int"}
 	m.openSavePanel()
 
-	assert.Equal(t, []string{"CSV", "JSON", "PARQUET", "ASCII"}, m.capture.formats)
-	assert.NotContains(t, m.formatsFor(capturing), "ASCII", "CAPTURE does not write ASCII")
+	assert.Equal(t, []string{"CSV", "JSON", "PARQUET"}, m.capture.formats)
+	assert.NotContains(t, m.capture.formats, "ASCII")
 }
 
 // TestParquetIsOfferedOnlyWithTheTypesToWriteIt.
@@ -624,11 +626,11 @@ func TestTheDefaultNameSuitsTheKind(t *testing.T) {
 	m := helpModel()
 
 	m.openSavePanel()
-	m.capture.format = slices.Index(m.capture.formats, "ASCII")
-	require.GreaterOrEqual(t, m.capture.format, 0, "SAVE offers ASCII")
+	m.capture.format = slices.Index(m.capture.formats, "JSON")
+	require.GreaterOrEqual(t, m.capture.format, 0, "SAVE offers JSON")
 	m.chooseCaptureFormat()
 	assert.Contains(t, m.capture.input.Value(), "results_")
-	assert.True(t, strings.HasSuffix(m.capture.input.Value(), ".txt"))
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), ".json"))
 
 	m.closeCapturePanel()
 	m.openCapturePanel(0)

--- a/test/bdd/features/save-command.feature
+++ b/test/bdd/features/save-command.feature
@@ -36,8 +36,10 @@ Feature: SAVE command parsing
       | filename     | format |
       | data.csv     | CSV    |
       | data.json    | JSON   |
-      | data.txt     | ASCII  |
-      | data.text    | ASCII  |
+      | data.parquet | PARQUET |
+      | data.txt     | CSV    |
+      | data.text    | CSV    |
+      | data.dat     | CSV    |
       | nameless     | CSV    |
 
   Scenario: SAVE TO with explicit AS overrides the extension
@@ -46,10 +48,19 @@ Feature: SAVE command parsing
     And the SAVE command has filename "out.dat"
     And the SAVE command has format "JSON"
 
-  Scenario: TXT and TEXT are normalised to ASCII
-    When I parse the SAVE command "SAVE TO 'out.dat' AS TEXT"
-    Then the SAVE command is parsed successfully
-    And the SAVE command has format "ASCII"
+  # ASCII wrote the table with its box drawing, padded to whatever width the
+  # terminal happened to be. Nothing could read it back, so it went, and the
+  # TXT and TEXT spellings that mapped onto it went with it. A .txt name now
+  # takes the same route as any other unrecognised extension.
+  Scenario Outline: the ASCII format and its spellings are refused
+    When I parse the SAVE command "SAVE TO 'out.dat' AS <format>"
+    Then the SAVE command is rejected with an error containing "unsupported format"
+
+    Examples:
+      | format |
+      | ASCII  |
+      | TEXT   |
+      | TXT    |
 
   Scenario: double-quoted filenames are accepted
     When I parse the SAVE command:


### PR DESCRIPTION
`SAVE` offered CSV, JSON, PARQUET and ASCII. ASCII wrote the table with its box
drawing, padded to the widths the terminal happened to be using: a picture of a
result rather than the result. Nothing could read it back, and what it contained
depended on how wide the window was when it was saved. The three left all
produce a file something else can open.

It goes from `saveFormats`, which the parser, the window and the completion all
read, so it disappears from all three at once. The seventy lines of
`exportToASCII` go with it, along with the TXT and TEXT spellings that mapped
onto it.

### The one decision in it

`SAVE TO 'report.txt'` picked ASCII from the extension. It now takes the route
`.dat`, `.out` and no extension at all already take, which is CSV - the existing
rule for anything unrecognised rather than a new one, and `AS CSV` or `AS JSON`
says so outright when it matters.

### Untouched

`OUTPUT ASCII`. That is how results are drawn on screen and is worth having;
`lastTableData` holds the rows either way, so a result displayed as ASCII still
saves as real CSV, JSON or Parquet.

### Also gone

`GenerateDefaultFilename`, which had no callers anywhere - the shared window
brought its own `extensionFor` in #129 - and which this removal left as a
single-case switch that had never learnt about Parquet. A dead function that
would need maintaining to stay correct is worse than no function.

Closes #141

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
