### PR TITLE
fix(save): the Save window wrote no file, for any format

### DIFF
--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -15,48 +15,58 @@ import (
 	"github.com/axonops/cqlai/internal/router"
 )
 
-// processCommandResult processes the result from a command execution
-func (m *MainModel) processCommandResult(command string, result interface{}, startTime time.Time) (*MainModel, tea.Cmd) {
-	switch v := result.(type) {
-	case *router.SaveCommand:
-		// Handle SAVE command - check if we have table data
-		if len(m.lastTableData) == 0 {
-			errorMsg := "No query results available to save. Execute a query first."
-			m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+errorMsg)
-			m.updateHistoryWrapping()
-			m.historyViewport.GotoBottom()
-			m.input.Reset()
-			return m, nil
-		}
-
-		// SAVE with no arguments asks which format and where, in the window
-		// Capture uses. Centred, because it was typed rather than clicked.
-		if v.Interactive {
-			m.input.Reset()
-			return m.openSavePanel()
-		}
-
-		// Direct save - execute the save command
-		// Check if data is already in JSON format (from OUTPUT JSON mode)
-		if v.Format == "JSON" && len(m.lastTableData) > 0 &&
-			len(m.lastTableData[0]) == 1 && m.lastTableData[0][0] == "[json]" {
-			if v.Options == nil {
-				v.Options = make(map[string]interface{})
-			}
-			v.Options["already_json"] = true
-		}
-		err := router.HandleSaveCommand(*v, m.lastTableData, m.columnTypes)
-		if err != nil {
-			m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+err.Error())
-		} else {
-			rowCount := len(m.lastTableData) - 1 // Exclude header
-			successMsg := fmt.Sprintf("Successfully saved %d rows to %s", rowCount, v.Filename)
-			m.fullHistoryContent += "\n" + m.styles.SuccessText.Render(successMsg)
-		}
+// runSaveCommand carries out a parsed SAVE.
+//
+// Both routes to a save come through here: typing the command, and the Save
+// window, which builds the command typing it would. The window went to
+// runCommand, which prints a string result and drops anything else - and SAVE
+// returns a parsed command rather than a string, so picking a format and a path
+// wrote no file, showed no error and said nothing at all. It had been that way
+// for every format since the window was shared in #129.
+func (m *MainModel) runSaveCommand(v *router.SaveCommand) (*MainModel, tea.Cmd) {
+	if len(m.lastTableData) == 0 {
+		errorMsg := "No query results available to save. Execute a query first."
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+errorMsg)
 		m.updateHistoryWrapping()
 		m.historyViewport.GotoBottom()
 		m.input.Reset()
 		return m, nil
+	}
+
+	// SAVE with no arguments asks which format and where, in the window
+	// Capture uses. Centred, because it was typed rather than clicked.
+	if v.Interactive {
+		m.input.Reset()
+		return m.openSavePanel()
+	}
+
+	// Check if data is already in JSON format (from OUTPUT JSON mode)
+	if v.Format == "JSON" && len(m.lastTableData[0]) == 1 && m.lastTableData[0][0] == "[json]" {
+		if v.Options == nil {
+			v.Options = make(map[string]interface{})
+		}
+		v.Options["already_json"] = true
+	}
+
+	err := router.HandleSaveCommand(*v, m.lastTableData, m.columnTypes)
+	if err != nil {
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+err.Error())
+	} else {
+		rowCount := len(m.lastTableData) - 1 // Exclude header
+		successMsg := fmt.Sprintf("Successfully saved %d rows to %s", rowCount, v.Filename)
+		m.fullHistoryContent += "\n" + m.styles.SuccessText.Render(successMsg)
+	}
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
+	m.input.Reset()
+	return m, nil
+}
+
+// processCommandResult processes the result from a command execution
+func (m *MainModel) processCommandResult(command string, result interface{}, startTime time.Time) (*MainModel, tea.Cmd) {
+	switch v := result.(type) {
+	case *router.SaveCommand:
+		return m.runSaveCommand(v)
 	case db.StreamingQueryResult:
 		return m.processStreamingQueryResult(command, v, startTime)
 	case db.QueryResult:

--- a/internal/ui/save_window_test.go
+++ b/internal/ui/save_window_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTheSaveWindowWritesTheFile is the reported bug: picking a format and a
+// path in the Save window produced no file, no error and no message.
+func TestTheSaveWindowWritesTheFile(t *testing.T) {
+	for _, format := range []string{"CSV", "JSON", "PARQUET"} {
+		t.Run(format, func(t *testing.T) {
+			m := helpModel()
+			m.windowHeight = 30
+			m.lastTableData = [][]string{{"id", "name"}, {"1", "alice"}}
+			m.columnTypes = []string{"int", "text"}
+
+			path := filepath.Join(t.TempDir(), "out")
+
+			m.openSavePanel()
+			m.capture.format = slices.Index(m.capture.formats, format)
+			require.GreaterOrEqual(t, m.capture.format, 0, "the window offers %s", format)
+			m.chooseCaptureFormat()
+			m.capture.input.SetValue(path)
+			m.startCapture()
+
+			assert.FileExists(t, path, "the window wrote nothing")
+			assert.Contains(t, stripAnsiForTest(m.fullHistoryContent), "Successfully saved 1 rows",
+				"and says so, rather than leaving you to go and look")
+		})
+	}
+}
+
+// TestBothRoutesToASaveDoTheSameThing: the window builds the command typing it
+// would, and both carry it out through the same call, so neither can start
+// writing a different file from the other.
+func TestBothRoutesToASaveDoTheSameThing(t *testing.T) {
+	data := [][]string{{"id", "name"}, {"1", "alice"}, {"2", "bob"}}
+	types := []string{"int", "text"}
+	dir := t.TempDir()
+
+	typed := helpModel()
+	typed.lastTableData, typed.columnTypes = data, types
+	typedPath := filepath.Join(dir, "typed.csv")
+	typed.runCommand("SAVE TO '" + typedPath + "' AS CSV")
+
+	clicked := helpModel()
+	clicked.windowHeight = 30
+	clicked.lastTableData, clicked.columnTypes = data, types
+	clickedPath := filepath.Join(dir, "clicked.csv")
+	clicked.openSavePanel()
+	clicked.capture.format = slices.Index(clicked.capture.formats, "CSV")
+	clicked.chooseCaptureFormat()
+	clicked.capture.input.SetValue(clickedPath)
+	clicked.startCapture()
+
+	fromTyping, err := os.ReadFile(typedPath) //nolint:gosec // a path this test just wrote
+	require.NoError(t, err)
+	fromClicking, err := os.ReadFile(clickedPath) //nolint:gosec // a path this test just wrote
+	require.NoError(t, err)
+
+	assert.Equal(t, string(fromTyping), string(fromClicking))
+	assert.Contains(t, string(fromTyping), "alice")
+}
+
+// TestASaveWithNothingToSaveSaysSo rather than writing an empty file.
+func TestASaveWithNothingToSaveSaysSo(t *testing.T) {
+	m := helpModel()
+	path := filepath.Join(t.TempDir(), "out.csv")
+
+	m.runCommand("SAVE TO '" + path + "' AS CSV")
+
+	assert.NoFileExists(t, path)
+	assert.Contains(t, stripAnsiForTest(m.fullHistoryContent), "No query results available")
+}
+
+// TestTheSettingsListsStillPrintTheirResult.
+//
+// runCommand is theirs first - PAGING, CONSISTENCY, OUTPUT all come back as a
+// string - and adding the SAVE case in front must not stop that being printed,
+// nor throw the results away the way a query result would.
+func TestTheSettingsListsStillPrintTheirResult(t *testing.T) {
+	m := helpModel()
+	m.lastTableData = [][]string{{"id"}, {"1"}}
+
+	m.runCommand("EXPAND")
+
+	printed := stripAnsiForTest(m.fullHistoryContent)
+	assert.Contains(t, printed, "> EXPAND", "the command is echoed")
+	assert.Contains(t, printed, "Expand mode is currently", "and its result printed")
+	assert.True(t, m.hasTable, "a settings change does not throw the results away")
+}

--- a/internal/ui/setting_chooser.go
+++ b/internal/ui/setting_chooser.go
@@ -355,6 +355,14 @@ func (m *MainModel) runCommand(command string) (*MainModel, tea.Cmd) {
 	result := router.ProcessCommand(command, m.session, m.sessionManager)
 
 	m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
+
+	// SAVE comes back as a parsed command rather than a string, and dropping it
+	// here is what made the Save window write no file and say nothing. Both
+	// routes carry it out through the same call now.
+	if save, ok := result.(*router.SaveCommand); ok {
+		return m.runSaveCommand(save)
+	}
+
 	if text, ok := result.(string); ok && text != "" {
 		m.fullHistoryContent += "\n" + text
 


### PR DESCRIPTION
Pick a format in the Save window, type a path, press Enter, and nothing
happened: no file, no error, no message. Reported against Parquet; it was every
format, and it had never worked.

`startCapture` builds the command and hands it to `runCommand`, which runs it
and then prints the result **if the result is a string**. SAVE does not come
back as a string - the parser hands a parsed `*SaveCommand` to the UI to carry
out, because only the UI has the rows. So the parse succeeded, the command was
dropped on the floor, and nothing was written.

Typing `SAVE TO 'out.csv' AS CSV` worked, because that goes through
`processCommandResult`, which has a `case *router.SaveCommand`.

Broken since #129, which moved SAVE onto the window Capture uses and routed it
through `runCommand`. `runCommand` was written for the settings lists - `PAGING`,
`CONSISTENCY`, `OUTPUT` - which all return strings, so it had never had to
handle anything else.

Two things kept it quiet. There is no error path: an unhandled result type looks
exactly like a command with nothing to say. And the window echoes the command
into the Console before dropping it, so it looked like it had run.

### Fix

One call carries out a save - `runSaveCommand` - and both routes go through it,
so neither can drift from the other.

### The test

It drives the window the way a person does: open it, pick a format, type a path,
confirm, then look for the file - for every format the window offers.

The tests that existed all stopped at the command string the window builds,
which was correct the whole time and never ran. That is the same mistake as the
Parquet test in #140 that counted rows in a file of nulls: checking the thing
that was built rather than the thing that was wanted.

Closes #143

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
