### PR TITLE
fix(ui): fit the status and info bars to the terminal

### DIFF
--- a/internal/ui/bar_fit_test.go
+++ b/internal/ui/bar_fit_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// busyStatusBar is a session with something in every field: a keyspace with a
+// real name and a consistency level longer than the default.
+func busyStatusBar() StatusBarModel {
+	m := NewStatusBarModel()
+	m.Keyspace = "my_keyspace"
+	m.Consistency = "LOCAL_QUORUM"
+	m.OutputFormat = "TABLE"
+	m.PagingSize = 100
+	return m
+}
+
+// barWidths is the number of rows a rendered bar takes and how wide its widest
+// row is.
+func barWidths(rendered string) (rows, width int) {
+	for _, line := range strings.Split(rendered, "\n") {
+		rows++
+		width = max(width, lipgloss.Width(line))
+	}
+	return rows, width
+}
+
+// testWidths covers a 24x80 default terminal, a split pane, and something wide.
+var testWidths = []int{20, 30, 40, 60, 80, 100, 120, 200}
+
+// TestTheStatusLineIsAlwaysOneRow is the defect behind #137.
+//
+// The bar laid itself out at whatever width it wanted and was rendered through
+// lipgloss Width, which wraps rather than truncates. Its fields come to 115
+// columns with a real keyspace name, so below about a hundred columns it became
+// two rows and the whole view was a row taller than the terminal - and 80
+// columns is the default width of a great many terminals, so this was the
+// common case rather than the edge one.
+func TestTheStatusLineIsAlwaysOneRow(t *testing.T) {
+	m := busyStatusBar()
+
+	for _, width := range testWidths {
+		rows, got := barWidths(m.View(width, DefaultStyles(), "history"))
+
+		assert.Equal(t, 1, rows, "at %d columns the status line took %d rows", width, rows)
+		assert.Equal(t, width, got, "and it fills the width exactly")
+	}
+}
+
+// TestTheInfoBarIsAlwaysOneRow. The same defect one row up, found by the same
+// test: at 30 columns it wrapped where the status line did not.
+func TestTheInfoBarIsAlwaysOneRow(t *testing.T) {
+	m := TopBarModel{
+		LastCommand:  "SELECT id, name, status FROM users WHERE status = 'active' ALLOW FILTERING",
+		HasQueryData: true,
+		RowCount:     1234,
+	}
+
+	for _, width := range testWidths {
+		rows, got := barWidths(m.View(width, DefaultStyles(), "history"))
+
+		assert.Equal(t, 1, rows, "at %d columns the info bar took %d rows", width, rows)
+		assert.Equal(t, width, got, "and it fills the width exactly")
+	}
+}
+
+// TestTheWholeViewFitsTheTerminal, which is what the wrapping cost: 25 rows for
+// a 24-row terminal at 80 columns, 26 at 40.
+func TestTheWholeViewFitsTheTerminal(t *testing.T) {
+	for _, width := range testWidths {
+		m := widthModel(t, width)
+		m.statusBar = busyStatusBar()
+
+		rows := strings.Count(m.View().Content, "\n") + 1
+
+		assert.LessOrEqual(t, rows, 24, "at %d columns the view is %d rows", width, rows)
+	}
+}
+
+// TestTheKeyspaceAndConsistencyAreTheLastToGo. They decide what a query does
+// and where it goes; the rest are settings you can look up.
+func TestTheKeyspaceAndConsistencyAreTheLastToGo(t *testing.T) {
+	m := busyStatusBar()
+
+	kept := func(width int) []string {
+		var settings []string
+		for _, seg := range placeSegments(m.segments(), width) {
+			settings = append(settings, seg.setting)
+		}
+		return settings
+	}
+
+	assert.Contains(t, kept(60), settingKeyspace)
+	assert.Contains(t, kept(60), settingConsistency)
+	assert.NotContains(t, kept(60), settingAutoFetch, "the least useful goes first")
+
+	full := kept(200)
+	for _, setting := range []string{
+		settingConnection, settingKeyspace, settingConsistency,
+		settingOutput, settingPaging, settingTracing, settingAutoFetch, settingCapture,
+	} {
+		assert.Contains(t, full, setting, "a wide terminal shows everything")
+	}
+}
+
+// TestTheLabelsShortenBeforeAFieldIsDropped. Losing three characters of a label
+// costs nothing; losing a field costs what it said.
+func TestTheLabelsShortenBeforeAFieldIsDropped(t *testing.T) {
+	m := busyStatusBar()
+
+	atWidth := func(width int) string {
+		return stripAnsiForTest(m.View(width, DefaultStyles(), "history"))
+	}
+
+	assert.Contains(t, atWidth(120), "Connection", "there is room for the full labels")
+	assert.Contains(t, atWidth(120), "Fetch: ")
+
+	narrow := atWidth(100)
+	assert.Contains(t, narrow, "Conn", "shortened rather than dropped")
+	assert.NotContains(t, narrow, "Connection")
+	assert.Contains(t, narrow, "F: ", "and the field is still there")
+}
+
+// TestAClickLandsOnWhatIsDrawn at any width. Rendering and hit testing both go
+// through placeSegments, so what has been shortened or dropped to fit cannot
+// make them disagree.
+func TestAClickLandsOnWhatIsDrawn(t *testing.T) {
+	m := busyStatusBar()
+
+	for _, width := range testWidths {
+		for _, seg := range placeSegments(m.segments(), width) {
+			if !seg.clickable() {
+				continue
+			}
+			mid := (seg.start + seg.end) / 2
+
+			setting, _, ok := m.settingAt(width, mid)
+
+			require.True(t, ok, "%s at %d columns, column %d", seg.setting, width, mid)
+			assert.Equal(t, seg.setting, setting, "at %d columns", width)
+		}
+	}
+}
+
+// TestTheLastCommandIsCutRatherThanDropped. It is the only field that can be
+// any length, and a shortened command still tells you which one it was.
+func TestTheLastCommandIsCutRatherThanDropped(t *testing.T) {
+	m := TopBarModel{
+		LastCommand:  "SELECT id, name, status FROM users WHERE status = 'active'",
+		HasQueryData: true,
+	}
+
+	drawn := stripAnsiForTest(m.View(60, DefaultStyles(), "history"))
+
+	assert.Contains(t, drawn, "History: SELECT", "the start of it survives")
+	assert.Contains(t, drawn, "…", "and it says it was cut")
+	assert.Contains(t, drawn, "Rows: ", "the short fields stay")
+}
+
+// TestTruncateToWidthNeverOverruns, whatever it is given.
+func TestTruncateToWidthNeverOverruns(t *testing.T) {
+	for _, room := range []int{0, 1, 2, 5, 20, 80} {
+		for _, value := range []string{"", "a", "SELECT * FROM users", strings.Repeat("x", 200)} {
+			got := truncateToWidth(value, room)
+			assert.LessOrEqual(t, lipgloss.Width(got), max(room, 1),
+				"%q in %d columns gave %q", value, room, got)
+		}
+	}
+}

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -47,18 +47,26 @@ func TestCaptureSitsAtTheRightOfTheLine(t *testing.T) {
 	assert.Equal(t, settingCapture, setting)
 }
 
-// TestCaptureIsDroppedWhenTheLineIsFull rather than sitting on top of a field.
-func TestCaptureIsDroppedWhenTheLineIsFull(t *testing.T) {
+// TestCaptureKeepsItsPlaceOnANarrowLine.
+//
+// Its room is reserved before the settings are measured, so a busy left-hand
+// side gives way instead. Capture is a thing you do rather than a fact about
+// the session, and a control that moves or vanishes as the terminal is resized
+// is worse than a fact you have to go and look up.
+func TestCaptureKeepsItsPlaceOnANarrowLine(t *testing.T) {
 	m := captureModel()
 
-	segs := placeSegments(m.statusBar.segments(), 60)
-	for _, seg := range segs {
-		assert.NotEqual(t, settingCapture, seg.setting, "there is no room for it here")
-	}
+	for _, width := range []int{40, 60, 80, 120} {
+		segs := placeSegments(m.statusBar.segments(), width)
 
-	// The fields that remain do not overlap.
-	for i := 1; i < len(segs); i++ {
-		assert.GreaterOrEqual(t, segs[i].start, segs[i-1].end)
+		last := segs[len(segs)-1]
+		assert.Equal(t, settingCapture, last.setting, "at %d columns", width)
+		assert.Equal(t, width-statusBarPadding, last.end, "against the right edge")
+
+		// The fields that remain do not overlap.
+		for i := 1; i < len(segs); i++ {
+			assert.GreaterOrEqual(t, segs[i].start, segs[i-1].end, "at %d columns", width)
+		}
 	}
 }
 

--- a/internal/ui/history_overlay_test.go
+++ b/internal/ui/history_overlay_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// infoTestWidth is a terminal wide enough for the whole info bar.
+const infoTestWidth = 140
+
 func testInfoBar() TopBarModel {
 	return TopBarModel{
 		LastCommand:  "SELECT * FROM system.local",
@@ -36,7 +39,7 @@ func TestTheLineDoesNotStartWithASeparator(t *testing.T) {
 // TestTheFieldIsCalledHistory, because that is what clicking it opens. The
 // value is still the last command run.
 func TestTheFieldIsCalledHistory(t *testing.T) {
-	segs := testInfoBar().segments()
+	segs := testInfoBar().placedSegments(infoTestWidth)
 	require.NotEmpty(t, segs)
 
 	assert.Equal(t, infoHistory, segs[0].field)
@@ -52,7 +55,7 @@ func TestInfoSegmentsMatchTheRenderedLine(t *testing.T) {
 
 	rendered := []rune(stripAnsiForTest(m.View(140, DefaultStyles(), "history")))
 
-	for _, seg := range m.segments() {
+	for _, seg := range m.placedSegments(infoTestWidth) {
 		require.LessOrEqual(t, seg.end, len(rendered),
 			"segment %q runs past the end of the line", seg.label)
 
@@ -68,7 +71,7 @@ func TestInfoSegmentsMatchTheRenderedLine(t *testing.T) {
 func TestTheFieldsAreThereBeforeAnythingRuns(t *testing.T) {
 	m := TopBarModel{}
 
-	segs := m.segments()
+	segs := m.placedSegments(infoTestWidth)
 	require.Len(t, segs, 3)
 	for _, seg := range segs {
 		assert.Equal(t, infoPlaceholder, seg.value, "%q should stand in until there is a value", seg.label)
@@ -80,7 +83,7 @@ func TestTheFieldsAreThereBeforeAnythingRuns(t *testing.T) {
 	}
 
 	// The field is still the clickable one; there is just nothing to show yet.
-	field, ok := m.fieldAt((segs[0].start + segs[0].end) / 2)
+	field, ok := m.fieldAt(infoTestWidth, (segs[0].start+segs[0].end)/2)
 	assert.True(t, ok)
 	assert.Equal(t, infoHistory, field)
 }
@@ -88,8 +91,8 @@ func TestTheFieldsAreThereBeforeAnythingRuns(t *testing.T) {
 // TestTheFieldsDoNotMoveWhenAQueryRuns: the labels sit in the same columns
 // before and after, so the line does not jump about as you work.
 func TestTheFieldsDoNotMoveWhenAQueryRuns(t *testing.T) {
-	empty := TopBarModel{}.segments()
-	filled := testInfoBar().segments()
+	empty := TopBarModel{}.placedSegments(infoTestWidth)
+	filled := testInfoBar().placedSegments(infoTestWidth)
 
 	require.Len(t, empty, len(filled))
 	for i := range empty {
@@ -106,7 +109,7 @@ func TestStaleTimingIsNotCarriedOver(t *testing.T) {
 	m.LastCommand = "USE system"
 	m.HasQueryData = false
 
-	segs := m.segments()
+	segs := m.placedSegments(infoTestWidth)
 	assert.Equal(t, "USE system", segs[0].value)
 	assert.Equal(t, infoPlaceholder, segs[1].value, "the timing belonged to an earlier query")
 	assert.Equal(t, infoPlaceholder, segs[2].value)
@@ -118,7 +121,7 @@ func TestClickingHistoryWithNoHistoryOpensNothing(t *testing.T) {
 	m := historyModel(0)
 	m.topBar = TopBarModel{}
 
-	seg := m.topBar.segments()[0]
+	seg := m.topBar.placedSegments(infoTestWidth)[0]
 	pressAt(m, (seg.start+seg.end)/2, m.windowHeight-2)
 
 	assert.False(t, m.historySearchMode)
@@ -161,7 +164,7 @@ func historyModel(n int) *MainModel {
 func TestClickingHistoryOpensTheList(t *testing.T) {
 	m := historyModel(20)
 
-	seg := m.topBar.segments()[0]
+	seg := m.topBar.placedSegments(infoTestWidth)[0]
 	pressAt(m, (seg.start+seg.end)/2, m.windowHeight-2)
 
 	require.True(t, m.historySearchMode, "clicking History should open the list")
@@ -172,7 +175,7 @@ func TestClickingHistoryOpensTheList(t *testing.T) {
 // TestClickingHistoryAgainClosesIt, the same as the lists on the status line.
 func TestClickingHistoryAgainClosesIt(t *testing.T) {
 	m := historyModel(20)
-	seg := m.topBar.segments()[0]
+	seg := m.topBar.placedSegments(infoTestWidth)[0]
 
 	pressAt(m, (seg.start+seg.end)/2, m.windowHeight-2)
 	require.True(t, m.historySearchMode)
@@ -186,7 +189,7 @@ func TestClickingHistoryAgainClosesIt(t *testing.T) {
 func TestClickingQueryFactsOpensNothing(t *testing.T) {
 	m := historyModel(20)
 
-	for _, seg := range m.topBar.segments()[1:] {
+	for _, seg := range m.topBar.placedSegments(infoTestWidth)[1:] {
 		pressAt(m, (seg.start+seg.end)/2, m.windowHeight-2)
 		assert.False(t, m.historySearchMode, "%q is not a control", seg.label)
 	}
@@ -358,7 +361,7 @@ func TestNoHistoryAtAllLeavesThePlaceholder(t *testing.T) {
 	require.Empty(t, m.latestCommand())
 
 	m.topBar.LastCommand = m.latestCommand()
-	assert.Equal(t, infoPlaceholder, m.topBar.segments()[0].value)
+	assert.Equal(t, infoPlaceholder, m.topBar.placedSegments(infoTestWidth)[0].value)
 }
 
 // TestClickingHistoryAndCtrlRGiveTheSameBox. They did the same job through two
@@ -366,7 +369,7 @@ func TestNoHistoryAtAllLeavesThePlaceholder(t *testing.T) {
 // typed into to narrow the list - which was the whole point of the other.
 func TestClickingHistoryAndCtrlRGiveTheSameBox(t *testing.T) {
 	clicked := historyModel(20)
-	seg := clicked.topBar.segments()[0]
+	seg := clicked.topBar.placedSegments(infoTestWidth)[0]
 	pressAt(clicked, (seg.start+seg.end)/2, clicked.windowHeight-2)
 	_, clickedLayer, ok := clicked.historyOverlay(clicked.windowWidth, clicked.windowHeight)
 	require.True(t, ok)
@@ -382,7 +385,7 @@ func TestClickingHistoryAndCtrlRGiveTheSameBox(t *testing.T) {
 // TestTypingNarrowsTheList is what the clicked list could not do.
 func TestTypingNarrowsTheList(t *testing.T) {
 	m := historyModel(20)
-	seg := m.topBar.segments()[0]
+	seg := m.topBar.placedSegments(infoTestWidth)[0]
 	pressAt(m, (seg.start+seg.end)/2, m.windowHeight-2)
 	require.Len(t, m.historySearchResults, 20)
 

--- a/internal/ui/infobar_fields.go
+++ b/internal/ui/infobar_fields.go
@@ -77,8 +77,47 @@ func (m TopBarModel) segments() []infoSegment {
 		{label: "Rows: ", value: rows},
 	}
 
-	// Columns, not bytes, for the same reason as the status line: the
-	// separator is three columns wide and five bytes.
+	return segs
+}
+
+// placeInfoSegments fits the line to the terminal and gives each segment its
+// columns.
+//
+// The same defect as the status line had, one row up: laid out at whatever
+// width it wanted and rendered through lipgloss Width, which wraps rather than
+// truncates, so on a narrow terminal the bar became two rows and the whole view
+// a row taller than the screen.
+//
+// What gives here is the last command, because it is the only field that can be
+// any length - it is cut to what is left rather than dropped, since a shortened
+// command still tells you which one it was. The timing and the row count are a
+// handful of columns and stay. If even that will not fit, fields drop from the
+// right, and Query goes before Rows.
+//
+// Columns, not bytes, for the same reason as the status line: the separator is
+// three columns wide and five bytes.
+func placeInfoSegments(segs []infoSegment, width int) []infoSegment {
+	room := width - infoBarPadding*2
+
+	for {
+		if len(segs) == 0 {
+			return segs
+		}
+
+		fixed := 0
+		for _, seg := range segs[1:] {
+			fixed += lipgloss.Width(statusSeparator) + lipgloss.Width(seg.label) + lipgloss.Width(seg.value)
+		}
+
+		// What the first segment has left for its value.
+		spare := room - fixed - infoBarPadding - lipgloss.Width(segs[0].label)
+		if spare >= 1 {
+			segs[0].value = truncateToWidth(segs[0].value, spare)
+			break
+		}
+		segs = segs[:len(segs)-1]
+	}
+
 	col := infoBarPadding
 	for i := range segs {
 		if i > 0 {
@@ -91,9 +130,34 @@ func (m TopBarModel) segments() []infoSegment {
 	return segs
 }
 
+// truncateToWidth cuts a value to fit, with an ellipsis where anything was
+// taken off, so a shortened command still reads as one that was cut.
+func truncateToWidth(value string, room int) string {
+	if lipgloss.Width(value) <= room {
+		return value
+	}
+	if room <= 1 {
+		return "…"
+	}
+	runes := []rune(value)
+	for len(runes) > 0 && lipgloss.Width(string(runes))+1 > room {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
+}
+
+// placedSegments is the info bar as it is drawn at a width.
+func (m TopBarModel) placedSegments(width int) []infoSegment {
+	return placeInfoSegments(m.segments(), width)
+}
+
 // fieldAt returns the clickable field covering a column.
-func (m TopBarModel) fieldAt(col int) (string, bool) {
-	for _, seg := range m.segments() {
+//
+// It takes the width for the same reason placeSegments does: what is on the
+// line depends on how much of it there is, and a click has to land on the field
+// actually drawn there.
+func (m TopBarModel) fieldAt(width, col int) (string, bool) {
+	for _, seg := range placeInfoSegments(m.segments(), width) {
 		if col >= seg.start && col < seg.end {
 			return seg.field, seg.field != ""
 		}

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -472,7 +472,7 @@ func (m *MainModel) clickStatusSetting(col int) (*MainModel, tea.Cmd) {
 
 // clickInfoField acts on a press on the query info bar.
 func (m *MainModel) clickInfoField(col int) (*MainModel, tea.Cmd) {
-	field, ok := m.topBar.fieldAt(col)
+	field, ok := m.topBar.fieldAt(m.windowWidth, col)
 	if !ok || field != infoHistory {
 		return m, nil
 	}

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -106,10 +106,15 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 		col = seg.end
 	}
 
-	// Apply style to the entire bar without forced background
+	// One row, always. Width on its own wraps rather than truncates, so a line
+	// that overran turned the bar into two rows and made the whole view a row
+	// taller than the terminal. placeSegments fits the fields to the width;
+	// MaxHeight makes sure that a mistake there costs a field rather than the
+	// layout.
 	barStyle := lipgloss.NewStyle().
 		Padding(0, statusBarPadding).
-		Width(width)
+		Width(width).
+		MaxHeight(1)
 
 	return barStyle.Render(statusText)
 }

--- a/internal/ui/statusbar_fields.go
+++ b/internal/ui/statusbar_fields.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 
 	"charm.land/lipgloss/v2"
 	"github.com/axonops/cqlai/internal/config"
@@ -34,9 +35,23 @@ const (
 type statusSegment struct {
 	setting    string // one of the setting constants, or "" if not clickable
 	label      string
+	short      string // the label used when the full set will not fit
 	value      string
 	start, end int  // column range covering label and value, end exclusive
 	right      bool // placed against the right-hand edge rather than in the flow
+}
+
+// width is the columns this segment takes as it will be drawn.
+func (s statusSegment) width() int {
+	return lipgloss.Width(s.label) + lipgloss.Width(s.value)
+}
+
+// shorten swaps in the abbreviated label, where there is one.
+func (s statusSegment) shorten() statusSegment {
+	if s.short != "" {
+		s.label = s.short
+	}
+	return s
 }
 
 // clickable reports whether this segment changes something.
@@ -67,14 +82,18 @@ func (m StatusBarModel) segments() []statusSegment {
 	// The version, the user and the host were three fields taking a third of
 	// the line to say things that rarely change. They are one field now, and
 	// clicking it opens the lot, encryption included.
+	// In order of what you would rather keep when the line will not hold all of
+	// it: the keyspace and the consistency level decide what a query does and
+	// where it goes, and the rest are settings you can look up. placeSegments
+	// drops from the right of this list.
 	segs := []statusSegment{
-		{setting: settingConnection, label: "Connection", value: ""},
+		{setting: settingConnection, label: "Connection", short: "Conn", value: ""},
 		{setting: settingKeyspace, label: "KS: ", value: keyspace},
 		{setting: settingConsistency, label: "CL: ", value: m.Consistency},
-		{setting: settingOutput, label: "Output: ", value: m.OutputFormat},
+		{setting: settingOutput, label: "Output: ", short: "Out: ", value: m.OutputFormat},
 		{setting: settingPaging, label: "Pg: ", value: fmt.Sprintf("%d", m.PagingSize)},
-		{setting: settingTracing, label: "Trace: ", value: onOff(m.Tracing)},
-		{setting: settingAutoFetch, label: "Fetch: ", value: onOff(m.AutoFetch)},
+		{setting: settingTracing, label: "Trace: ", short: "Tr: ", value: onOff(m.Tracing)},
+		{setting: settingAutoFetch, label: "Fetch: ", short: "F: ", value: onOff(m.AutoFetch)},
 	}
 
 	// Capture sits against the right-hand edge rather than in the flow, like
@@ -83,50 +102,114 @@ func (m StatusBarModel) segments() []statusSegment {
 	segs = append(segs, statusSegment{
 		setting: settingCapture,
 		label:   "Capture: ",
+		short:   "Cap: ",
 		value:   onOff(m.Capturing),
 		right:   true,
 	})
 
-	// Columns, not bytes. The separator is three columns wide but five bytes,
-	// because of the box-drawing character, and lipgloss.Width also gets
-	// double-width characters right, which a keyspace name can contain.
+	return segs
+}
+
+// layOutFlow gives the left-hand segments their columns, in order.
+//
+// Columns, not bytes. The separator is three columns wide but five bytes,
+// because of the box-drawing character, and lipgloss.Width also gets
+// double-width characters right, which a keyspace name can contain.
+func layOutFlow(segs []statusSegment) []statusSegment {
 	col := statusBarPadding
 	for i := range segs {
-		if segs[i].right {
-			continue
-		}
 		if i > 0 {
 			col += lipgloss.Width(statusSeparator)
 		}
 		segs[i].start = col
-		col += lipgloss.Width(segs[i].label) + lipgloss.Width(segs[i].value)
+		col += segs[i].width()
 		segs[i].end = col
 	}
 	return segs
 }
 
-// place gives the right-anchored segments their columns, once the width of the
-// line is known.
-//
-// Rendering and hit testing both call this, so a click on Capture lands on
-// Capture however wide the terminal is. It is dropped rather than overlapped
-// when the line is too full, for the same reason the Help button is.
-func placeSegments(segs []statusSegment, width int) []statusSegment {
+// flowEnd is the column the laid-out flow reaches.
+func flowEnd(segs []statusSegment) int {
 	end := statusBarPadding
 	for _, seg := range segs {
-		if !seg.right {
-			end = max(end, seg.end)
+		end = max(end, seg.end)
+	}
+	return end
+}
+
+// placeSegments fits the line to the terminal and gives every segment its
+// columns.
+//
+// The bar used to lay itself out at whatever width it wanted and be rendered
+// through lipgloss Width, which wraps rather than truncates: below about a
+// hundred columns the fields ran past the end and the bar became two rows, so
+// the whole view was a row taller than the terminal. It is one row at every
+// width now, and what does not fit is dropped rather than wrapped.
+//
+// What gives, in order:
+//
+//  1. the labels shorten - Connection to Conn, Output to Out, Trace to Tr
+//  2. fields drop from the right of the flow, so the keyspace and consistency
+//     level are the last to go: they decide what a query does and where it
+//     goes, and the rest are settings you can look up
+//
+// Capture keeps its place through both. It is a thing you do rather than a fact
+// about the session, and a control that moves or vanishes as the terminal is
+// resized is worse than a fact you have to go and look up. Its own label
+// shortens with the rest.
+//
+// Rendering and hit testing both call this, so a click lands on the field drawn
+// there however wide the terminal is and whatever has been dropped to fit.
+func placeSegments(segs []statusSegment, width int) []statusSegment {
+	var flow, anchored []statusSegment
+	for _, seg := range segs {
+		if seg.right {
+			anchored = append(anchored, seg)
+		} else {
+			flow = append(flow, seg)
 		}
 	}
 
-	placed := make([]statusSegment, 0, len(segs))
-	for _, seg := range segs {
-		if !seg.right {
-			placed = append(placed, seg)
-			continue
-		}
+	// The right-hand end is reserved before the flow is measured, so a busy
+	// left-hand side cannot push Capture off the line.
+	reserve := 0
+	for _, seg := range anchored {
+		reserve += lipgloss.Width(statusSeparator) + seg.width()
+	}
+	room := width - statusBarPadding - reserve
 
-		w := lipgloss.Width(seg.label) + lipgloss.Width(seg.value)
+	if fitted, ok := fitFlow(flow, room); ok {
+		flow = fitted
+	} else {
+		shortened := make([]statusSegment, len(flow))
+		for i, seg := range flow {
+			shortened[i] = seg.shorten()
+		}
+		for i := range anchored {
+			anchored[i] = anchored[i].shorten()
+		}
+		reserve = 0
+		for _, seg := range anchored {
+			reserve += lipgloss.Width(statusSeparator) + seg.width()
+		}
+		room = width - statusBarPadding - reserve
+
+		// Drop from the right until what is left fits. The first field always
+		// stays: a bar with nothing on it says less than a crowded one.
+		for len(shortened) > 1 {
+			if fitted, ok := fitFlow(shortened, room); ok {
+				shortened = fitted
+				break
+			}
+			shortened = shortened[:len(shortened)-1]
+		}
+		flow = layOutFlow(shortened)
+	}
+
+	placed := flow
+	end := flowEnd(flow)
+	for _, seg := range anchored {
+		w := seg.width()
 		seg.start = width - w - statusBarPadding
 		seg.end = seg.start + w
 		if seg.start <= end+lipgloss.Width(statusSeparator) {
@@ -135,6 +218,12 @@ func placeSegments(segs []statusSegment, width int) []statusSegment {
 		placed = append(placed, seg)
 	}
 	return placed
+}
+
+// fitFlow lays the flow out and reports whether it stays inside room.
+func fitFlow(segs []statusSegment, room int) ([]statusSegment, bool) {
+	laid := layOutFlow(slices.Clone(segs))
+	return laid, flowEnd(laid) <= room
 }
 
 // settingAt returns the setting whose segment covers a column, and where that

--- a/internal/ui/topbar.go
+++ b/internal/ui/topbar.go
@@ -59,7 +59,7 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	}
 
 	content := ""
-	for i, seg := range m.segments() {
+	for i, seg := range placeInfoSegments(m.segments(), width) {
 		if i > 0 {
 			content += separatorStyle.Render(statusSeparator)
 		}
@@ -67,7 +67,10 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	}
 
 	// Apply style to the entire bar without forced background
+	// One row, always - see placeInfoSegments. MaxHeight makes sure a mistake
+	// in the fitting costs a field rather than the layout.
 	barStyle := lipgloss.NewStyle().
+		MaxHeight(1).
 		Padding(0, infoBarPadding).
 		Width(width)
 


### PR DESCRIPTION
The status line's fields come to 115 columns with a real keyspace name and a
consistency level longer than the default. It laid itself out at whatever width
it wanted and was rendered through lipgloss `Width`, which wraps rather than
truncates, so below about a hundred columns the bar became two rows and the
whole view was a row taller than the terminal:

```
width  40 -> 26 rows for a 24-row terminal
width  60 -> 25 rows
width  80 -> 25 rows
width 100 -> 24 rows
```

80 columns is the default width of a great many terminals, so this was the
common case rather than the edge one.

Both bars are one row at every width now, and what will not fit is dropped
rather than wrapped:

```
w= 40  Conn │ KS: my_keyspace        Cap: OFF
w= 60  Conn │ KS: my_keyspace │ CL: LOCAL_QUORUM         Cap: OFF
w= 80  Conn │ KS: my_keyspace │ CL: LOCAL_QUORUM │ Out: TABLE │ Pg: 100      Cap: OFF
w=120  Connection │ KS: my_keyspace │ CL: LOCAL_QUORUM │ Output: TABLE │ Pg: 100 │ Trace: OFF │ Fetch: OFF       Capture: OFF
```

### What gives, in order

1. **The labels shorten** - Connection to Conn, Output to Out, Trace to Tr.
2. **Fields drop from the right**, so the keyspace and the consistency level are
   the last to go: they decide what a query does and where it goes, and the rest
   are settings you can look up.

Losing three characters of a label costs nothing; losing a field costs what it
said, so shortening comes first.

### Capture keeps its place

Its room is reserved before the settings are measured rather than being given
what is left over, so a busy left-hand side gives way instead of pushing it off.
It is a thing you do rather than a fact about the session, and a control that
moves or vanishes as the terminal is resized is worse than a fact you have to go
and look up.

That reverses what happened before, which is why the test that had it dropped at
sixty columns now has it kept.

### The info bar had it too

The same defect one row up, found by the same test: at thirty columns it wrapped
where the status line did not. The last command is the only field there that can
be any length, so it is cut to what is left rather than dropped - a shortened
command still tells you which one it was - and the timing and the row count are
a handful of columns and stay.

### Clicks

The fitting happens in `placeSegments`, which rendering and hit testing both
already went through, so a click lands on the field drawn there whatever has
been shortened or dropped to fit. `fieldAt` takes the width now for the same
reason: what is on the line depends on how much of it there is.

Both bars also render through `MaxHeight(1)`, so a mistake in the fitting costs
a field rather than the layout.

Closes #137

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
