### PR TITLE
feat(ui): say when rows have been dropped, after the row count

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,24 @@ press - and costs one row for the whole table rather than widening every column.
 `DESCRIBE` and the listings have no second row: their columns are not columns of
 a table and have no CQL type.
 
+#### The query info bar
+
+Under the results: the last command, how long the query took, and how many rows
+came back. `Rows: 300+` means there is more to fetch.
+
+When a result outgrows its memory limit, rows are dropped from the start of it
+and the bar says so:
+
+```
+History: SELECT * FROM events… │ Query: 41ms │ Rows: 300+ │ dropped: first 1200
+```
+
+Without that, scrolling to the top of a result and not finding its first row
+looks like lost data rather than a decision.
+
+On a narrow terminal the bar drops what it cannot fit, least useful first, and
+cuts the command rather than dropping it.
+
 #### Scrolling & Table Navigation
 | Shortcut | Action | macOS Alternative |
 |----------|--------|-------------------|

--- a/internal/ui/bar_fit_test.go
+++ b/internal/ui/bar_fit_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
@@ -171,4 +172,108 @@ func TestTruncateToWidthNeverOverruns(t *testing.T) {
 				"%q in %d columns gave %q", value, room, got)
 		}
 	}
+}
+
+// TestTheInfoBarTerminatesAtAnyWidth.
+//
+// Dropping used to take the rightmost segment, so it always shrank the list and
+// the loop always ended. Dropping the least important instead can pick nothing
+// when only the first is left - the first is cut rather than dropped - and the
+// loop spins for ever. Zero and one column are the widths that reach it.
+func TestTheInfoBarTerminatesAtAnyWidth(t *testing.T) {
+	m := TopBarModel{
+		LastCommand:  "SELECT * FROM users",
+		HasQueryData: true,
+		RowCount:     10,
+		RowsDropped:  true,
+		FirstRow:     1201,
+	}
+
+	for width := 0; width <= 60; width++ {
+		done := make(chan int, 1)
+		go func() { done <- len(placeInfoSegments(m.segments(), width)) }()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("placeInfoSegments did not finish at %d columns", width)
+		}
+	}
+}
+
+// TestTheDroppedRowsWarningSitsAfterTheRowCount.
+//
+// It is about that count: it says the number is of what is still held rather
+// than of what the query returned, and where in the result the rows you have
+// start. This is the only place the program admits it threw anything away - it
+// was computed every frame and appended past the right-hand edge of the status
+// line, where it was never once visible.
+func TestTheDroppedRowsWarningSitsAfterTheRowCount(t *testing.T) {
+	m := TopBarModel{HasQueryData: true, RowCount: 300, RowsDropped: true, FirstRow: 1201}
+
+	segs := m.placedSegments(infoTestWidth)
+	require.Len(t, segs, 4)
+
+	assert.Equal(t, infoRowsLabel, segs[2].label)
+	assert.Equal(t, infoDroppedLabel, segs[3].label)
+	assert.Equal(t, "first 1200", segs[3].value)
+
+	drawn := stripAnsiForTest(m.View(infoTestWidth, DefaultStyles(), "history"))
+	assert.Contains(t, drawn, "Rows: 300 │ dropped: first 1200")
+}
+
+// TestNothingIsSaidWhenNothingWasDropped.
+func TestNothingIsSaidWhenNothingWasDropped(t *testing.T) {
+	m := TopBarModel{HasQueryData: true, RowCount: 300}
+
+	assert.Len(t, m.placedSegments(infoTestWidth), 3)
+	assert.NotContains(t, stripAnsiForTest(m.View(infoTestWidth, DefaultStyles(), "history")), "dropped")
+}
+
+// TestTheWarningOutlivesTheQueryTime on a line too narrow for both.
+//
+// Every other field is a fact you can get again by looking. This one is the
+// only notice that something was thrown away, and without it, scrolling to the
+// top of a result and not finding its first row reads as a bug.
+func TestTheWarningOutlivesTheQueryTime(t *testing.T) {
+	m := TopBarModel{
+		LastCommand:  "SELECT * FROM users",
+		HasQueryData: true,
+		RowCount:     300,
+		RowsDropped:  true,
+		FirstRow:     1201,
+	}
+
+	labels := func(width int) []string {
+		var got []string
+		for _, seg := range m.placedSegments(width) {
+			got = append(got, seg.label)
+		}
+		return got
+	}
+
+	assert.Contains(t, labels(40), infoDroppedLabel)
+	assert.NotContains(t, labels(40), "Query: ", "the timing goes first")
+	assert.Contains(t, labels(infoTestWidth), "Query: ", "both fit on a wide line")
+}
+
+// TestTheWarningIsNotDroppedForALongerCommand.
+//
+// The command is cut to a readable stub rather than to "…", which means
+// dropping a field to make room - but only a field it outranks. Taking the
+// notice that rows were thrown away so that more of the command fits is the
+// wrong trade: the command is on screen twice over, in the Console above.
+func TestTheWarningIsNotDroppedForALongerCommand(t *testing.T) {
+	m := TopBarModel{
+		LastCommand:  "SELECT * FROM events WHERE day = '2026-09-10'",
+		HasQueryData: true,
+		RowCount:     300,
+		RowsDropped:  true,
+		FirstRow:     1201,
+	}
+
+	drawn := stripAnsiForTest(m.View(50, DefaultStyles(), "history"))
+
+	assert.Contains(t, drawn, "dropped: first 1200")
+	assert.Contains(t, drawn, "History: SELECT", "with a readable stub of the command")
 }

--- a/internal/ui/infobar_fields.go
+++ b/internal/ui/infobar_fields.go
@@ -23,6 +23,12 @@ type infoSegment struct {
 	label      string
 	value      string
 	start, end int // column range covering label and value, end exclusive
+
+	// priority decides what survives a line too narrow to hold everything: the
+	// lowest goes first. The last command is not dropped at all - it is cut to
+	// what is left - so its priority only matters once there is no room for
+	// even one column of it.
+	priority int
 }
 
 // infoBarPadding is the left padding lipgloss adds when rendering the line.
@@ -31,8 +37,18 @@ const infoBarPadding = 1
 // maxLastCommand is how much of the last command is shown before it is cut.
 const maxLastCommand = 50
 
+// minCommandWidth is the least of the last command worth showing. Under this
+// the line drops a field instead of cutting the command any further.
+const minCommandWidth = 12
+
 // infoPlaceholder stands in for a value there is not one of yet.
 const infoPlaceholder = "-"
+
+// Labels the renderer colours by.
+const (
+	infoRowsLabel    = "Rows: "
+	infoDroppedLabel = "dropped: "
+)
 
 // segments describes the info bar in order.
 //
@@ -72,9 +88,25 @@ func (m TopBarModel) segments() []infoSegment {
 	// value is still the last command run, which is the one thing worth having
 	// on screen without opening anything.
 	segs := []infoSegment{
-		{field: infoHistory, label: "History: ", value: command},
-		{label: "Query: ", value: queryTime},
-		{label: "Rows: ", value: rows},
+		{field: infoHistory, label: "History: ", value: command, priority: 3},
+		{label: "Query: ", value: queryTime, priority: 1},
+		{label: infoRowsLabel, value: rows, priority: 2},
+	}
+
+	// Sits after the row count, because it is about that count: it says the
+	// number is of what is still held rather than of what the query returned,
+	// and where in the result the rows you have start.
+	//
+	// A high priority so it outlives the query time on a narrow line. Every
+	// other field is a fact you can get again by looking; this one is the only
+	// notice that something was thrown away, and without it scrolling to the
+	// top of a result and not finding its first row reads as a bug.
+	if m.RowsDropped {
+		segs = append(segs, infoSegment{
+			label:    infoDroppedLabel,
+			value:    fmt.Sprintf("first %d", m.FirstRow-1),
+			priority: 4,
+		})
 	}
 
 	return segs
@@ -98,25 +130,35 @@ func (m TopBarModel) segments() []infoSegment {
 // three columns wide and five bytes.
 func placeInfoSegments(segs []infoSegment, width int) []infoSegment {
 	room := width - infoBarPadding*2
+	if len(segs) == 0 {
+		return segs
+	}
 
-	for {
-		if len(segs) == 0 {
-			return segs
-		}
-
+	// What the first segment has left for its value, once the rest have taken
+	// their columns.
+	spare := func(segs []infoSegment) int {
 		fixed := 0
 		for _, seg := range segs[1:] {
 			fixed += lipgloss.Width(statusSeparator) + lipgloss.Width(seg.label) + lipgloss.Width(seg.value)
 		}
-
-		// What the first segment has left for its value.
-		spare := room - fixed - infoBarPadding - lipgloss.Width(segs[0].label)
-		if spare >= 1 {
-			segs[0].value = truncateToWidth(segs[0].value, spare)
-			break
-		}
-		segs = segs[:len(segs)-1]
+		return room - fixed - infoBarPadding - lipgloss.Width(segs[0].label)
 	}
+
+	// Make room for a readable stub of the command by dropping fields it
+	// outranks. Squeezing it to "…" keeps a field that says nothing, so below
+	// minCommandWidth it is worth losing the query time to get the start of the
+	// command back - but only fields the command outranks, or the notice that
+	// rows were thrown away would go to make room for a longer command.
+	for spare(segs) < minCommandWidth && droppableFor(segs) {
+		segs = dropLeastImportant(segs)
+	}
+
+	// If it still will not fit, anything may go. The first segment is never
+	// dropped - it is cut instead - so the loop always ends.
+	for len(segs) > 1 && spare(segs) < 1 {
+		segs = dropLeastImportant(segs)
+	}
+	segs[0].value = truncateToWidth(segs[0].value, max(spare(segs), 0))
 
 	col := infoBarPadding
 	for i := range segs {
@@ -128,6 +170,34 @@ func placeInfoSegments(segs []infoSegment, width int) []infoSegment {
 		segs[i].end = col
 	}
 	return segs
+}
+
+// droppableFor reports whether any segment ranks below the first, and so may be
+// dropped to give it room.
+func droppableFor(segs []infoSegment) bool {
+	for _, seg := range segs[1:] {
+		if seg.priority < segs[0].priority {
+			return true
+		}
+	}
+	return false
+}
+
+// dropLeastImportant removes the lowest-priority segment after the first,
+// rightmost among equals. The first is never dropped: it is cut instead, and a
+// bar with nothing on it says less than a crowded one.
+func dropLeastImportant(segs []infoSegment) []infoSegment {
+	if len(segs) < 2 {
+		return segs
+	}
+
+	worst := 1
+	for i := 2; i < len(segs); i++ {
+		if segs[i].priority <= segs[worst].priority {
+			worst = i
+		}
+	}
+	return append(segs[:worst:worst], segs[worst+1:]...)
 }
 
 // truncateToWidth cuts a value to fit, with an ellipsis where anything was

--- a/internal/ui/topbar.go
+++ b/internal/ui/topbar.go
@@ -17,6 +17,18 @@ type TopBarModel struct {
 	// shown as "100+" with more to fetch.
 	AutoFetch   bool
 	HasMoreData bool // Indicates if there's more data to fetch
+
+	// RowsDropped is set when the sliding window has thrown away rows from the
+	// start of the result to stay inside its memory limit, and FirstRow is the
+	// first row still held, counting from one.
+	//
+	// This is the only place the program admits it has dropped anything. It was
+	// computed every frame and appended to the status line past the right-hand
+	// edge, where it was never once visible (#135), so scrolling up to the start
+	// of a result and not finding it there looked like lost data rather than a
+	// decision.
+	RowsDropped bool
+	FirstRow    int64
 }
 
 // NewTopBarModel creates a new TopBarModel.
@@ -42,6 +54,9 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 	rowCountStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FFD700"))
 
+	droppedStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FFA500"))
+
 	separatorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#555555"))
 
@@ -51,8 +66,10 @@ func (m TopBarModel) View(width int, styles *Styles, viewMode string) string {
 		switch {
 		case seg.field == infoHistory:
 			return commandStyle
-		case seg.label == "Rows: ":
+		case seg.label == infoRowsLabel:
 			return rowCountStyle
+		case seg.label == infoDroppedLabel:
+			return droppedStyle
 		default:
 			return queryTimeStyle
 		}

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -60,6 +60,8 @@ func (m *MainModel) View() tea.View {
 	}
 	if m.slidingWindow != nil {
 		m.topBar.HasMoreData = m.slidingWindow.hasMoreData
+		m.topBar.RowsDropped = m.slidingWindow.DataDroppedAtStart
+		m.topBar.FirstRow = m.slidingWindow.FirstRowIndex + 1
 	}
 	if m.session != nil {
 		currentKeyspace := ""


### PR DESCRIPTION
When a result outgrows its memory limit the sliding window throws away rows from
the start of it. The only notice of that was computed every frame and appended
to the status line past the right-hand edge, where it was never once visible,
and it went with the rest of `scrollInfo` in #135.

It sits after the row count now, because it is about that count: the number is
of what is still held rather than of what the query returned.

```
History: SELECT * FROM events… │ Query: 41ms │ Rows: 300+ │ dropped: first 1200
```

Without it, scrolling to the top of a result and not finding its first row reads
as lost data rather than a decision.

### Surviving the fit

The info bar drops fields it cannot fit, and this one has to survive that. Every
other field is a fact you can get again by looking - the row count, the timing,
the command, which is on screen twice over in the Console above. So the segments
carry a priority and the lowest goes first, rather than the rightmost, which is
what the warning would be.

That interacts with cutting the last command. The command is cut rather than
dropped, and squeezing it to `…` keeps a field saying nothing while a field
saying something is dropped to make room for it - so below a readable stub the
line drops a field instead, **but only a field the command outranks**. Taking
the notice that rows were thrown away so that more of a command fits is the
wrong trade.

```
w= 40  History: SELEC… │ dropped: first 1200
w= 50  History: SELECT * FROM e… │ dropped: first 1200
w= 60  History: SELECT * FRO… │ Rows: 300+ │ dropped: first 1200
w= 80  History: SELECT * FROM events… │ Query: 0s │ Rows: 300+ │ dropped: first 1200
```

### Fixed while writing it

Dropping the least important rather than the rightmost can pick nothing when
only the first segment is left, since the first is cut rather than dropped - and
the loop then spins for ever. Nought and one column reach it. A test walks every
width from zero.

### Not here

Horizontal scroll position, the other half of #136. It belongs beside the
Results view rather than on a line shared with the query info, and #133 left the
Results scrollbar for the same reason: its horizontal scrolling and frozen
header are both keyed to its width.

Closes #136

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
