### PR TITLE
feat(ui): move Capture in with the other settings, after Fetch

### DIFF
--- a/internal/ui/bar_fit_test.go
+++ b/internal/ui/bar_fit_test.go
@@ -99,6 +99,7 @@ func TestTheKeyspaceAndConsistencyAreTheLastToGo(t *testing.T) {
 	assert.Contains(t, kept(60), settingKeyspace)
 	assert.Contains(t, kept(60), settingConsistency)
 	assert.NotContains(t, kept(60), settingAutoFetch, "the least useful goes first")
+	assert.NotContains(t, kept(60), settingCapture, "and Capture is one of them while it is off")
 
 	full := kept(200)
 	for _, setting := range []string{
@@ -276,4 +277,23 @@ func TestTheWarningIsNotDroppedForALongerCommand(t *testing.T) {
 
 	assert.Contains(t, drawn, "dropped: first 1200")
 	assert.Contains(t, drawn, "History: SELECT", "with a readable stub of the command")
+}
+
+
+// TestCaptureNoLongerCostsTheLineItsWidth.
+//
+// The right-hand end was reserved before the settings were measured, so Capture
+// took its width plus a separator at every terminal width even with nothing to
+// say. In the flow it takes its turn, and Trace fits on an 80-column terminal
+// again.
+func TestCaptureNoLongerCostsTheLineItsWidth(t *testing.T) {
+	m := busyStatusBar()
+
+	var settings []string
+	for _, seg := range placeSegments(m.segments(), 80) {
+		settings = append(settings, seg.setting)
+	}
+
+	assert.Contains(t, settings, settingTracing, "which the reserved end used to cost")
+	assert.NotContains(t, settings, settingCapture, "because it is off")
 }

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -31,15 +31,22 @@ func captureColumn(m *MainModel) int {
 	return -1
 }
 
-// TestCaptureSitsAtTheRightOfTheLine, out of the way of the settings.
-func TestCaptureSitsAtTheRightOfTheLine(t *testing.T) {
+// TestCaptureSitsWithTheOtherSettings, after Fetch.
+//
+// It was against the right-hand edge, apart from them, because it was put there
+// as a control. It is both a control and a fact about the session, and the fact
+// is the more important half.
+func TestCaptureSitsWithTheOtherSettings(t *testing.T) {
 	m := captureModel()
 
 	segs := placeSegments(m.statusBar.segments(), m.windowWidth)
 	last := segs[len(segs)-1]
 
-	assert.Equal(t, settingCapture, last.setting)
-	assert.Equal(t, m.windowWidth-statusBarPadding, last.end, "against the right edge")
+	assert.Equal(t, settingCapture, last.setting, "last in the flow")
+	require.GreaterOrEqual(t, len(segs), 2)
+	assert.Equal(t, settingAutoFetch, segs[len(segs)-2].setting, "after Fetch")
+	assert.Equal(t, last.start, segs[len(segs)-2].end+lipgloss.Width(statusSeparator),
+		"a separator away, like any other field, rather than a gap to the edge")
 
 	// And a click there resolves to it.
 	setting, _, ok := m.statusBar.settingAt(m.windowWidth, captureColumn(m))
@@ -47,27 +54,30 @@ func TestCaptureSitsAtTheRightOfTheLine(t *testing.T) {
 	assert.Equal(t, settingCapture, setting)
 }
 
-// TestCaptureKeepsItsPlaceOnANarrowLine.
+// TestARunningCaptureIsNeverDropped.
 //
-// Its room is reserved before the settings are measured, so a busy left-hand
-// side gives way instead. Capture is a thing you do rather than a fact about
-// the session, and a control that moves or vanishes as the terminal is resized
-// is worse than a fact you have to go and look up.
-func TestCaptureKeepsItsPlaceOnANarrowLine(t *testing.T) {
+// It is the one setting that keeps doing something after you have stopped
+// thinking about it, and quietly writing to a file you have forgotten is
+// exactly what wants to be on screen. A capture that is off takes its turn with
+// the rest: "Capture: OFF" says nothing you had not already assumed.
+func TestARunningCaptureIsNeverDropped(t *testing.T) {
 	m := captureModel()
 
-	for _, width := range []int{40, 60, 80, 120} {
-		segs := placeSegments(m.statusBar.segments(), width)
-
-		last := segs[len(segs)-1]
-		assert.Equal(t, settingCapture, last.setting, "at %d columns", width)
-		assert.Equal(t, width-statusBarPadding, last.end, "against the right edge")
-
-		// The fields that remain do not overlap.
-		for i := 1; i < len(segs); i++ {
-			assert.GreaterOrEqual(t, segs[i].start, segs[i-1].end, "at %d columns", width)
+	shown := func(capturing bool, width int) []string {
+		m.statusBar.Capturing = capturing
+		var settings []string
+		for _, seg := range placeSegments(m.statusBar.segments(), width) {
+			settings = append(settings, seg.setting)
 		}
+		return settings
 	}
+
+	for _, width := range []int{30, 40, 60, 80} {
+		assert.Contains(t, shown(true, width), settingCapture,
+			"a running capture stays at %d columns", width)
+	}
+	assert.NotContains(t, shown(false, 40), settingCapture,
+		"one that is off gives way like any other field")
 }
 
 // TestClickingCaptureOpensAndClosesIt.

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"strings"
-
 	"charm.land/lipgloss/v2"
 )
 
@@ -94,16 +92,11 @@ func (m StatusBarModel) View(width int, styles *Styles, currentView string) stri
 	segs := placeSegments(m.segments(), width)
 
 	statusText := ""
-	col := statusBarPadding
 	for i, seg := range segs {
-		switch {
-		case seg.right:
-			statusText += strings.Repeat(" ", max(seg.start-col, 0))
-		case i > 0:
+		if i > 0 {
 			statusText += separatorStyle.Render(statusSeparator)
 		}
 		statusText += labelStyle.Render(seg.label) + styleFor(seg).Render(seg.value)
-		col = seg.end
 	}
 
 	// One row, always. Width on its own wraps rather than truncates, so a line

--- a/internal/ui/statusbar_fields.go
+++ b/internal/ui/statusbar_fields.go
@@ -38,7 +38,7 @@ type statusSegment struct {
 	short      string // the label used when the full set will not fit
 	value      string
 	start, end int  // column range covering label and value, end exclusive
-	right      bool // placed against the right-hand edge rather than in the flow
+	keep       bool // never dropped, however narrow the line
 }
 
 // width is the columns this segment takes as it will be drawn.
@@ -96,15 +96,22 @@ func (m StatusBarModel) segments() []statusSegment {
 		{setting: settingAutoFetch, label: "Fetch: ", short: "F: ", value: onOff(m.AutoFetch)},
 	}
 
-	// Capture sits against the right-hand edge rather than in the flow, like
-	// the Help button on the tab line: it is a thing you do, not a fact about
-	// the session, and the line is already busy on the left.
+	// Capture was against the right-hand edge, apart from the settings, because
+	// it was put there as a control - a thing you press. It is both, and the
+	// fact is the more important half: it is the one setting that keeps doing
+	// something after you have stopped thinking about it, and quietly writing
+	// to a file you have forgotten is exactly what wants to be on screen. As a
+	// fact it belongs with the other facts.
+	//
+	// A capture that is running is never dropped, however narrow the line, for
+	// that same reason. One that is off takes its turn with the rest:
+	// "Capture: OFF" says nothing you had not already assumed.
 	segs = append(segs, statusSegment{
 		setting: settingCapture,
 		label:   "Capture: ",
 		short:   "Cap: ",
 		value:   onOff(m.Capturing),
-		right:   true,
+		keep:    m.Capturing,
 	})
 
 	return segs
@@ -161,66 +168,43 @@ func flowEnd(segs []statusSegment) int {
 // Rendering and hit testing both call this, so a click lands on the field drawn
 // there however wide the terminal is and whatever has been dropped to fit.
 func placeSegments(segs []statusSegment, width int) []statusSegment {
-	var flow, anchored []statusSegment
-	for _, seg := range segs {
-		if seg.right {
-			anchored = append(anchored, seg)
-		} else {
-			flow = append(flow, seg)
-		}
+	room := width - statusBarPadding
+
+	if fitted, ok := fitFlow(segs, room); ok {
+		return fitted
 	}
 
-	// The right-hand end is reserved before the flow is measured, so a busy
-	// left-hand side cannot push Capture off the line.
-	reserve := 0
-	for _, seg := range anchored {
-		reserve += lipgloss.Width(statusSeparator) + seg.width()
+	shortened := make([]statusSegment, len(segs))
+	for i, seg := range segs {
+		shortened[i] = seg.shorten()
 	}
-	room := width - statusBarPadding - reserve
 
-	if fitted, ok := fitFlow(flow, room); ok {
-		flow = fitted
-	} else {
-		shortened := make([]statusSegment, len(flow))
-		for i, seg := range flow {
-			shortened[i] = seg.shorten()
+	// Drop from the right until what is left fits, passing over anything
+	// marked keep - a capture that is running, which is the whole reason the
+	// field is on this line. The first field always stays: a bar with nothing
+	// on it says less than a crowded one.
+	for {
+		if fitted, ok := fitFlow(shortened, room); ok {
+			return fitted
 		}
-		for i := range anchored {
-			anchored[i] = anchored[i].shorten()
-		}
-		reserve = 0
-		for _, seg := range anchored {
-			reserve += lipgloss.Width(statusSeparator) + seg.width()
-		}
-		room = width - statusBarPadding - reserve
 
-		// Drop from the right until what is left fits. The first field always
-		// stays: a bar with nothing on it says less than a crowded one.
-		for len(shortened) > 1 {
-			if fitted, ok := fitFlow(shortened, room); ok {
-				shortened = fitted
+		last := -1
+		for i := len(shortened) - 1; i > 0; i-- {
+			if !shortened[i].keep {
+				last = i
 				break
 			}
-			shortened = shortened[:len(shortened)-1]
 		}
-		flow = layOutFlow(shortened)
-	}
-
-	placed := flow
-	end := flowEnd(flow)
-	for _, seg := range anchored {
-		w := seg.width()
-		seg.start = width - w - statusBarPadding
-		seg.end = seg.start + w
-		if seg.start <= end+lipgloss.Width(statusSeparator) {
-			continue // no room; leave it off rather than on top of a field
+		if last < 0 {
+			// Only the first field and whatever must stay are left, and they
+			// still overrun. Drawing them cut off says more than drawing none.
+			return layOutFlow(shortened)
 		}
-		placed = append(placed, seg)
+		shortened = append(shortened[:last:last], shortened[last+1:]...)
 	}
-	return placed
 }
 
-// fitFlow lays the flow out and reports whether it stays inside room.
+// fitFlow lays the segments out and reports whether they stay inside room.
 func fitFlow(segs []statusSegment, room int) ([]statusSegment, bool) {
 	laid := layOutFlow(slices.Clone(segs))
 	return laid, flowEnd(laid) <= room


### PR DESCRIPTION
Capture sat against the right-hand edge of the status line, apart from the
settings, because it was put there as a control - a thing you press.

It is both a control and a fact about the session, and the fact is the more
important half. Capture is the one setting that keeps doing something after you
have stopped thinking about it, and quietly writing to a file you have forgotten
is exactly what wants to be on screen. As a fact it belongs with the other
facts. It stays clickable.

```
 Connection │ KS: my_keyspace │ CL: LOCAL_QUORUM │ Output: TABLE │ Pg: 100 │ Trace: OFF │ Fetch: OFF │ Capture: OFF
```

### What it buys

The right-hand end was reserved before the settings were measured (#137), so
Capture cost its width plus a separator at every terminal width even with
nothing to say. In the flow it takes its turn - which is the difference between
losing `Trace` on an 80-column terminal and keeping it.

### Dropping

Dropping goes from the right, and after `Fetch` that is Capture, which would
defeat the reason for having it on the line. So **a capture that is running is
never dropped**, however narrow. One that is off gives way like any other field:
`Capture: OFF` says nothing you had not already assumed.

```
w= 40  Conn │ KS: my_keyspace │ Cap: ON
w= 60  Conn │ KS: my_keyspace │ CL: LOCAL_QUORUM │ Cap: ON
w= 80  Conn │ KS: my_keyspace │ CL: LOCAL_QUORUM │ Out: TABLE │ Pg: 100 │ Cap: ON
```

### Removed with it

Nothing is right-anchored any more, so the `right` field on `statusSegment`, the
reserve-and-place branch in `placeSegments` and the gap-filling in the renderer
go too - about thirty lines, and `placeSegments` is now one loop that shortens
and drops. A capability with no user is a thing that has to keep working with
nothing checking that it does; it can come back with whatever needs it next.

The window still opens above the field and is still clamped to the screen, so it
points at Capture wherever the fitting has put it.

Closes #149

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
