### PR TITLE
feat(ui): a way back up in the file listing

### DIFF
--- a/internal/ui/capture_panel.go
+++ b/internal/ui/capture_panel.go
@@ -309,14 +309,42 @@ func (m *MainModel) useMatch() (*MainModel, tea.Cmd) {
 	}
 
 	dir, _ := splitPath(m.capture.input.Value())
-	chosen := dir + m.capture.matches[m.capture.match]
+
+	// The way up replaces the directory rather than being appended to it.
+	chosen := m.capture.matches[m.capture.match]
+	if chosen == parentEntry {
+		chosen = parentDir(dir)
+	} else {
+		chosen = dir + chosen
+	}
+
+	wentUp := m.capture.matches[m.capture.match] == parentEntry
 
 	m.capture.input.SetValue(chosen)
 	m.capture.input.CursorEnd()
 	m.clearMatches()
 
-	if strings.HasSuffix(chosen, string(filepath.Separator)) {
-		return m.completeCapturePath()
+	if !strings.HasSuffix(chosen, string(filepath.Separator)) {
+		return m, nil
+	}
+
+	// Show what is in it. Going up lists rather than completes: with one entry
+	// in the parent, filling in as far as the candidates agree walked straight
+	// back into the directory just left.
+	if wentUp {
+		return m.listCapturePath()
+	}
+	return m.completeCapturePath()
+}
+
+// listCapturePath shows what is in the directory the path names, without
+// filling anything in.
+func (m *MainModel) listCapturePath() (*MainModel, tea.Cmd) {
+	dir, _ := splitPath(m.capture.input.Value())
+
+	m.clearMatches()
+	if got := completePath(dir); got.worthListing() {
+		m.capture.matches = got.Matches
 	}
 	return m, nil
 }
@@ -548,7 +576,7 @@ func (m *MainModel) completeCapturePath() (*MainModel, tea.Cmd) {
 
 	// List them only when filling in was not enough to pick one.
 	m.clearMatches()
-	if len(got.Matches) > 1 {
+	if got.worthListing() {
 		m.capture.matches = got.Matches
 	}
 	return m, nil

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -364,7 +364,10 @@ func listingModel(t *testing.T, files int) *MainModel {
 	m.chooseCaptureFormat()
 	m.capture.input.SetValue(manyFiles(t, files) + string(filepath.Separator))
 	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
-	require.Len(t, m.capture.matches, files)
+
+	// The files, and the way up at the top of them.
+	require.Len(t, m.capture.matches, files+1)
+	require.Equal(t, parentEntry, m.capture.matches[0])
 	return m
 }
 
@@ -411,8 +414,9 @@ func TestTheArrowsWalkTheWholeList(t *testing.T) {
 		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
 
-	assert.Equal(t, 39, m.capture.match, "it should stop at the last candidate")
-	assert.Len(t, seen, 40, "every candidate should be reachable")
+	// Forty files and the way up above them.
+	assert.Equal(t, 40, m.capture.match, "it should stop at the last candidate")
+	assert.Len(t, seen, 41, "every candidate should be reachable")
 
 	for range 60 {
 		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyUp})
@@ -424,8 +428,11 @@ func TestTheArrowsWalkTheWholeList(t *testing.T) {
 // TestEnterUsesTheHighlightedCandidate rather than starting the capture.
 func TestEnterUsesTheHighlightedCandidate(t *testing.T) {
 	m := listingModel(t, 4)
-	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
 
+	// Past the way up at the top, then onto the second file.
+	for range 2 {
+		m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
 	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	assert.True(t, strings.HasSuffix(m.capture.input.Value(), "file01.csv"),
@@ -440,9 +447,10 @@ func TestClickingACandidateUsesIt(t *testing.T) {
 
 	layer, ok := m.viewCapturePanel(m.windowWidth, m.windowHeight)
 	require.True(t, ok)
+	// Row 0 is the way up, so the third row is the second file.
 	pressAt(m, layer.X+3, layer.Y+1+captureMatchesStart+2)
 
-	assert.True(t, strings.HasSuffix(m.capture.input.Value(), "file02.csv"),
+	assert.True(t, strings.HasSuffix(m.capture.input.Value(), "file01.csv"),
 		"got %q", m.capture.input.Value())
 }
 
@@ -463,13 +471,37 @@ func TestChoosingADirectoryOpensIt(t *testing.T) {
 	m.capture.input.SetValue(dir + string(filepath.Separator))
 	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
 
-	// The directory sorts first.
-	require.Equal(t, "exports"+string(filepath.Separator), m.capture.matches[0])
+	// The way up is first; the directory sorts above the file beside it.
+	require.Equal(t, parentEntry, m.capture.matches[0])
+	require.Equal(t, "exports"+string(filepath.Separator), m.capture.matches[1])
+
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyDown})
 	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	assert.Equal(t, inner+string(filepath.Separator), m.capture.input.Value())
-	assert.Equal(t, []string{"one.csv", "two.csv"}, m.capture.matches,
-		"it should be listing what is inside")
+	assert.Equal(t, []string{parentEntry, "one.csv", "two.csv"}, m.capture.matches,
+		"it should be listing what is inside, with the way back out")
+}
+
+// TestTheWayUpWalksBackOut, which is what makes browsing two-way.
+func TestTheWayUpWalksBackOut(t *testing.T) {
+	dir := t.TempDir()
+	inner := filepath.Join(dir, "exports")
+	require.NoError(t, os.Mkdir(inner, 0o750))
+
+	m := captureModel()
+	m.windowHeight = 30
+	m.openCapturePanel(4)
+	m.chooseCaptureFormat()
+	m.capture.input.SetValue(inner + string(filepath.Separator))
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	require.Equal(t, parentEntry, m.capture.matches[0])
+	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.Equal(t, dir+string(filepath.Separator), m.capture.input.Value())
+	assert.Contains(t, m.capture.matches, "exports"+string(filepath.Separator),
+		"and it lists where it has arrived")
 }
 
 // TestEscapePutsTheListAwayWithoutLosingThePath.

--- a/internal/ui/file_form.go
+++ b/internal/ui/file_form.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -1184,7 +1185,7 @@ func (m *MainModel) completeField() (*MainModel, tea.Cmd) {
 		got := completePath(field.input.Value())
 		field.set(got.Completed)
 		m.form.clearMatches()
-		if len(got.Matches) > 1 {
+		if got.worthListing() {
 			m.form.matches = got.Matches
 		}
 
@@ -1326,13 +1327,24 @@ func (m *MainModel) useMatchInForm() (*MainModel, tea.Cmd) {
 	chosen := m.form.matches[m.form.match]
 	if field.kind == fieldPath {
 		// The candidates are names inside a directory, so the directory the
-		// user typed has to stay in front of the one they picked.
+		// user typed has to stay in front of the one they picked - except the
+		// way up, which replaces it.
 		dir, _ := splitPath(field.input.Value())
-		chosen = dir + chosen
+		if chosen == parentEntry {
+			chosen = parentDir(dir)
+		} else {
+			chosen = dir + chosen
+		}
 	}
 
 	field.set(chosen)
 	m.form.clearMatches()
+
+	// Stepping into a directory - or back out of one - shows what is in it,
+	// rather than leaving you to press Tab again to find out.
+	if field.kind == fieldPath && strings.HasSuffix(chosen, string(filepath.Separator)) {
+		return m.listField()
+	}
 	return m, nil
 }
 

--- a/internal/ui/path_complete.go
+++ b/internal/ui/path_complete.go
@@ -58,15 +58,33 @@ func completePath(input string) pathCompletion {
 		matches = append(matches, name)
 	}
 
-	if len(matches) == 0 {
+	// The way up counts as something to offer, so an empty directory is not a
+	// dead end: with nothing in it and nothing listed, the only way back out
+	// was to edit the path by hand.
+	canGoUp := prefix == "" && parentDir(dir) != ""
+	if len(matches) == 0 && !canGoUp {
 		return none
 	}
 	sort.Strings(matches)
 
 	// Fill in as far as they agree. With one match that is the whole name, and
 	// a directory ends in a separator so the next Tab carries on inside it.
+	completed := dir + commonPrefix(matches)
+
+	// The way back up, at the top of the list, so browsing is not one-way: with
+	// only the contents of a directory to pick from, a wrong turn meant editing
+	// the path by hand.
+	//
+	// Added after the common prefix is worked out rather than before. In the
+	// list it is one more thing to pick; in the prefix it agrees with nothing,
+	// and would stop "/b" filling itself in to "/boot/" the moment the parent
+	// directory existed.
+	if canGoUp {
+		matches = append([]string{parentEntry}, matches...)
+	}
+
 	return pathCompletion{
-		Completed: dir + commonPrefix(matches),
+		Completed: completed,
 		Matches:   matches,
 	}
 }
@@ -80,6 +98,39 @@ func splitPath(input string) (dir, prefix string) {
 		return "", input
 	}
 	return input[:i+1], input[i+1:]
+}
+
+// worthListing reports whether the candidates are worth showing.
+//
+// More than one, as a shell does - or exactly one that is the way up, which is
+// what an empty directory offers. That one is not a completion to fill in: it
+// is the only thing you can do from there, and applying it silently would walk
+// you out of the directory you had just walked into.
+func (p pathCompletion) worthListing() bool {
+	return len(p.Matches) > 1 || (len(p.Matches) == 1 && p.Matches[0] == parentEntry)
+}
+
+// parentEntry is the way up, as it appears in the list.
+const parentEntry = ".."
+
+// parentDir is the directory above one, or "" when there is nowhere above.
+//
+// Takes the path as typed, so it works before ~ is expanded: what goes back in
+// the field should read the way the rest of it does.
+func parentDir(dir string) string {
+	sep := string(filepath.Separator)
+
+	trimmed := strings.TrimSuffix(dir, sep)
+	if trimmed == "" || trimmed == "~" {
+		return "" // the root, or home with nothing above it worth offering
+	}
+
+	i := strings.LastIndex(trimmed, sep)
+	if i < 0 {
+		// A bare name with no separator: above it is where we started.
+		return ""
+	}
+	return trimmed[:i+1]
 }
 
 // expandHome turns a leading ~ into the home directory.

--- a/internal/ui/path_complete_test.go
+++ b/internal/ui/path_complete_test.go
@@ -58,8 +58,10 @@ func TestEverythingInADirectoryIsOffered(t *testing.T) {
 
 	got := completePath(dir + string(filepath.Separator))
 
-	assert.Len(t, got.Matches, 4, "three files and a directory, not the hidden one: %v", got.Matches)
+	assert.Len(t, got.Matches, 5,
+		"three files, a directory and the way up, not the hidden one: %v", got.Matches)
 	assert.Contains(t, got.Matches, "exports"+string(filepath.Separator))
+	assert.Equal(t, parentEntry, got.Matches[0])
 }
 
 // TestHiddenFilesOnlyWhenAskedFor, as a shell does.
@@ -128,4 +130,69 @@ func TestCommonPrefix(t *testing.T) {
 	assert.Equal(t, "only", commonPrefix([]string{"only"}))
 	assert.Equal(t, "", commonPrefix([]string{"alpha", "beta"}))
 	assert.Equal(t, "", commonPrefix(nil))
+}
+
+// TestTheWayUpIsInTheList.
+//
+// With only the contents of a directory to pick from, browsing was one-way: a
+// wrong turn meant editing the path by hand.
+func TestTheWayUpIsInTheList(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "inner"), 0o755))
+
+	got := completePath(filepath.Join(dir, "inner") + string(filepath.Separator))
+
+	require.NotEmpty(t, got.Matches)
+	assert.Equal(t, parentEntry, got.Matches[0], "at the top, where it is easy to reach")
+}
+
+// TestThereIsNoWayUpFromTheRoot, because there is nowhere above it.
+func TestThereIsNoWayUpFromTheRoot(t *testing.T) {
+	got := completePath(string(filepath.Separator))
+
+	assert.NotContains(t, got.Matches, parentEntry)
+}
+
+// TestTheWayUpDoesNotSpoilTheFillIn.
+//
+// It is added after the common prefix is worked out. In the prefix it agrees
+// with nothing, and would stop a directory filling itself in the moment its
+// parent existed.
+func TestTheWayUpDoesNotSpoilTheFillIn(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"report_a", "report_b"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	got := completePath(dir + string(filepath.Separator))
+
+	assert.Equal(t, filepath.Join(dir, "report_")+"", got.Completed,
+		"filled in as far as the names agree")
+	assert.Equal(t, parentEntry, got.Matches[0])
+}
+
+// TestTheWayUpOnlyShowsWhenNothingIsTyped: once you are naming something, ".."
+// is not one of the things you might mean.
+func TestTheWayUpOnlyShowsWhenNothingIsTyped(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "report"), nil, 0o600))
+
+	got := completePath(filepath.Join(dir, "rep"))
+
+	assert.NotContains(t, got.Matches, parentEntry)
+}
+
+// TestParentDir reads the path as typed, so what goes back in the field reads
+// the way the rest of it does.
+func TestParentDir(t *testing.T) {
+	for input, want := range map[string]string{
+		"/usr/share/": "/usr/",
+		"/usr/":       "/",
+		"/":           "",
+		"":            "",
+		"~/":          "",
+		"~/code/":     "~/",
+	} {
+		assert.Equal(t, want, parentDir(input), "above %q", input)
+	}
 }

--- a/internal/ui/path_prompt.go
+++ b/internal/ui/path_prompt.go
@@ -57,7 +57,7 @@ func (m *MainModel) completePathAtPrompt(input string) (*MainModel, tea.Cmd, boo
 	m.completionScrollOffset = 0
 
 	m.completingPath = false
-	if len(got.Matches) > 1 {
+	if got.worthListing() {
 		m.completions = got.Matches
 		m.completionIndex = 0
 		m.showCompletions = true
@@ -94,8 +94,16 @@ func (m *MainModel) applyPathCompletion(name string) {
 		return
 	}
 
+	// The candidates are names inside a directory, so the directory typed so
+	// far stays in front of the one picked - except the way up, which replaces
+	// it.
 	dir, _ := splitPath(prefix)
-	m.input.SetValue(completion.ReplacePath(input, prefix, quote, dir+name))
+	chosen := dir + name
+	if name == parentEntry {
+		chosen = parentDir(dir)
+	}
+
+	m.input.SetValue(completion.ReplacePath(input, prefix, quote, chosen))
 	m.input.CursorEnd()
 	m.clearCompletions()
 }

--- a/internal/ui/path_prompt_test.go
+++ b/internal/ui/path_prompt_test.go
@@ -286,7 +286,8 @@ func TestInsideTheQuoteItListsTheDirectory(t *testing.T) {
 
 	m.handleTabKey()
 
-	assert.Equal(t, []string{"a.csv", "b.csv"}, m.completions)
+	assert.Equal(t, []string{parentEntry, "a.csv", "b.csv"}, m.completions,
+		"the files, and the way up above them")
 	assert.NotContains(t, m.completions, pathHint)
 }
 
@@ -322,4 +323,21 @@ func TestTheWholeFlowFromTheFormatToTheFile(t *testing.T) {
 	m.handleTabKey()
 
 	assert.Equal(t, "CAPTURE CSV '"+filepath.Join(dir, "results.csv")+"'", m.input.Value())
+}
+
+// TestTheWayUpWorksAtThePromptToo, not only in the windows.
+func TestTheWayUpWorksAtThePromptToo(t *testing.T) {
+	dir := t.TempDir()
+	inner := filepath.Join(dir, "exports")
+	require.NoError(t, os.Mkdir(inner, 0o750))
+
+	m := promptModel(t)
+	m.input.SetValue("CAPTURE CSV '" + inner + string(filepath.Separator))
+	m.handleTabKey()
+
+	require.Equal(t, parentEntry, m.completions[0])
+	m.applyPathCompletion(parentEntry)
+
+	assert.Contains(t, m.input.Value(), dir+string(filepath.Separator))
+	assert.NotContains(t, m.input.Value(), parentEntry, "it goes up rather than appending")
 }


### PR DESCRIPTION
Tab completion lists what is in a directory, and picking a directory walks into
it. There was nothing that walked back out: with only the contents to pick from,
browsing was one-way, and a wrong turn meant editing the path by hand.

```
> ..
  GConf/
  ImageMagick-6/
  ModemManager/
```

It goes in `completePath`, so it turns up everywhere paths are completed - the
COPY and SOURCE forms, the Capture and Save window, and the prompt - rather than
in whichever one it was noticed in.

### Three things it had to avoid breaking

None of which it got right first time.

**The fill-in.** `..` agrees with nothing, so in the list the common prefix is
worked out from, `/b` would stop completing to `/boot/` the moment the parent
directory existed. It is added after.

**Empty directories.** `completePath` returned nothing at all for one, so walking
into an empty directory left no way back out. The way up counts as something to
offer - and a list holding only it is shown rather than filled in, because
applying it silently would walk you out of the directory you had just walked
into.

**Going up and falling straight back in.** A parent holding one entry completed
to it, which is the same auto-fill that makes a single candidate useful
everywhere else. Going up lists rather than completes.

### When it shows

Only when nothing has been typed after the directory. Once you are naming
something, `..` is not one of the things you might mean, and the prefix filters
it out like any other name.

Closes #155

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
