### PR TITLE
fix(ui): scroll the Trace sideways, and measure a table in columns

### DIFF
--- a/internal/ui/keyboard_navigation_pager.go
+++ b/internal/ui/keyboard_navigation_pager.go
@@ -366,81 +366,25 @@ func (m *MainModel) handleGoToBottom() (*MainModel, tea.Cmd) {
 
 // handleHorizontalScrollLeft scrolls left (< or , key)
 func (m *MainModel) handleHorizontalScrollLeft() (*MainModel, tea.Cmd) {
-	switch {
-	case m.viewMode == "trace" && m.hasTrace:
-		if m.traceHorizontalOffset > 0 {
-			m.traceHorizontalOffset -= 10
-			if m.traceHorizontalOffset < 0 {
-				m.traceHorizontalOffset = 0
-			}
-			m.refreshTraceView()
-		}
-	default:
-		m.scrollHorizontally(-horizontalStep)
-	}
+	m.scrollHorizontally(-horizontalStep)
 	return m, nil
 }
 
 // handlePageLeftScroll scrolls left by page width (Alt+PageUp)
 func (m *MainModel) handlePageLeftScroll() (*MainModel, tea.Cmd) {
-	switch {
-	case m.viewMode == "trace" && m.hasTrace:
-		if m.traceHorizontalOffset > 0 {
-			scrollAmount := m.traceViewport.Width() / 2
-			if scrollAmount < 10 {
-				scrollAmount = 10
-			}
-			m.traceHorizontalOffset -= scrollAmount
-			if m.traceHorizontalOffset < 0 {
-				m.traceHorizontalOffset = 0
-			}
-			m.refreshTraceView()
-		}
-	default:
-		m.scrollHorizontally(-m.halfScreen())
-	}
+	m.scrollHorizontally(-m.halfScreen())
 	return m, nil
 }
 
 // handlePageRightScroll scrolls right by page width (Alt+PageDown)
 func (m *MainModel) handlePageRightScroll() (*MainModel, tea.Cmd) {
-	switch {
-	case m.viewMode == "trace" && m.hasTrace:
-		if m.traceTableWidth > m.traceViewport.Width() {
-			scrollAmount := m.traceViewport.Width() / 2
-			if scrollAmount < 10 {
-				scrollAmount = 10
-			}
-			maxOffset := m.traceTableWidth - m.traceViewport.Width() + 10
-			m.traceHorizontalOffset += scrollAmount
-			if m.traceHorizontalOffset > maxOffset {
-				m.traceHorizontalOffset = maxOffset
-			}
-			m.refreshTraceView()
-		}
-	default:
-		m.scrollHorizontally(m.halfScreen())
-	}
+	m.scrollHorizontally(m.halfScreen())
 	return m, nil
 }
 
 // handleHorizontalScrollRight scrolls right (> or . key)
 func (m *MainModel) handleHorizontalScrollRight() (*MainModel, tea.Cmd) {
-	switch {
-	case m.viewMode == "trace" && m.hasTrace:
-		if m.traceTableWidth > m.traceViewport.Width() {
-			maxOffset := m.traceTableWidth - m.traceViewport.Width() + 10
-			if m.traceHorizontalOffset < maxOffset {
-				m.traceHorizontalOffset += 10
-				if m.traceHorizontalOffset > maxOffset {
-					m.traceHorizontalOffset = maxOffset
-				}
-				m.refreshTraceView()
-			}
-		}
-	default:
-		m.scrollHorizontally(horizontalStep)
-	}
+	m.scrollHorizontally(horizontalStep)
 	return m, nil
 }
 
@@ -450,28 +394,51 @@ const horizontalStep = 10
 // halfScreen is how far < and > scroll: half the width on screen, so a page
 // sideways leaves half of what you were reading in view.
 func (m *MainModel) halfScreen() int {
-	return max(m.tableViewport.Width()/2, horizontalStep)
+	width := m.tableViewport.Width()
+	if m.viewMode == "trace" && m.hasTrace {
+		width = m.traceViewport.Width()
+	}
+	return max(width/2, horizontalStep)
 }
 
-// scrollHorizontally moves the Results view sideways by n columns.
+// scrollHorizontally moves whichever view is in front of you sideways by n
+// columns.
 //
 // Every route sideways comes through here - h and l, the arrows, < and >, and
 // the wheel. They used to be six copies of the same clamp-then-rebuild, in
 // three files, and #115 fixed two of them: the other four went on rebuilding
 // ASCII output as a boxed table the moment you scrolled.
+//
+// The Trace view was the last of them. It kept its own offset and its own
+// clamp, reached only by h, l, < and > in navigation mode, and this returned
+// without doing anything for it - so Alt+Left, Alt+Right and the wheel, which
+// are what anyone would try, did nothing at all on a trace wider than the
+// screen.
 func (m *MainModel) scrollHorizontally(n int) {
-	if m.viewMode != "table" || !m.hasTable {
-		return
-	}
+	switch {
+	case m.viewMode == "trace" && m.hasTrace:
+		offset := clampOffset(m.traceHorizontalOffset+n, m.traceTableWidth, m.traceViewport.Width())
+		if offset == m.traceHorizontalOffset {
+			return
+		}
+		m.traceHorizontalOffset = offset
+		m.refreshTraceView()
 
-	maxOffset := max(m.tableWidth-m.tableViewport.Width()+horizontalStep, 0)
-	offset := min(max(m.horizontalOffset+n, 0), maxOffset)
-	if offset == m.horizontalOffset {
-		return
+	case m.viewMode == "table" && m.hasTable:
+		offset := clampOffset(m.horizontalOffset+n, m.tableWidth, m.tableViewport.Width())
+		if offset == m.horizontalOffset {
+			return
+		}
+		m.horizontalOffset = offset
+		m.applyHorizontalOffset()
 	}
+}
 
-	m.horizontalOffset = offset
-	m.applyHorizontalOffset()
+// clampOffset keeps a sideways offset inside what there is to scroll.
+//
+// A step past the end, so the last column is not left half off the edge.
+func clampOffset(offset, content, visible int) int {
+	return min(max(offset, 0), max(content-visible+horizontalStep, 0))
 }
 
 // resetHorizontalScroll puts a new result back at the left-hand edge.

--- a/internal/ui/keyboard_navtigation.go
+++ b/internal/ui/keyboard_navtigation.go
@@ -236,22 +236,9 @@ func (m *MainModel) handleLeftArrow(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
 		m.modal.PrevChoice()
 		return m, nil
 	}
-	// If Alt is held, scroll table/trace left
+	// If Alt is held, scroll whichever view is in front of you left
 	if msg.Mod.Contains(tea.ModAlt) {
-		switch {
-		case m.viewMode == "trace" && m.hasTrace:
-			// Scroll trace table left
-			if m.traceHorizontalOffset > 0 {
-				m.traceHorizontalOffset -= 10
-				if m.traceHorizontalOffset < 0 {
-					m.traceHorizontalOffset = 0
-				}
-				// Refresh the trace view using existing table renderer
-				m.refreshTraceView()
-			}
-		default:
-			m.scrollHorizontally(-horizontalStep)
-		}
+		m.scrollHorizontally(-horizontalStep)
 		return m, nil
 	}
 	// If Alt is not held, pass the key to the input for cursor movement
@@ -268,25 +255,9 @@ func (m *MainModel) handleRightArrow(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) 
 		m.modal.NextChoice()
 		return m, nil
 	}
-	// If Alt is held, scroll table/trace right
+	// If Alt is held, scroll whichever view is in front of you right
 	if msg.Mod.Contains(tea.ModAlt) {
-		switch {
-		case m.viewMode == "trace" && m.hasTrace:
-			// Scroll trace table right
-			if m.traceTableWidth > m.traceViewport.Width() {
-				maxOffset := m.traceTableWidth - m.traceViewport.Width() + 10 // Add some buffer
-				if m.traceHorizontalOffset < maxOffset {
-					m.traceHorizontalOffset += 10
-					if m.traceHorizontalOffset > maxOffset {
-						m.traceHorizontalOffset = maxOffset
-					}
-					// Refresh the trace view using existing table renderer
-					m.refreshTraceView()
-				}
-			}
-		default:
-			m.scrollHorizontally(horizontalStep)
-		}
+		m.scrollHorizontally(horizontalStep)
 		return m, nil
 	}
 	// If Alt is not held, pass the key to the input for cursor movement

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -276,12 +276,12 @@ func (m *MainModel) handleMouseWheel(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 
 	switch mouse.Button {
 	case tea.MouseWheelUp:
-		if modified && m.viewMode == "table" && m.hasTable {
+		if modified && m.scrollsSideways() {
 			return m.handleMouseWheelLeft()
 		}
 		return m.handleMouseWheelUp()
 	case tea.MouseWheelDown:
-		if modified && m.viewMode == "table" && m.hasTable {
+		if modified && m.scrollsSideways() {
 			return m.handleMouseWheelRight()
 		}
 		return m.handleMouseWheelDown()
@@ -377,6 +377,16 @@ func (m *MainModel) handleMouseWheelDown() (*MainModel, tea.Cmd) {
 		m.historyViewport.SetYOffset(min(maxOffset, m.historyViewport.YOffset()+scrollAmount))
 	}
 	return m, nil
+}
+
+// scrollsSideways reports whether the view in front of you has anything to
+// scroll sideways.
+//
+// The Trace view was left out of this, so a modifier and the wheel scrolled it
+// up and down instead - on a trace far wider than the screen, which is the one
+// view where reaching sideways matters most.
+func (m *MainModel) scrollsSideways() bool {
+	return (m.viewMode == "table" && m.hasTable) || (m.viewMode == "trace" && m.hasTrace)
 }
 
 // handleMouseWheelLeft handles horizontal scrolling left

--- a/internal/ui/table_renderer.go
+++ b/internal/ui/table_renderer.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"charm.land/lipgloss/v2"
 	"fmt"
 	"regexp"
 	"strings"
@@ -140,7 +141,12 @@ func (m *MainModel) formatTableForViewport(data [][]string) string {
 
 		// Calculate total table width
 		if len(fullLines) > 0 {
-			m.tableWidth = len(stripAnsi(fullLines[0]))
+			// Columns, not bytes. A boxed table is mostly box-drawing
+			// characters, and each of those is three bytes: measured with len
+			// the table came out about two and a half times as wide as it is,
+			// so scrolling sideways ran hundreds of columns past the end of it
+			// into blank screen.
+			m.tableWidth = lipgloss.Width(fullLines[0])
 		}
 	}
 

--- a/internal/ui/trace_scroll_test.go
+++ b/internal/ui/trace_scroll_test.go
@@ -1,0 +1,179 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wideTrace is a trace far wider than the screen, which is what a real one is:
+// the activity column alone runs past eighty columns.
+func wideTrace(t *testing.T) *MainModel {
+	t.Helper()
+
+	rows := [][]string{{"activity", "timestamp", "source", "source_elapsed", "client", "thread"}}
+	for i := range 5 {
+		rows = append(rows, []string{
+			fmt.Sprintf("Parsing SELECT * FROM my_keyspace.users WHERE id = %d LIMIT 100", i),
+			"2026-09-10 17:20:00.000", "10.0.0.1", "1234", "10.0.0.9", "Native-Transport-Requests-1",
+		})
+	}
+
+	m := &MainModel{
+		styles:        DefaultStyles(),
+		viewMode:      "trace",
+		hasTrace:      true,
+		traceData:     rows,
+		traceHeaders:  rows[0],
+		traceViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		tableViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		windowWidth:   80,
+		windowHeight:  24,
+		input:         newTestInput(),
+	}
+	m.refreshTraceView()
+
+	require.Greater(t, m.traceTableWidth, m.traceViewport.Width(),
+		"the fixture has to be wider than the screen or there is nothing to test")
+	return m
+}
+
+// TestEveryWayOfScrollingATraceSideways.
+//
+// The keyboard worked and the mouse did not: scrollHorizontally, which the
+// wheel calls, returned without doing anything for anything but the Results
+// view, while the trace had four hand-rolled copies of the same clamp that the
+// keys reached instead.
+func TestEveryWayOfScrollingATraceSideways(t *testing.T) {
+	for name, scroll := range map[string]func(*MainModel){
+		"Alt+Right": func(m *MainModel) {
+			m.handleRightArrow(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModAlt})
+		},
+		"Alt+PageDown":         func(m *MainModel) { m.handlePageRightScroll() },
+		"> in navigation mode": func(m *MainModel) { m.handleHorizontalScrollRight() },
+		"the wheel sideways":   func(m *MainModel) { m.handleMouseWheelRight() },
+		"a modifier and the wheel": func(m *MainModel) {
+			m.handleMouseWheel(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift})
+		},
+	} {
+		m := wideTrace(t)
+		before := traceRow(m)
+
+		scroll(m)
+
+		assert.Positive(t, m.traceHorizontalOffset, "%s should move it", name)
+		assert.NotEqual(t, before, traceRow(m), "%s should change what is drawn", name)
+	}
+}
+
+// TestAModifierAndTheWheelDoesNotScrollATraceUpAndDown.
+//
+// The gate named the Results view, so on a trace it fell through to the
+// vertical wheel - on the one view where reaching sideways matters most.
+func TestAModifierAndTheWheelDoesNotScrollATraceUpAndDown(t *testing.T) {
+	m := wideTrace(t)
+	before := m.traceViewport.YOffset()
+
+	m.handleMouseWheel(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift})
+
+	assert.Equal(t, before, m.traceViewport.YOffset(), "it should not have moved down")
+	assert.Positive(t, m.traceHorizontalOffset, "it should have moved across")
+}
+
+// TestScrollingATraceBackToTheLeftStopsAtTheEdge.
+func TestScrollingATraceBackToTheLeftStopsAtTheEdge(t *testing.T) {
+	m := wideTrace(t)
+	leftmost := traceRow(m)
+
+	for range 5 {
+		m.handleHorizontalScrollRight()
+	}
+	require.Positive(t, m.traceHorizontalOffset)
+
+	for range 20 {
+		m.handleHorizontalScrollLeft()
+	}
+
+	assert.Zero(t, m.traceHorizontalOffset, "it should stop at the left-hand edge")
+	assert.Equal(t, leftmost, traceRow(m), "and be showing what it started with")
+}
+
+// TestATraceStopsAtItsRightHandEdge rather than scrolling into empty space.
+func TestATraceStopsAtItsRightHandEdge(t *testing.T) {
+	m := wideTrace(t)
+
+	for range 200 {
+		m.handleHorizontalScrollRight()
+	}
+
+	assert.LessOrEqual(t, m.traceHorizontalOffset,
+		m.traceTableWidth-m.traceViewport.Width()+horizontalStep)
+	assert.NotEmpty(t, strings.TrimSpace(traceRow(m)), "there should still be something drawn")
+}
+
+// TestANarrowTraceDoesNotScroll, because there is nothing off the edge.
+func TestANarrowTraceDoesNotScroll(t *testing.T) {
+	m := wideTrace(t)
+	m.traceViewport.SetWidth(m.traceTableWidth + horizontalStep)
+
+	m.handleHorizontalScrollRight()
+
+	assert.Zero(t, m.traceHorizontalOffset)
+}
+
+// traceRow is the first row of the trace as drawn, for telling whether the view
+// actually moved rather than only the number behind it.
+func traceRow(m *MainModel) string {
+	rows := strings.Split(stripAnsiForTest(m.traceViewport.View()), "\n")
+	if len(rows) < 2 {
+		return ""
+	}
+	return rows[1]
+}
+
+// TestATableIsMeasuredInColumnsNotBytes.
+//
+// A boxed table is mostly box-drawing characters and each of those is three
+// bytes, so len made the table about two and a half times as wide as it is.
+// Everything that reads the width believed it: scrolling ran hundreds of
+// columns past the end into blank screen, and the Results view had it too.
+func TestATableIsMeasuredInColumnsNotBytes(t *testing.T) {
+	m := wideTrace(t)
+
+	// The table as it is built, before the viewport clips it.
+	m.horizontalOffset = 0
+	m.cachedTableLines = nil
+	m.initialColumnWidths = nil
+	drawn := m.formatTableForViewport(m.traceData)
+
+	want := 0
+	bytes := 0
+	for _, line := range strings.Split(drawn, "\n") {
+		want = max(want, lipgloss.Width(line))
+		bytes = max(bytes, len(stripAnsiForTest(line)))
+	}
+
+	require.Greater(t, bytes, want, "the fixture has to contain box drawing to be a test")
+	assert.Equal(t, want, m.tableWidth, "the width is what it takes on screen")
+	assert.NotEqual(t, bytes, m.tableWidth, "not what it takes in memory")
+}
+
+// TestScrollingRightLeavesSomethingOnScreen.
+//
+// With the width in bytes there was room to scroll a hundred columns past the
+// last one, and the view went blank rather than stopping at the edge.
+func TestScrollingRightLeavesSomethingOnScreen(t *testing.T) {
+	m := wideTrace(t)
+
+	for range 200 {
+		m.handleHorizontalScrollRight()
+	}
+
+	assert.Contains(t, traceRow(m), "thread", "the last column should still be there")
+}


### PR DESCRIPTION
A trace is far wider than the screen and the mouse would not reach the
right-hand side of it.

### What was actually broken

The keyboard already worked. Measured route by route on a trace in an
80-column viewport:

| | before |
|---|---|
| `Alt+Left` / `Alt+Right` | works |
| `Alt+PageUp` / `Alt+PageDown` | works |
| `h`, `l`, `<`, `>` in navigation mode | works |
| wheel sideways | **nothing** |
| a modifier and the wheel | **scrolls up and down instead** |

Each of the working ones had its own hand-rolled copy of the same clamp - four
of them across two files. The wheel goes through `scrollHorizontally`, which
opened with `if m.viewMode != "table" || !m.hasTable { return }`, and the
modifier-and-wheel case named the Results view a third time.

There is one function that scrolls sideways now, whichever view is in front of
you, and the six copies are gone. Same shape as #115 and #123: six copies of a
clamp-then-rebuild across three files, two fixed then and four left. These were
the last.

### What the fix uncovered

Scrolling a trace right went blank. `tableWidth` was measured with `len()` -
**bytes, not columns**. A boxed table is mostly box-drawing characters at three
bytes each, so a trace 161 columns wide reported **483**. Everything reading the
width believed it, and there was room to scroll three hundred columns past the
last one into empty screen.

**This is not a trace bug.** The Results view has had it since the width was
first measured, and a wide table scrolled fully right runs off into nothing
there too. It is one line, and `lipgloss.Width` is what every other width in the
file already uses.

### The test

It drives all five routes rather than the one that was reported, because four of
them worked and the report was about the fifth. It also pins the width against
what the table takes on screen rather than in memory.

Closes #157

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
