### PR TITLE
fix(save): write collection columns as text rather than null

### DIFF
--- a/internal/parquet/string_values_test.go
+++ b/internal/parquet/string_values_test.go
@@ -73,3 +73,27 @@ func TestAnUnparseableValueIsAnError(t *testing.T) {
 		assert.Error(t, err, given)
 	}
 }
+
+// TestWhatCanBeReadBackFromItsPrintedForm.
+//
+// The question SAVE has to ask: it holds what was on screen, so a type whose
+// text cannot be turned back into the value has to be written as text.
+func TestWhatCanBeReadBackFromItsPrintedForm(t *testing.T) {
+	for _, cqlType := range []string{
+		"int", "bigint", "text", "boolean", "timestamp", "uuid", "double",
+	} {
+		assert.True(t, RebuildableFromText(cqlType), "%s prints as something it can be read from", cqlType)
+	}
+
+	for _, cqlType := range []string{
+		"map<text, int>", "list<int>", "set<text>", "tuple<int, text>",
+	} {
+		assert.False(t, RebuildableFromText(cqlType), "%s does not", cqlType)
+	}
+}
+
+// TestAnUnknownTypeIsAlreadyText, so it needs no special mention.
+func TestAnUnknownTypeIsAlreadyText(t *testing.T) {
+	assert.True(t, RebuildableFromText("some_udt_name"))
+	assert.True(t, RebuildableFromText(""))
+}

--- a/internal/parquet/types.go
+++ b/internal/parquet/types.go
@@ -1047,3 +1047,34 @@ func parseTimeString(v string) (time.Time, error) {
 	}
 	return time.Time{}, fmt.Errorf("cannot parse %q as a time", v)
 }
+
+// RebuildableFromText reports whether a value of this type can be turned back
+// into itself from the way it is printed.
+//
+// Asked by anything holding a rendered value rather than the value: SAVE writes
+// what was on screen, so a column whose text cannot be read back has to be
+// written as text rather than as a shape that cannot be filled.
+//
+// The scalars can: a number, a boolean, a timestamp all parse from what they
+// print as.
+//
+// The collections cannot. A map prints as "map[a:1 b:2]", which is ambiguous
+// the moment a value contains a space or a colon - there is no telling where
+// one pair ends and the next begins. A parser for it would be right most of the
+// time, which for an export is worse than being obviously wrong.
+//
+// It asks the type mapper rather than reading the CQL type itself, so a type
+// that is already written as text - which is what an unrecognised one becomes -
+// answers yes without needing to be named here.
+func RebuildableFromText(cassandraType string) bool {
+	dt, err := NewTypeMapper().CassandraToArrowType(cassandraType)
+	if err != nil || dt == nil {
+		return true // unknown types are written as text already
+	}
+
+	switch dt.ID() {
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.MAP, arrow.STRUCT:
+		return false
+	}
+	return true
+}

--- a/internal/router/save_command.go
+++ b/internal/router/save_command.go
@@ -429,6 +429,18 @@ func exportToParquet(filename string, data [][]string, columnTypes []string, opt
 		headers[i] = db.StripKeyMarker(stripAnsi(cell))
 	}
 
+	// A collection column is written as text, because text is all SAVE has.
+	//
+	// The values here are what was on screen - a map printed as "map[a:1 b:2]"
+	// - and there is no way back from that to a map: it is ambiguous the moment
+	// a value contains a space or a colon. Asking for an Arrow MAP and handing
+	// it that string wrote a column of nulls, which is worse than writing the
+	// text, because the text is at least the data.
+	//
+	// CAPTURE is untouched by this. It has the gocql values and writes maps as
+	// maps.
+	columnTypes = writtenAsText(columnTypes)
+
 	writerOptions := parquet.DefaultWriterOptions()
 	if val, ok := options["compression"]; ok {
 		if s, ok := val.(string); ok {
@@ -461,4 +473,17 @@ func exportToParquet(filename string, data [][]string, columnTypes []string, opt
 		return fmt.Errorf("failed to close Parquet file: %w", err)
 	}
 	return nil
+}
+
+// writtenAsText turns the types that cannot be read back into text, leaving the
+// rest alone.
+func writtenAsText(columnTypes []string) []string {
+	written := make([]string, len(columnTypes))
+	for i, cqlType := range columnTypes {
+		written[i] = cqlType
+		if !parquet.RebuildableFromText(cqlType) {
+			written[i] = "text"
+		}
+	}
+	return written
 }

--- a/internal/router/save_parquet_test.go
+++ b/internal/router/save_parquet_test.go
@@ -270,3 +270,59 @@ func TestATextExtensionFallsToTheDefault(t *testing.T) {
 		assert.Equal(t, "CSV", cmd.Format, name)
 	}
 }
+
+// TestCollectionsAreWrittenAsTextRatherThanNull.
+//
+// SAVE has only what was on screen, so a map arrives as "map[a:1 b:2]". Asking
+// for an Arrow MAP and handing it that string wrote a column of nulls: toMap
+// takes Go maps and nothing else, the conversion failed, and
+// AppendValueToBuilder swallowed it - the same silence that made every numeric
+// column null before #139.
+//
+// The text is not parsed back. "map[a:1 b:2]" is ambiguous the moment a value
+// contains a space or a colon, and a parser that is right most of the time is
+// worse for an export than one that is obviously wrong. Text is what we have,
+// so text is what is written.
+func TestCollectionsAreWrittenAsTextRatherThanNull(t *testing.T) {
+	data := [][]string{
+		{"id", "tags", "scores", "names"},
+		{"1", "map[a:1 b:2]", "[10, 20]", "[x, y]"},
+	}
+	types := []string{"int", "map<text, int>", "list<int>", "set<text>"}
+
+	path := filepath.Join(t.TempDir(), "collections.parquet")
+	require.NoError(t, HandleSaveCommand(
+		SaveCommand{Filename: path, Format: "PARQUET"}, data, types))
+
+	names, rows := readParquet(t, path)
+	require.Equal(t, data[0], names)
+	require.Len(t, rows, 1)
+
+	for i, name := range names {
+		assert.NotEmpty(t, rows[0][i], "column %s must not be null", name)
+	}
+	assert.Equal(t, data[1], rows[0], "and it is what was on screen")
+}
+
+// TestOnlyTheTypesThatCannotBeReadBackBecomeText.
+func TestOnlyTheTypesThatCannotBeReadBackBecomeText(t *testing.T) {
+	given := []string{"int", "text", "timestamp", "map<text, int>", "list<int>", "set<text>"}
+	want := []string{"int", "text", "timestamp", "text", "text", "text"}
+
+	assert.Equal(t, want, writtenAsText(given))
+}
+
+// TestAScalarKeepsItsType, so the fix does not turn the whole file into strings.
+func TestAScalarKeepsItsType(t *testing.T) {
+	data := [][]string{{"id", "when", "ok"}, {"42", "2026-09-10T12:00:00Z", "true"}}
+	types := []string{"int", "timestamp", "boolean"}
+
+	path := filepath.Join(t.TempDir(), "scalars.parquet")
+	require.NoError(t, HandleSaveCommand(
+		SaveCommand{Filename: path, Format: "PARQUET"}, data, types))
+
+	_, rows := readParquet(t, path)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "42", rows[0][0])
+	assert.Equal(t, "true", rows[0][2])
+}


### PR DESCRIPTION
Saving a result with a `map` column to Parquet left the column empty, and lists
and sets went the same way.

```
types:   int  map<text, int>  list<int>

before:  "1"  ""              [null]
after:   "1"  map[a:1 b:2]    [10, 20]
```

`SAVE` has only what was on screen - `lastTableData` is `[][]string`, the values
as they were rendered - so a map arrives as `map[a:1 b:2]` and the builder for
that column is an Arrow MAP. `toMap` takes Go maps and nothing else, the
conversion fails, and `AppendValueToBuilder` appends null.

That is the same swallowed failure that made every numeric column null before
#139. That fix added string cases to the numbers, booleans and timestamps, and
stopped at the collections.

### The text is not parsed back

`map[a:1 b:2]` is what Go's `%v` prints, and it is ambiguous the moment a value
contains a space or a colon - there is no telling where one pair ends and the
next begins. A parser for it would be right most of the time, which for an
export is worse than being obviously wrong.

So when the only thing we have is the rendered text, the Parquet type for that
column is text. `map[a:1 b:2]` in a string column is the data; a typed MAP
column full of nulls is not.

The decision is made at the SAVE boundary, where the "we only have strings" fact
lives, rather than as a fallback buried in the converter. **`CAPTURE` is
untouched**: it has the gocql values and still writes maps as maps.

`RebuildableFromText` asks the type mapper rather than reading the CQL type
itself, so a type that already becomes text - which is what an unrecognised one
does - answers yes without needing to be named there.

### Nearly shipped with it

A special case keeping `vector` columns typed, which turned out to be justified
by behaviour that does not exist: `CassandraToArrowType` matches the bare word
`vector` and not `vector<float, 3>`, so a vector was already being written as
text. The special case went rather than the comment claiming otherwise.

Closes #159

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
