### PR TITLE
fix(ui): close the command history when you press outside it

### DIFF
--- a/internal/ui/history_overlay.go
+++ b/internal/ui/history_overlay.go
@@ -170,3 +170,27 @@ func (m *MainModel) openHistoryList() (*MainModel, tea.Cmd) {
 	}
 	return m.handleCtrlR()
 }
+
+// closeHistorySearch puts the command list away.
+//
+// It was five assignments written out six times across five files, and two of
+// those six left out the scroll offset - so closing a scrolled list with Escape
+// and opening it again showed the middle of the history with the selection
+// somewhere above it.
+func (m *MainModel) closeHistorySearch() {
+	m.historySearchMode = false
+	m.historySearchQuery = ""
+	m.historySearchResults = []string{}
+	m.historySearchIndex = 0
+	m.historySearchScrollOffset = 0
+}
+
+// inHistoryOverlay reports whether a press landed inside the command list.
+func (m *MainModel) inHistoryOverlay(col, row int) bool {
+	_, layer, ok := m.historyOverlay(m.windowWidth, m.windowHeight)
+	if !ok {
+		return false
+	}
+	return col >= layer.X && col < layer.X+layer.Width &&
+		row >= layer.Y && row < layer.Y+layer.Height
+}

--- a/internal/ui/history_overlay_test.go
+++ b/internal/ui/history_overlay_test.go
@@ -624,3 +624,58 @@ func TestAShortListHasNoArrowRowsAtAll(t *testing.T) {
 	// Border, title, query, four commands, rule, hint, border.
 	assert.Equal(t, 4+6, layer.Height)
 }
+
+// TestPressingOutsideTheListClosesIt, the same as every other window.
+//
+// It was the exception: a press anywhere but on a command fell through to the
+// ordinary row handling and started a text selection behind the list, which
+// stayed open until you pressed Escape or picked something.
+func TestPressingOutsideTheListClosesIt(t *testing.T) {
+	m := historyModel(20)
+	m.handleCtrlR()
+	require.True(t, m.historySearchMode)
+
+	_, layer, ok := m.historyOverlay(m.windowWidth, m.windowHeight)
+	require.True(t, ok)
+
+	// Well clear of the box, in the middle of the view behind it.
+	pressAt(m, max(layer.X-2, 0), layer.Y+layer.Height+1)
+
+	assert.False(t, m.historySearchMode, "a press outside should close it")
+}
+
+// TestPressingInsideTheListButNotOnACommandLeavesItOpen.
+//
+// The title, the search line and the scrollbar are part of the window. An aimed
+// press that misses by a row is not the same as walking away from it.
+func TestPressingInsideTheListButNotOnACommandLeavesItOpen(t *testing.T) {
+	m := historyModel(20)
+	m.handleCtrlR()
+	require.True(t, m.historySearchMode)
+
+	_, layer, ok := m.historyOverlay(m.windowWidth, m.windowHeight)
+	require.True(t, ok)
+
+	pressAt(m, layer.X+2, layer.Y) // the title row
+
+	assert.True(t, m.historySearchMode, "it should still be open")
+}
+
+// TestClosingTheListForgetsWhereItWasScrolled.
+//
+// Closing it was five assignments written out six times, and two of the six
+// left out the scroll offset - so a scrolled list closed with Escape opened
+// again showing the middle of the history.
+func TestClosingTheListForgetsWhereItWasScrolled(t *testing.T) {
+	m := historyModel(50)
+	m.handleCtrlR()
+	m.moveHistorySelection(20)
+	require.NotZero(t, m.historySearchScrollOffset, "the fixture has to be scrolled")
+
+	m.closeHistorySearch()
+
+	assert.Zero(t, m.historySearchScrollOffset)
+	assert.Zero(t, m.historySearchIndex)
+	assert.Empty(t, m.historySearchQuery)
+	assert.False(t, m.historySearchMode)
+}

--- a/internal/ui/keyboard_handler_ai_conversation.go
+++ b/internal/ui/keyboard_handler_ai_conversation.go
@@ -13,24 +13,14 @@ func (m *MainModel) handleAIConversationInput(msg tea.KeyPressMsg) (*MainModel, 
 	if m.historySearchMode {
 		switch msg.String() {
 		case "ctrl+r", "ctrl+c", "esc":
-			// Exit history search mode
-			m.historySearchMode = false
-			m.historySearchQuery = ""
-			m.historySearchResults = []string{}
-			m.historySearchIndex = 0
-			m.historySearchScrollOffset = 0
+			m.closeHistorySearch()
 			return m, nil
 		case "enter":
 			// Select the current history entry
 			if len(m.historySearchResults) > 0 && m.historySearchIndex < len(m.historySearchResults) {
 				// Set the AI input value to the selected history entry
 				m.aiConversationInput.SetValue(m.historySearchResults[m.historySearchIndex])
-				// Exit history search mode
-				m.historySearchMode = false
-				m.historySearchQuery = ""
-				m.historySearchResults = []string{}
-				m.historySearchIndex = 0
-				m.historySearchScrollOffset = 0
+				m.closeHistorySearch()
 			}
 			return m, nil
 		case "up":
@@ -89,12 +79,7 @@ func (m *MainModel) handleAIConversationInput(msg tea.KeyPressMsg) (*MainModel, 
 	// Check for Ctrl+R to toggle history search mode
 	if msg.String() == "ctrl+r" {
 		if m.historySearchMode {
-			// Exit history search mode
-			m.historySearchMode = false
-			m.historySearchQuery = ""
-			m.historySearchResults = []string{}
-			m.historySearchIndex = 0
-			m.historySearchScrollOffset = 0
+			m.closeHistorySearch()
 		} else {
 			// Enter history search mode
 			m.historySearchMode = true

--- a/internal/ui/keyboard_handler_control.go
+++ b/internal/ui/keyboard_handler_control.go
@@ -8,11 +8,7 @@ import (
 func (m *MainModel) handleCtrlC() (*MainModel, tea.Cmd) {
 	// If in history search mode, exit it
 	if m.historySearchMode {
-		m.historySearchMode = false
-		m.historySearchQuery = ""
-		m.historySearchResults = []string{}
-		m.historySearchIndex = 0
-		m.historySearchScrollOffset = 0
+		m.closeHistorySearch()
 		return m, nil
 	}
 	// If modal is showing, close it
@@ -116,11 +112,7 @@ func (m *MainModel) handleCtrlR() (*MainModel, tea.Cmd) {
 			m.historySearchScrollOffset = 0
 		}
 	} else {
-		// Exit history search mode
-		m.historySearchMode = false
-		m.historySearchQuery = ""
-		m.historySearchResults = []string{}
-		m.historySearchIndex = 0
+		m.closeHistorySearch()
 	}
 	return m, nil
 }

--- a/internal/ui/keyboard_handler_escape.go
+++ b/internal/ui/keyboard_handler_escape.go
@@ -48,10 +48,7 @@ func (m *MainModel) handleEscapeKey() (*MainModel, tea.Cmd) {
 
 	// If in history search mode, exit it
 	if m.historySearchMode {
-		m.historySearchMode = false
-		m.historySearchQuery = ""
-		m.historySearchResults = []string{}
-		m.historySearchIndex = 0
+		m.closeHistorySearch()
 		return m, nil
 	}
 

--- a/internal/ui/keyboard_handler_history.go
+++ b/internal/ui/keyboard_handler_history.go
@@ -81,11 +81,7 @@ func (m *MainModel) handleHistorySearchSelect() (*MainModel, tea.Cmd) {
 	if len(m.historySearchResults) > 0 && m.historySearchIndex < len(m.historySearchResults) {
 		// Set the input value to the selected history entry
 		m.input.SetValue(m.historySearchResults[m.historySearchIndex])
-		// Exit history search mode
-		m.historySearchMode = false
-		m.historySearchQuery = ""
-		m.historySearchResults = []string{}
-		m.historySearchIndex = 0
+		m.closeHistorySearch()
 	}
 	return m, nil
 }

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -215,8 +215,31 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 
 	// A press on a command in either history list puts it in the prompt. This
 	// comes before the rows below, because the lists are drawn over them.
-	if updated, cmd, hit := m.clickHistoryCommand(mouse.X, mouse.Y); hit {
-		return updated, cmd
+	if m.historySearchMode {
+		if updated, cmd, hit := m.clickHistoryCommand(mouse.X, mouse.Y); hit {
+			return updated, cmd
+		}
+
+		// Inside the box but not on a command - the title, the search line, the
+		// scrollbar - does nothing rather than closing it, so an aimed press
+		// that misses by a row is not the same as walking away.
+		if m.inHistoryOverlay(mouse.X, mouse.Y) {
+			return m, nil
+		}
+
+		// Anywhere else closes it, the same as every other window, and the
+		// press carries on to whatever it landed on: the tabs and the settings
+		// are still live underneath.
+		//
+		// Except the control that opened it. Left to carry on, the press closed
+		// the list and the History field reopened it in the same press, so it
+		// looked like nothing happened - the bug the settings lists, Capture and
+		// SAVE RESULTS each had in turn.
+		reopens := m.pressOpensHistory(mouse)
+		m.closeHistorySearch()
+		if reopens {
+			return m, nil
+		}
 	}
 
 	// Row 0 is the tabs, the last row is the connection bar and the one above
@@ -233,6 +256,16 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 	}
 
 	return m.beginSelection(mouse.X, mouse.Y)
+}
+
+// pressOpensHistory reports whether a press is on the History field, which is
+// what opens the command list.
+func (m *MainModel) pressOpensHistory(mouse tea.Mouse) bool {
+	if mouse.Y != m.windowHeight-2 {
+		return false
+	}
+	field, ok := m.topBar.fieldAt(m.windowWidth, mouse.X)
+	return ok && field == infoHistory
 }
 
 // pressOpensCapture reports whether a press is on a control that opens the


### PR DESCRIPTION
Open the list with `Ctrl+R`, or by clicking `History:` on the info bar, and a
press anywhere outside it did nothing. It stayed open until you pressed Escape
or picked something, while the press started a text selection in the view behind
it.

Every other window closes that way - the settings lists, the Capture and Save
window, the FILE menu, the help - and there was no reason for this one to be the
exception. `handleMousePress` had a branch for a press *on* a command and
nothing for a press anywhere else.

### What closes it and what does not

A press inside the box but not on a command - the title, the search line, the
scrollbar - leaves it open. An aimed press that misses by a row is not the same
as walking away from it.

Anywhere else closes it, and the press carries on to whatever it landed on, so
the tabs and the settings are still live underneath.

**Except the control that opened it.** Left to carry on, the press closed the
list and the `History:` field opened it again in the same press, so it looked
like nothing had happened. That is the fourth time - the settings lists, Capture
and `SAVE RESULTS` each had it in turn - and it is the same rule each time.

### The other half

Closing the list was five assignments written out six times across five files,
and **two of the six left out `historySearchScrollOffset`**: Escape, and the copy
in `keyboard_handler_history.go`. Close a scrolled list with Escape, open it
again, and it showed the middle of the history with the selection somewhere
above it.

One function now, called from all seven places.

Closes #161

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
