### PR TITLE
fix(ui): clicking Header row crashed cqlai

### DIFF
--- a/internal/ui/file_form.go
+++ b/internal/ui/file_form.go
@@ -484,7 +484,12 @@ func actionFields(action formAction, keyspace string) []formField {
 			// On the FROM form and not the TO form because this is where
 			// getting it wrong costs you: a CSV whose first row is column
 			// names, read with HEADER=false, inserts that row as data.
-			{label: "Header row", kind: fieldYesNo, yes: true, hint: "the file's first row is column names"},
+			// Given an input like every other field even though it is never
+			// typed into and never draws it. A zero textinput has no cursor,
+			// and focusing one dereferences it: clicking this field crashed
+			// cqlai.
+			{label: "Header row", kind: fieldYesNo, yes: true, input: newFormInput("", ""),
+				hint: "the file's first row is column names"},
 		}
 	}
 	return []formField{

--- a/internal/ui/file_form_test.go
+++ b/internal/ui/file_form_test.go
@@ -327,3 +327,48 @@ func collect(errors map[int]string) []string {
 	slices.Sort(all)
 	return all
 }
+
+// TestEveryFieldCanBeFocused.
+//
+// The Header row field was declared without a textinput, and a zero textinput
+// has no cursor: focusing one dereferences it. Clicking that field crashed
+// cqlai, and the panic came from three layers down in bubbles, which is not
+// where anyone would look.
+//
+// Every field, on every form, by click and by key - because the one that was
+// wrong was the one field that never draws its input, and nothing else touched
+// it.
+func TestEveryFieldCanBeFocused(t *testing.T) {
+	for _, action := range []formAction{sourcing, copyingTo, copyingFrom} {
+		m := formModel(t, action)
+
+		for i := range m.form.fields {
+			label := m.form.fields[i].label
+			require.NotPanics(t, func() { m.form.focusField(i) },
+				"focusing %s should not panic", label)
+			require.NotPanics(t, func() { m.form.blurAll() },
+				"blurring past %s should not panic", label)
+		}
+
+		// And by walking with the arrows, which is how you reach it without a
+		// mouse.
+		require.NotPanics(t, func() {
+			m.form.focusField(0)
+			for range len(m.form.fields) + 2 {
+				m.handleFormKey(tea.KeyPressMsg{Code: tea.KeyDown})
+			}
+		}, "walking the whole form should not panic")
+	}
+}
+
+// TestEveryFieldHasAnInput, which is what makes the above true rather than
+// happening to be true.
+func TestEveryFieldHasAnInput(t *testing.T) {
+	for _, action := range []formAction{sourcing, copyingTo, copyingFrom} {
+		m := formModel(t, action)
+		for i, field := range m.form.fields {
+			assert.NotPanics(t, func() { m.form.fields[i].input.Focus() },
+				"%s has no usable input", field.label)
+		}
+	}
+}


### PR DESCRIPTION
```
runtime error: invalid memory address or nil pointer dereference

cursor.(*Model).Blink
cursor.(*Model).Focus
textinput.(*Model).Focus
(*fileForm).focusField
(*MainModel).handleMousePress
```

`Header row` is the one field on any form declared without a textinput. It never
needs one - it shows `yes` or `no` rather than drawing an input, and typing goes
past it - so the zero value looked harmless. A zero `textinput.Model` has no
cursor, and `Focus()` dereferences it.

`focusField` focuses whatever field you land on, so a click on that row, or an
arrow key onto it, took the whole program down.

It has an input now, like every other field, even though nothing types into it
or draws it.

### Why nothing caught it

The field that was wrong is the one nothing else touches: no rendering path
reads its input, no typing path writes to it, no completion path lists it. Every
test written for these forms exercised fields that carry text.

So the test that goes with the fix is the general one rather than the specific
one - **every field, on every form, focusable by click and by key**, and every
field holding an input that can be focused. That would have caught it the day
the form was written.

Closes #165

https://claude.ai/code/session_01SMUAQUgfmbP9cPo8Q1e6wC
