### PR TITLE
Switching OUTPUT redraws the result on screen, from the values behind it

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,17 @@ Meta-commands provide additional functionality beyond standard CQL:
   OUTPUT EXPAND   -- Expanded vertical format
   OUTPUT ASCII    -- ASCII table format
   ```
+  The format decides how a result is drawn and nothing else. `OUTPUT JSON` used
+  to rewrite the query as `SELECT JSON`, so what came back was one column of
+  documents rather than the columns asked for; JSON is now written by CQLAI from
+  the values that come back, keeping their types. Typing `SELECT JSON` yourself
+  still does what it always did.
+
+  Changing the format redraws the result already on screen, in the new format,
+  without running the query again. `EXPAND ON` and `EXPAND OFF` are the same
+  setting by another name, as is the Output control on the status line. Only the
+  rows fetched so far are redrawn: a switch does not pull the rest of a result
+  in, and says how many rows are showing when there are more.
 
 #### Schema Description
 - **DESCRIBE** - Show schema information

--- a/internal/db/executor.go
+++ b/internal/db/executor.go
@@ -710,34 +710,6 @@ func (s *Session) ExecuteStreamingQuery(query string) interface{} {
 	}
 }
 
-// ConvertToJSONQuery converts a SELECT query to SELECT JSON format
-// This is now a public method so it can be called from the router/UI layer when needed
-func ConvertToJSONQuery(query string) string {
-	upperQuery := strings.ToUpper(strings.TrimSpace(query))
-
-	// Check if it's already a JSON query
-	if strings.Contains(upperQuery, "SELECT JSON") || strings.Contains(upperQuery, "SELECT DISTINCT JSON") {
-		return query
-	}
-
-	// Only convert SELECT queries
-	if !strings.HasPrefix(upperQuery, "SELECT") {
-		return query
-	}
-
-	// Handle SELECT DISTINCT
-	if strings.HasPrefix(upperQuery, "SELECT DISTINCT") {
-		// Replace "SELECT DISTINCT" with "SELECT DISTINCT JSON"
-		re := regexp.MustCompile(`(?i)^SELECT\s+DISTINCT\s+`)
-		return re.ReplaceAllString(query, "SELECT DISTINCT JSON ")
-	}
-
-	// Handle regular SELECT
-	// Replace "SELECT" with "SELECT JSON"
-	re := regexp.MustCompile(`(?i)^SELECT\s+`)
-	return re.ReplaceAllString(query, "SELECT JSON ")
-}
-
 // GetKeyColumns returns information about partition and clustering columns for a table
 func (s *Session) GetKeyColumns(query string) KeyColumns {
 	keyColumns := make(KeyColumns)

--- a/internal/db/json_value.go
+++ b/internal/db/json_value.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"reflect"
+	"time"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"gopkg.in/inf.v0"
+)
+
+// Turning a value from the driver into one encoding/json can write.
+//
+// Most of them go straight through. The ones that do not are the ones Cassandra
+// has and JSON does not: a UUID is sixteen bytes, which json writes as an array
+// of numbers; a blob is bytes, which it writes as base64 rather than the 0x
+// form every other tool prints; a decimal is a big number with a scale, and a
+// timestamp is a time.
+//
+// This is what the Results view builds JSON from. It used to ask Cassandra for
+// JSON instead, by rewriting the query as SELECT JSON, which answered the
+// question but changed the result: one column of documents, in place of the
+// columns that were asked for.
+
+// JSONValue converts a driver value into something json.Marshal writes
+// faithfully, walking into collections and user-defined types on the way.
+func JSONValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case gocql.UUID:
+		return v.String()
+	case *gocql.UUID:
+		if v == nil {
+			return nil
+		}
+		return v.String()
+	case []byte:
+		// The form cqlsh, DESCRIBE and every driver print a blob in.
+		return fmt.Sprintf("0x%x", v)
+	case time.Time:
+		return v.Format(time.RFC3339Nano)
+	case time.Duration:
+		return v.String()
+	case gocql.Duration:
+		return fmt.Sprintf("%dmo%dd%dns", v.Months, v.Days, v.Nanoseconds)
+	case net.IP:
+		return v.String()
+	case *big.Int:
+		if v == nil {
+			return nil
+		}
+		return v.String()
+	case *inf.Dec:
+		if v == nil {
+			return nil
+		}
+		return v.String()
+	case string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, float32, float64:
+		return v
+	}
+
+	return jsonCollection(value)
+}
+
+// jsonCollection walks a list, set, map or tuple, converting what is inside it.
+//
+// A map's keys have to be strings in JSON, and Cassandra's need not be: a
+// map<uuid, text> arrives with UUID keys, which json.Marshal will not write at
+// all. They are converted the same way the values are and then written as text,
+// which is how the key reads everywhere else.
+func jsonCollection(value interface{}) interface{} {
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if rv.IsNil() {
+			return nil
+		}
+		return JSONValue(rv.Elem().Interface())
+
+	case reflect.Slice, reflect.Array:
+		items := make([]interface{}, rv.Len())
+		for i := range items {
+			items[i] = JSONValue(rv.Index(i).Interface())
+		}
+		return items
+
+	case reflect.Map:
+		object := make(map[string]interface{}, rv.Len())
+		for _, key := range rv.MapKeys() {
+			name, ok := JSONValue(key.Interface()).(string)
+			if !ok {
+				name = fmt.Sprint(JSONValue(key.Interface()))
+			}
+			object[name] = JSONValue(rv.MapIndex(key).Interface())
+		}
+		return object
+	}
+
+	// Anything else - a UDT the driver handed back as a struct, say - is left
+	// to json.Marshal, which knows what to do with a struct and writes a string
+	// for whatever it does not.
+	return value
+}

--- a/internal/db/json_value_test.go
+++ b/internal/db/json_value_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"encoding/json"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONValueWritesWhatCassandraHasAndJSONDoesNot.
+//
+// Left to itself json.Marshal writes a UUID as sixteen numbers and a blob as
+// base64, neither of which is what the value is anywhere else in cqlai.
+func TestJSONValueWritesWhatCassandraHasAndJSONDoesNot(t *testing.T) {
+	id, err := gocql.ParseUUID("d2177dd0-eaa2-11de-a572-001b779c76e3")
+	require.NoError(t, err)
+
+	for name, this := range map[string]struct {
+		value interface{}
+		want  string
+	}{
+		"uuid":      {id, `"d2177dd0-eaa2-11de-a572-001b779c76e3"`},
+		"blob":      {[]byte{0xca, 0xfe}, `"0xcafe"`},
+		"timestamp": {time.Date(2026, 9, 11, 10, 0, 0, 0, time.UTC), `"2026-09-11T10:00:00Z"`},
+		"inet":      {net.ParseIP("10.0.0.1"), `"10.0.0.1"`},
+		"varint":    {big.NewInt(12345678901234), `"12345678901234"`},
+		"int":       {7, `7`},
+		"boolean":   {true, `true`},
+		"text":      {"alice", `"alice"`},
+		"null":      {nil, `null`},
+	} {
+		encoded, err := json.Marshal(JSONValue(this.value))
+		require.NoError(t, err, name)
+		assert.Equal(t, this.want, string(encoded), name)
+	}
+}
+
+// TestJSONValueWalksIntoCollections, which is where the awkward values usually
+// are: a list of UUIDs is a list of sixteen-number arrays otherwise.
+func TestJSONValueWalksIntoCollections(t *testing.T) {
+	id, err := gocql.ParseUUID("d2177dd0-eaa2-11de-a572-001b779c76e3")
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(JSONValue([]gocql.UUID{id}))
+	require.NoError(t, err)
+	assert.JSONEq(t, `["d2177dd0-eaa2-11de-a572-001b779c76e3"]`, string(encoded))
+
+	encoded, err = json.Marshal(JSONValue(map[string][]byte{"key": {0x01}}))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"key":"0x01"}`, string(encoded))
+
+	// A map whose keys are not strings - map<uuid, text> - cannot be written at
+	// all without this: the keys become what they read as everywhere else.
+	encoded, err = json.Marshal(JSONValue(map[gocql.UUID]string{id: "alice"}))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"d2177dd0-eaa2-11de-a572-001b779c76e3":"alice"}`, string(encoded))
+
+	// A user-defined type arrives as a map of its fields.
+	encoded, err = json.Marshal(JSONValue(map[string]interface{}{
+		"street": "1 High Street",
+		"zip":    12345,
+	}))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"street":"1 High Street","zip":12345}`, string(encoded))
+}

--- a/internal/db/session_test.go
+++ b/internal/db/session_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/axonops/cqlai/internal/config"
@@ -96,74 +95,6 @@ func TestSetPageSize(t *testing.T) {
 			session.SetPageSize(tt.newSize)
 			if session.PageSize() != tt.expected {
 				t.Errorf("PageSize() = %d, want %d", session.PageSize(), tt.expected)
-			}
-		})
-	}
-}
-
-func TestConvertToJSONQuery(t *testing.T) {
-	tests := []struct {
-		name     string
-		query    string
-		expected string
-	}{
-		{
-			name:     "regular SELECT",
-			query:    "SELECT * FROM users",
-			expected: "SELECT JSON * FROM users",
-		},
-		{
-			name:     "SELECT with columns",
-			query:    "SELECT id, name FROM users WHERE id = 1",
-			expected: "SELECT JSON id, name FROM users WHERE id = 1",
-		},
-		{
-			name:     "SELECT DISTINCT",
-			query:    "SELECT DISTINCT country FROM users",
-			expected: "SELECT DISTINCT JSON country FROM users",
-		},
-		{
-			name:     "SELECT DISTINCT with multiple columns",
-			query:    "SELECT DISTINCT city, country FROM users",
-			expected: "SELECT DISTINCT JSON city, country FROM users",
-		},
-		{
-			name:     "already SELECT JSON",
-			query:    "SELECT JSON * FROM users",
-			expected: "SELECT JSON * FROM users",
-		},
-		{
-			name:     "already SELECT DISTINCT JSON",
-			query:    "SELECT DISTINCT JSON country FROM users",
-			expected: "SELECT DISTINCT JSON country FROM users",
-		},
-		{
-			name:     "lowercase select",
-			query:    "select * from users",
-			expected: "SELECT JSON * from users",
-		},
-		{
-			name:     "lowercase select distinct",
-			query:    "select distinct country from users",
-			expected: "SELECT DISTINCT JSON country from users",
-		},
-		{
-			name:     "non-SELECT query",
-			query:    "INSERT INTO users (id) VALUES (1)",
-			expected: "INSERT INTO users (id) VALUES (1)",
-		},
-		{
-			name:     "UPDATE query",
-			query:    "UPDATE users SET name = 'foo'",
-			expected: "UPDATE users SET name = 'foo'",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertToJSONQuery(tt.query)
-			if !strings.EqualFold(result, tt.expected) && result != tt.expected {
-				t.Errorf("ConvertToJSONQuery(%q) = %q, want %q", tt.query, result, tt.expected)
 			}
 		})
 	}

--- a/internal/db/streaming_processor.go
+++ b/internal/db/streaming_processor.go
@@ -50,38 +50,43 @@ func NewStreamingProcessor(result StreamingQueryResult, session *Session) *Strea
 
 // LoadResults loads a batch of results from the iterator
 // Returns the formatted rows, whether more results exist, and any error
-func (sp *StreamingProcessor) LoadResults(ctx context.Context, maxRows int) ([][]string, bool, error) {
+func (sp *StreamingProcessor) LoadResults(ctx context.Context, maxRows int) (Page, error) {
 	if sp.iterator == nil {
-		return nil, false, fmt.Errorf("iterator is nil")
+		return Page{}, fmt.Errorf("iterator is nil")
 	}
 
-	rows := make([][]string, 0, maxRows)
-	rowCount := 0
+	page := Page{
+		Rows: make([][]string, 0, maxRows),
+		Raw:  make([]map[string]interface{}, 0, maxRows),
+	}
 
-	for rowCount < maxRows {
+	for len(page.Rows) < maxRows {
 		select {
 		case <-ctx.Done():
-			return rows, false, ctx.Err()
+			return page, ctx.Err()
 		default:
 			// Use MapScan to handle NULLs properly
 			rowMap := make(map[string]interface{})
 			if !sp.iterator.MapScan(rowMap) {
 				// No more rows or error occurred
 				if err := sp.iterator.Close(); err != nil {
-					return rows, false, fmt.Errorf("iterator error: %w", err)
+					return page, fmt.Errorf("iterator error: %w", err)
 				}
-				return rows, false, nil
+				return page, nil
 			}
 
-			// Convert row to string array
-			row := sp.formatRow(rowMap)
-			rows = append(rows, row)
-			rowCount++
+			// Both the values as they are drawn and the values themselves. The
+			// second set is what JSON is built from: a timestamp formatted for
+			// a table cell, or a collection written the way cqlsh writes one,
+			// cannot be turned back into what it came from.
+			page.Rows = append(page.Rows, sp.formatRow(rowMap))
+			page.Raw = append(page.Raw, rowMap)
 		}
 	}
 
 	// We loaded maxRows, there might be more
-	return rows, true, nil
+	page.HasMore = true
+	return page, nil
 }
 
 // formatRow formats a single row from MapScan results
@@ -175,12 +180,26 @@ func (sp *StreamingProcessor) GetColumnNames() []string {
 	return sp.columnNames
 }
 
+// Page is a batch of rows as they came back: the values as they are drawn, and
+// the values themselves.
+//
+// Both, because they answer different questions and neither can be got from the
+// other. The strings are what a table cell holds. The raw values are what JSON
+// is built from, and what the OUTPUT format could not be changed without: a
+// result fetched as JSON is one column of documents, and no amount of redrawing
+// turns that back into columns.
+type Page struct {
+	Rows    [][]string
+	Raw     []map[string]interface{}
+	HasMore bool
+}
+
 // StreamingResult represents a complete result that can be loaded progressively
 type StreamingResult struct {
 	Headers     []string
 	Rows        [][]string
 	HasMore     bool
-	LoadMore    func(ctx context.Context, count int) ([][]string, bool, error)
+	LoadMore    func(ctx context.Context, count int) (Page, error)
 	Close       func() error
 	ElapsedTime time.Duration
 }
@@ -193,12 +212,8 @@ func (s *Session) ProcessStreamingQuery(result StreamingQueryResult) *StreamingR
 		Headers: processor.GetHeaders(),
 		Rows:    [][]string{},
 		HasMore: true,
-		LoadMore: func(ctx context.Context, count int) ([][]string, bool, error) {
-			rows, hasMore, err := processor.LoadResults(ctx, count)
-			if err != nil {
-				return nil, false, err
-			}
-			return rows, hasMore, nil
+		LoadMore: func(ctx context.Context, count int) (Page, error) {
+			return processor.LoadResults(ctx, count)
 		},
 		Close: func() error {
 			return processor.Close()

--- a/internal/router/meta_commands.go
+++ b/internal/router/meta_commands.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/parquet"
@@ -21,7 +22,6 @@ import (
 type MetaCommandHandler struct {
 	session                 *db.Session
 	sessionManager          *session.Manager
-	expandMode              bool
 	autoSaveDir             string
 	lastAutoSaved           string // the file the last query went to, for the message
 	autoSaveCount           int    // which query this is, so two in a second do not collide
@@ -43,7 +43,6 @@ func NewMetaCommandHandler(session *db.Session, sessionMgr *session.Manager) *Me
 	return &MetaCommandHandler{
 		session:        session,
 		sessionManager: sessionMgr,
-		expandMode:     false,
 		captureFormat:  "text",
 	}
 }
@@ -156,7 +155,7 @@ func (h *MetaCommandHandler) handleShow(command string) interface{} {
 		result += fmt.Sprintf("Page size: %d\n", h.session.PageSize())
 		result += fmt.Sprintf("Tracing: %v\n", h.session.Tracing())
 		result += fmt.Sprintf("Auto-fetch: %v\n", h.session.AutoFetch())
-		result += fmt.Sprintf("Expand mode: %v", h.expandMode)
+		result += fmt.Sprintf("Expand mode: %v", h.expandMode())
 		return result
 	}
 
@@ -256,24 +255,48 @@ func (h *MetaCommandHandler) handleExpand(command string) interface{} {
 
 	switch len(parts) {
 	case 1:
-		if h.expandMode {
+		if h.expandMode() {
 			return "Expand mode is currently ON (vertical output)"
 		}
 		return "Expand mode is currently OFF (table output)"
 	case 2:
 		switch parts[1] {
 		case "ON":
-			h.expandMode = true
-			return "Expand mode turned ON - results will be shown vertically"
+			return h.setExpand(config.OutputFormatExpand,
+				"Expand mode turned ON - results will be shown vertically")
 		case "OFF":
-			h.expandMode = false
-			return "Expand mode turned OFF - results will be shown as tables"
+			return h.setExpand(config.OutputFormatTable,
+				"Expand mode turned OFF - results will be shown as tables")
 		default:
 			return "Usage: EXPAND ON | OFF"
 		}
 	default:
 		return "Usage: EXPAND ON | OFF"
 	}
+}
+
+// expandMode reports whether results are being drawn vertically.
+//
+// It was a flag of its own, set by EXPAND ON and read by nothing: the command
+// said results would be shown vertically and then nothing anywhere drew them
+// that way. EXPAND is the OUTPUT format called by another name, so it is that
+// setting, and one place to look when asking what the format is.
+func (h *MetaCommandHandler) expandMode() bool {
+	if h.sessionManager == nil {
+		return false
+	}
+	return h.sessionManager.GetOutputFormat() == config.OutputFormatExpand
+}
+
+// setExpand puts the output format where EXPAND says it should be.
+func (h *MetaCommandHandler) setExpand(format config.OutputFormat, said string) interface{} {
+	if h.sessionManager == nil {
+		return "Session manager not initialized"
+	}
+	if err := h.sessionManager.SetOutputFormat(format); err != nil {
+		return fmt.Sprintf("Failed to set output format: %v", err)
+	}
+	return said
 }
 
 // handleSource handles SOURCE command to execute CQL from file
@@ -566,7 +589,7 @@ func (h *MetaCommandHandler) parseValueForBinding(value string, _ string, _ stri
 
 // IsExpandMode returns whether expand mode is on
 func (h *MetaCommandHandler) IsExpandMode() bool {
-	return h.expandMode
+	return h.expandMode()
 }
 
 // FormatResultAsJSONWithRawData formats query results as JSON with optional raw data

--- a/internal/router/meta_commands_help.go
+++ b/internal/router/meta_commands_help.go
@@ -54,10 +54,11 @@ func HelpRows() [][]string {
 
 		// Output Control
 		{"─────────", "─────────", "─────────────"},
-		{"Output", "OUTPUT [format]", "Set output format:"},
+		{"Output", "OUTPUT [format]", "Set output format, and redraw what is on screen:"},
 		{"", "  TABLE", "Formatted table (default)"},
 		{"", "  JSON", "JSON format"},
-		{"", "  EXPAND", "Vertical format"},
+		{"", "  EXPAND", "Vertical format (EXPAND ON does the same)"},
+		{"", "  ASCII", "ASCII table"},
 		{"", "AUTOSAVE 'dir'", "Save each query's output into a directory"},
 		{"", "AUTOSAVE JSON 'dir'", "One JSON file per query"},
 		{"", "AUTOSAVE PARQUET 'dir'", "One Parquet file per query"},

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -16,8 +16,16 @@ var metaHandler *MetaCommandHandler
 var sessionManager *session.Manager
 
 // InitRouter initializes the router with a session manager
+//
+// The meta handler is built once, on the first command, and keeps whatever it
+// was given for the life of the process. Pointing the router at a manager and
+// leaving the handler on an older one is two managers answering the same
+// question - which is how EXPAND could set a format that OUTPUT did not see.
 func InitRouter(mgr *session.Manager) {
 	sessionManager = mgr
+	if metaHandler != nil {
+		metaHandler.sessionManager = mgr
+	}
 }
 
 // GetMetaHandler returns the current meta command handler
@@ -153,18 +161,13 @@ func ProcessCommand(command string, session *db.Session, sessionMgr *session.Man
 		logger.DebugToFile("ProcessCommand", "Routing to parseMetaCommand")
 		return parseMetaCommand(command, session, sessionMgr)
 	} else {
-		// Check if we need to transform SELECT to SELECT JSON
-		if sessionManager != nil && sessionManager.GetOutputFormat() == config.OutputFormatJSON {
-			// Check if it's a SELECT query that should be transformed (with word boundary)
-			if (upperCommand == "SELECT" || strings.HasPrefix(upperCommand, "SELECT ")) && !strings.Contains(upperCommand, "SELECT JSON") {
-				// Use db.ConvertToJSONQuery which properly handles SELECT DISTINCT
-				modifiedCommand := db.ConvertToJSONQuery(command)
-				if modifiedCommand != command {
-					logger.DebugfToFile("ProcessCommand", "Transformed query to: %s", modifiedCommand)
-					return session.ExecuteCQLQuery(modifiedCommand)
-				}
-			}
-		}
+		// OUTPUT JSON used to rewrite the query as SELECT JSON here, so what
+		// came back was one column of documents rather than the columns that
+		// were asked for. It answered the question and lost the result: the
+		// Results view could not draw it as a table, because the table was
+		// never fetched, and neither could SAVE or COPY. JSON is drawn from the
+		// values that come back, like every other format.
+
 		// Execute as regular CQL query
 		logger.DebugToFile("ProcessCommand", "Routing to executeCQLQuery")
 		result := session.ExecuteCQLQuery(command)

--- a/internal/ui/horizontal_scroll_test.go
+++ b/internal/ui/horizontal_scroll_test.go
@@ -22,11 +22,12 @@ func wideResults(t *testing.T, format config.OutputFormat) *MainModel {
 	m := queryResultModel(t)
 	m.tableViewport.SetWidth(40)
 	m.columnWidths = []int{8, 8}
+	require.NoError(t, m.sessionManager.SetOutputFormat(format))
 	m.showQueryResult([][]string{
 		{"id", "payload"},
 		{"1", strings.Repeat("a", 300)},
 		{"2", strings.Repeat("b", 300)},
-	}, nil, format)
+	}, nil)
 	return m
 }
 
@@ -127,7 +128,8 @@ func TestANewResultStartsAtTheLeftEdge(t *testing.T) {
 	}
 	require.Positive(t, m.tableViewport.XOffset())
 
-	m.showQueryResult([][]string{{"id"}, {"1"}}, nil, config.OutputFormatASCII)
+	require.NoError(t, m.sessionManager.SetOutputFormat(config.OutputFormatASCII))
+	m.showQueryResult([][]string{{"id"}, {"1"}}, nil)
 
 	assert.Zero(t, m.horizontalOffset)
 	assert.Zero(t, m.tableViewport.XOffset())
@@ -137,7 +139,8 @@ func TestANewResultStartsAtTheLeftEdge(t *testing.T) {
 func TestNarrowContentDoesNotScroll(t *testing.T) {
 	m := queryResultModel(t)
 	m.tableViewport.SetWidth(80)
-	m.showQueryResult([][]string{{"id"}, {"1"}}, nil, config.OutputFormatASCII)
+	require.NoError(t, m.sessionManager.SetOutputFormat(config.OutputFormatASCII))
+	m.showQueryResult([][]string{{"id"}, {"1"}}, nil)
 
 	for name, scroll := range scrollRight {
 		scroll(m)

--- a/internal/ui/keyboard_handler_enter.go
+++ b/internal/ui/keyboard_handler_enter.go
@@ -192,7 +192,7 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 	}
 
 	start := time.Now()
-	result := router.ProcessCommand(command, m.session, m.sessionManager)
+	result := m.processCommand(command)
 	m.lastQueryTime = time.Since(start)
 
 	// Add command to history viewport

--- a/internal/ui/keyboard_handler_enter_modal.go
+++ b/internal/ui/keyboard_handler_enter_modal.go
@@ -7,7 +7,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/axonops/cqlai/internal/logger"
-	"github.com/axonops/cqlai/internal/router"
 )
 
 // handleModalConfirmation handles Enter key when a modal is showing
@@ -50,7 +49,7 @@ func (m *MainModel) answerModal(choice int) (*MainModel, tea.Cmd) {
 
 		// Process the command
 		start := time.Now()
-		result := router.ProcessCommand(command, m.session, m.sessionManager)
+		result := m.processCommand(command)
 		m.lastQueryTime = time.Since(start)
 
 		// Add command to full history and viewport

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -9,7 +9,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/db"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
@@ -123,7 +122,7 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 	maxInitialRows := m.initialRowsToLoad()
 
 	// Load initial rows from the streaming processor
-	initialRows, hasMore, err := streamingResult.LoadMore(ctx, maxInitialRows)
+	page, err := streamingResult.LoadMore(ctx, maxInitialRows)
 	if err != nil {
 		logger.DebugfToFile("HandleEnterKey", "Error loading initial rows: %v", err)
 		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render(fmt.Sprintf("Error: %v", err))
@@ -136,15 +135,15 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 	}
 
 	// Add rows to sliding window
-	for _, row := range initialRows {
-		m.slidingWindow.AddRow(row)
+	for i, row := range page.Rows {
+		m.slidingWindow.AddRow(row, rawAt(page.Raw, i))
 	}
 
-	logger.DebugfToFile("HandleEnterKey", "Loaded %d initial rows", len(initialRows))
+	logger.DebugfToFile("HandleEnterKey", "Loaded %d initial rows", len(page.Rows))
 	logger.DebugfToFile("HandleEnterKey", "Sliding window has %d rows", len(m.slidingWindow.Rows))
 
 	// Check if we got any data
-	if len(initialRows) == 0 {
+	if len(page.Rows) == 0 {
 		// No data returned
 		m.fullHistoryContent += "\n" + "No results"
 		m.updateHistoryWrapping()
@@ -157,7 +156,7 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 
 	// Store the streaming result in sliding window for progressive loading
 	m.slidingWindow.streamingResult = streamingResult
-	m.slidingWindow.hasMoreData = hasMore
+	m.slidingWindow.hasMoreData = page.HasMore
 
 	// If auto-fetch is enabled, fetch all remaining pages immediately
 	if m.session != nil && m.session.AutoFetch() && m.slidingWindow.hasMoreData {
@@ -195,47 +194,35 @@ func (m *MainModel) processStreamingQueryResult(command string, v db.StreamingQu
 
 	logger.DebugfToFile("HandleEnterKey", "Row count set to %d", m.rowCount)
 
-	// Prepare display based on format
-	outputFormat := config.OutputFormatTable
-	if m.sessionManager != nil {
-		outputFormat = m.sessionManager.GetOutputFormat()
-		logger.DebugfToFile("HandleEnterKey", "Got output format from session manager: %v", outputFormat)
-	}
-	logger.DebugfToFile("HandleEnterKey", "Using output format: %v", outputFormat)
-
-	switch outputFormat {
-	case config.OutputFormatExpand:
-		return m.displayExpandFormat(v.Headers, v.ColumnTypes)
-	case config.OutputFormatASCII:
-		return m.displayASCIIFormat(v.Headers, v.ColumnTypes)
-	case config.OutputFormatJSON:
-		return m.displayJSONFormat(v.Headers, v.ColumnTypes, v.ColumnNames)
-	default:
-		return m.displayTableFormat(v.Headers, v.ColumnTypes)
-	}
+	return m.displayResult(v.Headers, v.ColumnTypes)
 }
 
-// displayExpandFormat displays results in expanded vertical format
-func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) (*MainModel, tea.Cmd) {
-	// EXPAND format - use table viewport for pagination support
+// displayResult puts a streaming result on screen, in the format OUTPUT is set
+// to.
+//
+// There were four of these, one per format, and between them they were where
+// the format got written down a third time: each set m.resultFormat itself,
+// and which one ran was decided by a switch somewhere else. They differed in
+// two lines - whether to pull the rest of the rows in first - so that is all
+// that is left of them.
+func (m *MainModel) displayResult(headers, columnTypes []string) (*MainModel, tea.Cmd) {
 	m.tableHeaders = headers
 	m.columnTypes = columnTypes
-	m.resultFormat = config.OutputFormatExpand
 	m.hasTable = true
 	m.viewMode = "table"
 	m.initialColumnWidths = nil // Reset initial widths for new table
 	m.cachedTableLines = nil    // Clear cache for new table
-
-	// Format initial data as expanded vertical format
-	allData := append([][]string{headers}, m.slidingWindow.Rows...)
-	m.lastTableData = allData // Store for pagination
 	m.resetHorizontalScroll()
 
-	// Format as expanded vertical table. The boundaries have to come from this
-	// layout: paging snaps to them, and a record here is many lines tall.
-	expandStr, boundaries := FormatExpandTableWithBoundaries(allData, m.styles)
-	m.tableRowBoundaries = boundaries
-	m.tableViewport.SetContent(expandStr)
+	format := m.outputFormat()
+	if onePassFormat(format) {
+		// AutoFetch only decides how much is pulled in; the result goes to the
+		// Results view either way, in every format.
+		m.fetchAllPages(string(format))
+	}
+
+	logger.DebugfToFile("HandleEnterKey", "Showing %d rows as %v", len(m.slidingWindow.Rows), format)
+	m.renderResults(m.resultRows())
 	m.tableViewport.GotoTop()
 
 	m.input.Reset()
@@ -244,7 +231,7 @@ func (m *MainModel) displayExpandFormat(headers []string, columnTypes []string) 
 
 // showQueryResult draws a result that arrived complete, in whatever format
 // OUTPUT is set to.
-func (m *MainModel) showQueryResult(data [][]string, columnTypes []string, outputFormat config.OutputFormat) {
+func (m *MainModel) showQueryResult(data [][]string, columnTypes []string, raw ...[]map[string]interface{}) {
 	if len(data) == 0 {
 		return
 	}
@@ -253,44 +240,33 @@ func (m *MainModel) showQueryResult(data [][]string, columnTypes []string, outpu
 	// written into the console as text instead, where it is wrapped to the
 	// window - which breaks an ASCII table's borders mid-row and gives up
 	// the sideways scrolling that wide output needs.
-	m.lastTableData = data
 	m.tableHeaders = data[0]
 	m.columnTypes = columnTypes
-	m.resultFormat = outputFormat
+	m.lastRawData = nil
+	if len(raw) > 0 {
+		m.lastRawData = raw[0]
+	}
 	m.resetHorizontalScroll()
 	m.hasTable = true
 	m.viewMode = "table"
 	m.initialColumnWidths = nil // Reset initial widths for new table
 	m.cachedTableLines = nil    // Clear cache for new table
-	m.tableRowBoundaries = nil
 
-	var content string
-	switch outputFormat {
-	case config.OutputFormatASCII:
-		content = FormatASCIITableWithTypes(data, columnTypes)
-	case config.OutputFormatJSON:
-		content = formatRowsAsJSON(data)
-	case config.OutputFormatExpand:
-		var boundaries []int
-		content, boundaries = FormatExpandTableWithBoundaries(data, m.styles)
-		m.tableRowBoundaries = boundaries
-	default:
-		content = m.formatTableForViewport(data)
-	}
-	if content == "" {
-		content = "No results"
-	}
+	// This result arrived whole. Any sliding window belongs to an earlier
+	// streaming one, and left in place it would answer for this result: how
+	// many rows are showing, whether there are more, and which rows to draw
+	// when the format changes.
+	m.slidingWindow = nil
 
-	m.tableViewport.SetContent(content)
+	m.renderResults(data)
 	m.tableViewport.GotoTop()
-	m.tableWidth = widestLine(content)
 }
 
 // jsonLines renders rows as one JSON object per line.
 //
 // A SELECT JSON already comes back as JSON in a single "[json]" column, so that
 // is passed through rather than wrapped in an object a second time.
-func jsonLines(headers []string, rows [][]string) string {
+func jsonLines(headers []string, rows [][]string, raw []map[string]interface{}) string {
 	var b strings.Builder
 
 	if len(headers) == 1 && headers[0] == "[json]" {
@@ -302,26 +278,60 @@ func jsonLines(headers []string, rows [][]string) string {
 		return b.String()
 	}
 
-	for _, row := range rows {
-		object := make(map[string]interface{}, len(headers))
-		for i, header := range headers {
-			if i < len(row) {
-				object[header] = row[i]
+	for i, row := range rows {
+		b.WriteByte('{')
+		for c, header := range headers {
+			if c > 0 {
+				b.WriteByte(',')
 			}
+			name := db.StripKeyMarker(header)
+			key, _ := json.Marshal(name)
+			b.Write(key)
+			b.WriteByte(':')
+			b.Write(jsonCell(name, row, c, rawRow(raw, i)))
 		}
-		if encoded, err := json.Marshal(object); err == nil {
-			b.WriteString(string(encoded) + "\n")
-		}
+		b.WriteString("}\n")
 	}
 	return b.String()
 }
 
+// jsonCell is one value, written from what it was rather than from how it is
+// drawn where that is still in hand.
+//
+// The string in the cell is a fallback: it is what a grid the shell made up has
+// instead of values, and what is left of a row whose values were dropped.
+func jsonCell(name string, row []string, i int, raw map[string]interface{}) []byte {
+	if value, ok := raw[name]; ok {
+		if encoded, err := json.Marshal(db.JSONValue(value)); err == nil {
+			return encoded
+		}
+	}
+
+	cell := ""
+	if i < len(row) {
+		cell = row[i]
+	}
+	encoded, err := json.Marshal(cell)
+	if err != nil {
+		return []byte(`""`)
+	}
+	return encoded
+}
+
+// rawRow is the values behind a row, or nil when there are none.
+func rawRow(raw []map[string]interface{}, i int) map[string]interface{} {
+	if i < len(raw) {
+		return raw[i]
+	}
+	return nil
+}
+
 // formatRowsAsJSON renders a result whose first row is its headers.
-func formatRowsAsJSON(data [][]string) string {
+func formatRowsAsJSON(data [][]string, raw []map[string]interface{}) string {
 	if len(data) < 2 {
 		return ""
 	}
-	return jsonLines(data[0], data[1:])
+	return jsonLines(data[0], data[1:], raw)
 }
 
 // widestLine is the width of the longest line, for horizontal scrolling.
@@ -367,122 +377,6 @@ func (m *MainModel) fetchAllPages(format string) {
 	m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 }
 
-// displayASCIIFormat displays results in ASCII table format
-func (m *MainModel) displayASCIIFormat(headers []string, columnTypes []string) (*MainModel, tea.Cmd) {
-	logger.DebugToFile("HandleEnterKey", "Formatting output as ASCII")
-
-	// Store headers and types for table view
-	m.tableHeaders = headers
-	m.columnTypes = columnTypes
-	m.resultFormat = config.OutputFormatASCII
-
-	// AutoFetch only decides how much is pulled in; the result goes to the
-	// Results view either way, the same as TABLE and EXPAND.
-	m.fetchAllPages("ASCII")
-
-	m.hasTable = true
-	m.viewMode = "table"
-	m.resetHorizontalScroll()
-	m.initialColumnWidths = nil // Reset initial widths for new table
-	m.cachedTableLines = nil    // Clear cache for new table
-
-	allData := append([][]string{headers}, m.slidingWindow.Rows...)
-	m.lastTableData = allData
-
-	asciiStr := FormatASCIITableWithTypes(allData, columnTypes)
-
-	// Add notice about more data if applicable. AutoFetch will have taken the
-	// lot already, so this only shows when it is off.
-	if m.slidingWindow.hasMoreData {
-		asciiStr += "\n" + m.styles.MutedText.Render(
-			fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
-				len(m.slidingWindow.Rows)))
-	}
-
-	// Set content in table viewport
-	// No record boundaries in this layout; stale ones would cap scrolling.
-	m.tableRowBoundaries = nil
-	m.tableViewport.SetContent(asciiStr)
-	m.tableViewport.GotoTop()
-
-	// Calculate width for horizontal scrolling
-	m.tableWidth = widestLine(asciiStr)
-
-	m.input.Reset()
-	return m, nil
-}
-
-// displayJSONFormat displays results in JSON format
-func (m *MainModel) displayJSONFormat(headers []string, columnTypes []string, columnNames []string) (*MainModel, tea.Cmd) {
-	logger.DebugToFile("HandleEnterKey", "Formatting output as JSON")
-
-	// Store headers and types for table view
-	m.tableHeaders = headers
-	m.columnTypes = columnTypes
-	m.resultFormat = config.OutputFormatJSON
-
-	// AutoFetch only decides how much is pulled in; the result goes to the
-	// Results view either way, the same as TABLE and EXPAND.
-	m.fetchAllPages("JSON")
-
-	m.hasTable = true
-	m.viewMode = "table"
-	m.resetHorizontalScroll()
-	m.initialColumnWidths = nil // Reset initial widths for new table
-	m.cachedTableLines = nil    // Clear cache for new table
-
-	allData := append([][]string{headers}, m.slidingWindow.Rows...)
-	m.lastTableData = allData
-
-	jsonStr := jsonLines(headers, m.slidingWindow.Rows)
-
-	// Add notice about more data if applicable. AutoFetch will have taken the
-	// lot already, so this only shows when it is off.
-	if m.slidingWindow.hasMoreData {
-		jsonStr += "\n" + m.styles.MutedText.Render(
-			fmt.Sprintf("(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
-				len(m.slidingWindow.Rows)))
-	}
-
-	// Set content in table viewport
-	// No record boundaries in this layout; stale ones would cap scrolling.
-	m.tableRowBoundaries = nil
-	m.tableViewport.SetContent(jsonStr)
-	m.tableViewport.GotoTop()
-
-	// Calculate width for horizontal scrolling
-	m.tableWidth = widestLine(jsonStr)
-
-	m.input.Reset()
-	return m, nil
-}
-
-// displayTableFormat displays results in table format
-func (m *MainModel) displayTableFormat(headers []string, columnTypes []string) (*MainModel, tea.Cmd) {
-	// TABLE format - use table viewport
-	m.tableHeaders = headers
-	m.columnTypes = columnTypes
-	m.resultFormat = config.OutputFormatTable
-	m.hasTable = true
-	m.viewMode = "table"
-	m.initialColumnWidths = nil // Reset initial widths for new table
-	m.cachedTableLines = nil    // Clear cache for new table
-
-	// Format initial data for display
-	allData := append([][]string{headers}, m.slidingWindow.Rows...)
-	m.lastTableData = allData // Store for horizontal scrolling
-	m.resetHorizontalScroll()
-	logger.DebugfToFile("HandleEnterKey", "Formatting table with %d rows (including header)", len(allData))
-	tableStr := m.formatTableForViewport(allData)
-	logger.DebugfToFile("HandleEnterKey", "Table string length: %d", len(tableStr))
-	m.tableViewport.SetContent(tableStr)
-	m.tableViewport.GotoTop()
-	logger.DebugfToFile("HandleEnterKey", "Table viewport content set, viewMode: %s", m.viewMode)
-
-	m.input.Reset()
-	return m, nil
-}
-
 // processQueryResult handles QueryResult type
 func (m *MainModel) processQueryResult(command string, v db.QueryResult) (*MainModel, tea.Cmd) {
 	// Query result with metadata
@@ -493,14 +387,8 @@ func (m *MainModel) processQueryResult(command string, v db.QueryResult) (*MainM
 
 		m.rowCount = v.RowCount
 
-		// Get output format from session manager
-		outputFormat := config.OutputFormatTable
-		if m.sessionManager != nil {
-			outputFormat = m.sessionManager.GetOutputFormat()
-		}
-		logger.DebugfToFile("keyboard_handler_enter", "QueryResult Format: %v", outputFormat)
-
-		m.showQueryResult(v.Data, v.ColumnTypes, outputFormat)
+		logger.DebugfToFile("keyboard_handler_enter", "QueryResult Format: %v", m.outputFormat())
+		m.showQueryResult(v.Data, v.ColumnTypes, v.RawData)
 
 		// Write to the AutoSave file, unless the router already did: a streaming
 		// result is drained there and handed on as an ordinary QueryResult, and
@@ -543,16 +431,22 @@ func (m *MainModel) processTableResult(command string, v [][]string) (*MainModel
 		// the header's detail row reads them by index and PARQUET builds a
 		// schema from them, so both would be quietly wrong.
 		m.columnTypes = nil
-		m.resultFormat = config.OutputFormatTable
+		m.lastRawData = nil
 		m.resetHorizontalScroll()
 		m.hasTable = true
 		m.viewMode = "table"
 		m.initialColumnWidths = nil // Reset initial widths for new table
 		m.cachedTableLines = nil    // Clear cache for new table
 
-		// Format and display in table viewport
-		tableStr := m.formatTableForViewport(v)
-		m.tableViewport.SetContent(tableStr)
+		// Nothing streamed this, so there is no window of rows to page: what is
+		// on screen is all of it.
+		m.slidingWindow = nil
+
+		// Drawn in whatever OUTPUT is set to, like every other result. It used
+		// to force the boxed table, which was a rule nothing else followed and
+		// one that changing the format on screen would have broken anyway: a
+		// grid drawn one way and redrawn another.
+		m.renderResults(v)
 		m.tableViewport.GotoTop() // Start at top of table
 
 		// Write to capture file if capturing

--- a/internal/ui/keyboard_navigation_pager.go
+++ b/internal/ui/keyboard_navigation_pager.go
@@ -486,13 +486,9 @@ func (m *MainModel) loadMoreTableDataHelper() {
 			}
 		}
 
-		// Update the table data and refresh the view
-		allData := append([][]string{m.slidingWindow.Headers}, m.slidingWindow.Rows...)
 		// Clear cache to force rebuild
 		m.cachedTableLines = nil
-		// NOTE: Don't update m.lastTableData - formatTableForViewport will handle it
-
-		m.refreshTableContent(allData)
+		m.renderResults(m.resultRows())
 
 		// Update row count
 		m.rowCount = int(m.slidingWindow.TotalRowsSeen)

--- a/internal/ui/keyboard_navtigation.go
+++ b/internal/ui/keyboard_navtigation.go
@@ -145,12 +145,9 @@ func (m *MainModel) handlePageDown(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
 						}
 					}
 
-					// Update the table data and refresh the view
-					allData := append([][]string{m.slidingWindow.Headers}, m.slidingWindow.Rows...)
 					// Clear cache to force rebuild
 					m.cachedTableLines = nil
-
-					m.refreshTableContent(allData)
+					m.renderResults(m.resultRows())
 
 					// Update row count
 					m.rowCount = int(m.slidingWindow.TotalRowsSeen)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -124,6 +124,11 @@ type MainModel struct {
 	help             helpWindow     // Open help window, if any
 	capture          capturePanel   // Open capture window, if any
 	preferences      preferences    // Open PREFERENCES window, if any
+
+	// lastRawData is the values behind lastTableData for a result that arrived
+	// whole, so JSON is written from what came back rather than from what was
+	// drawn in the cells.
+	lastRawData []map[string]interface{}
 	// completingPath says the candidates on offer are filenames rather than
 	// CQL words. Applying one has to keep the directory in front of it; the
 	// word-based path would replace /tmp/rep with report.csv and lose the /tmp.

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
-
 	tea "charm.land/bubbletea/v2"
 	"github.com/axonops/cqlai/internal/logger"
 	"github.com/axonops/cqlai/internal/router"
@@ -506,53 +504,13 @@ func (m *MainModel) loadMoreTableData() {
 			}
 		}
 
-		// Update the table data and refresh the view
-		allData := append([][]string{m.slidingWindow.Headers}, m.slidingWindow.Rows...)
-
 		// Clear cache to force rebuild (important!)
 		m.cachedTableLines = nil
-		m.lastTableData = allData
-
-		m.refreshTableContent(allData)
+		m.renderResults(m.resultRows())
 
 		// Update row count
 		m.rowCount = int(m.slidingWindow.TotalRowsSeen)
 	}
-}
-
-// Helper function to format table as JSON
-func (m *MainModel) formatTableAsJSON() string {
-	if m.slidingWindow == nil {
-		return ""
-	}
-
-	// Check if we have a single [json] column from SELECT JSON
-	if len(m.slidingWindow.Headers) == 1 && m.slidingWindow.Headers[0] == "[json]" {
-		// This is already JSON from SELECT JSON - just extract it
-		jsonStr := ""
-		for _, row := range m.slidingWindow.Rows {
-			if len(row) > 0 {
-				jsonStr += row[0] + "\n"
-			}
-		}
-		return jsonStr
-	}
-
-	// Convert regular table data to JSON
-	jsonStr := ""
-	for _, row := range m.slidingWindow.Rows {
-		jsonMap := make(map[string]interface{})
-		for i, header := range m.slidingWindow.Headers {
-			if i < len(row) {
-				jsonMap[header] = row[i]
-			}
-		}
-		jsonBytes, err := json.Marshal(jsonMap)
-		if err == nil {
-			jsonStr += string(jsonBytes) + "\n"
-		}
-	}
-	return jsonStr
 }
 
 // clickTab switches to whichever mode's tab covers a column.

--- a/internal/ui/output_view_test.go
+++ b/internal/ui/output_view_test.go
@@ -8,39 +8,54 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	"github.com/axonops/cqlai/internal/config"
 	"github.com/axonops/cqlai/internal/db"
+	"github.com/axonops/cqlai/internal/router"
+	session2 "github.com/axonops/cqlai/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // outputModel builds a model holding one page of a result, with a second page
-// still to come.
-func outputModel(t *testing.T, autoFetch bool) *MainModel {
+// still to come, with OUTPUT set to the given format.
+func outputModel(t *testing.T, autoFetch bool, format config.OutputFormat) *MainModel {
 	t.Helper()
 
 	session := &db.Session{}
 	session.SetAutoFetch(autoFetch)
 
+	manager := session2.NewManager(&config.Config{})
+	require.NoError(t, manager.SetOutputFormat(format))
+
+	// OUTPUT is answered by the router, which keeps its own pointer to the
+	// manager: without this a command in a test would set the format somewhere
+	// the model is not looking.
+	router.InitRouter(manager)
+	t.Cleanup(func() { router.InitRouter(nil) })
+
 	window := NewSlidingWindowTable(1000, 10)
 	window.Headers = []string{"id", "name"}
 	window.ColumnNames = window.Headers
 	for _, row := range [][]string{{"1", "alice"}, {"2", "bob"}} {
-		window.AddRow(row)
+		window.AddRow(row, rowValues(window.Headers, row))
 	}
 
 	// A second page, delivered once and then exhausted.
 	remaining := [][]string{{"3", "carol"}, {"4", "dave"}}
 	window.hasMoreData = true
 	window.streamingResult = &db.StreamingResult{
-		LoadMore: func(_ context.Context, _ int) ([][]string, bool, error) {
-			rows := remaining
+		LoadMore: func(_ context.Context, _ int) (db.Page, error) {
+			page := db.Page{Rows: remaining}
+			for _, row := range remaining {
+				page.Raw = append(page.Raw, rowValues(window.Headers, row))
+			}
 			remaining = nil
-			return rows, false, nil
+			return page, nil
 		},
 	}
 
 	return &MainModel{
 		styles:          DefaultStyles(),
 		session:         session,
+		sessionManager:  manager,
 		windowWidth:     100,
 		windowHeight:    30,
 		viewMode:        "history",
@@ -58,10 +73,10 @@ func outputModel(t *testing.T, autoFetch bool) *MainModel {
 // half - and the Results view is where it can scroll sideways instead.
 func TestASCIIResultsGoToTheResultsView(t *testing.T) {
 	for _, autoFetch := range []bool{false, true} {
-		m := outputModel(t, autoFetch)
+		m := outputModel(t, autoFetch, config.OutputFormatASCII)
 		before := m.fullHistoryContent
 
-		m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+		m.displayResult(m.slidingWindow.Headers, nil)
 
 		assert.Equal(t, "table", m.viewMode, "AutoFetch %v", autoFetch)
 		assert.True(t, m.hasTable, "AutoFetch %v", autoFetch)
@@ -74,10 +89,10 @@ func TestASCIIResultsGoToTheResultsView(t *testing.T) {
 // TestJSONResultsGoToTheResultsView: the same bug, in the other format.
 func TestJSONResultsGoToTheResultsView(t *testing.T) {
 	for _, autoFetch := range []bool{false, true} {
-		m := outputModel(t, autoFetch)
+		m := outputModel(t, autoFetch, config.OutputFormatJSON)
 		before := m.fullHistoryContent
 
-		m.displayJSONFormat(m.slidingWindow.Headers, nil, m.slidingWindow.ColumnNames)
+		m.displayResult(m.slidingWindow.Headers, nil)
 
 		assert.Equal(t, "table", m.viewMode, "AutoFetch %v", autoFetch)
 		assert.True(t, m.hasTable, "AutoFetch %v", autoFetch)
@@ -90,9 +105,9 @@ func TestJSONResultsGoToTheResultsView(t *testing.T) {
 // TestAutoFetchStillFetchesEverything. It decides how much is pulled in, which
 // is the part that should not have changed.
 func TestAutoFetchStillFetchesEverything(t *testing.T) {
-	m := outputModel(t, true)
+	m := outputModel(t, true, config.OutputFormatASCII)
 
-	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+	m.displayResult(m.slidingWindow.Headers, nil)
 
 	assert.False(t, m.slidingWindow.hasMoreData, "AutoFetch should have taken the rest")
 	assert.Len(t, m.slidingWindow.Rows, 4)
@@ -101,9 +116,9 @@ func TestAutoFetchStillFetchesEverything(t *testing.T) {
 
 // TestWithoutAutoFetchTheRestIsLeft, and the notice says so.
 func TestWithoutAutoFetchTheRestIsLeft(t *testing.T) {
-	m := outputModel(t, false)
+	m := outputModel(t, false, config.OutputFormatASCII)
 
-	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+	m.displayResult(m.slidingWindow.Headers, nil)
 
 	assert.True(t, m.slidingWindow.hasMoreData)
 	assert.Len(t, m.slidingWindow.Rows, 2)
@@ -113,9 +128,9 @@ func TestWithoutAutoFetchTheRestIsLeft(t *testing.T) {
 // TestTheNoticeIsGoneOnceEverythingIsFetched: it tells you to press PgDn for
 // rows that are already on screen otherwise.
 func TestTheNoticeIsGoneOnceEverythingIsFetched(t *testing.T) {
-	m := outputModel(t, true)
+	m := outputModel(t, true, config.OutputFormatASCII)
 
-	m.displayASCIIFormat(m.slidingWindow.Headers, nil)
+	m.displayResult(m.slidingWindow.Headers, nil)
 
 	assert.NotContains(t, stripAnsiForTest(m.tableViewport.GetContent()), "More data available")
 }
@@ -123,17 +138,15 @@ func TestTheNoticeIsGoneOnceEverythingIsFetched(t *testing.T) {
 // TestAllFourFormatsAgreeOnWhereResultsGo. ASCII and JSON were the odd ones
 // out; TABLE and EXPAND always used the Results view.
 func TestAllFourFormatsAgreeOnWhereResultsGo(t *testing.T) {
-	display := map[string]func(m *MainModel){
-		"ASCII":  func(m *MainModel) { m.displayASCIIFormat(m.slidingWindow.Headers, nil) },
-		"JSON":   func(m *MainModel) { m.displayJSONFormat(m.slidingWindow.Headers, nil, m.slidingWindow.ColumnNames) },
-		"EXPAND": func(m *MainModel) { m.displayExpandFormat(m.slidingWindow.Headers, nil) },
-	}
+	for _, format := range config.OutputFormats() {
+		parsed, err := config.ParseOutputFormat(format)
+		require.NoError(t, err)
 
-	for name, show := range display {
 		for _, autoFetch := range []bool{false, true} {
-			m := outputModel(t, autoFetch)
-			show(m)
-			assert.Equal(t, "table", m.viewMode, "%s with AutoFetch %v", name, autoFetch)
+			m := outputModel(t, autoFetch, parsed)
+			m.displayResult(m.slidingWindow.Headers, nil)
+			assert.Equal(t, "table", m.viewMode, "%s with AutoFetch %v", format, autoFetch)
+			assert.Equal(t, parsed, m.resultFormat, "%s with AutoFetch %v", format, autoFetch)
 		}
 	}
 }
@@ -157,7 +170,7 @@ func queryResultModel(t *testing.T) *MainModel {
 
 	return &MainModel{
 		styles:          DefaultStyles(),
-		sessionManager:  nil,
+		sessionManager:  session2.NewManager(&config.Config{}),
 		windowWidth:     100,
 		windowHeight:    30,
 		viewMode:        "history",
@@ -184,8 +197,9 @@ func TestEveryFormatUsesTheResultsViewOnTheDirectPath(t *testing.T) {
 	} {
 		m := queryResultModel(t)
 		before := m.fullHistoryContent
+		require.NoError(t, m.sessionManager.SetOutputFormat(format))
 
-		m.showQueryResult(data, nil, format)
+		m.showQueryResult(data, nil)
 
 		assert.Equal(t, "table", m.viewMode, "%s", format)
 		assert.True(t, m.hasTable, "%s", format)
@@ -198,7 +212,7 @@ func TestEveryFormatUsesTheResultsViewOnTheDirectPath(t *testing.T) {
 
 // TestJSONIsOneObjectPerRow.
 func TestJSONIsOneObjectPerRow(t *testing.T) {
-	out := formatRowsAsJSON([][]string{{"id", "name"}, {"1", "alice"}, {"2", "bob"}})
+	out := formatRowsAsJSON([][]string{{"id", "name"}, {"1", "alice"}, {"2", "bob"}}, nil)
 
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	require.Len(t, lines, 2)
@@ -208,14 +222,14 @@ func TestJSONIsOneObjectPerRow(t *testing.T) {
 
 // TestSelectJSONIsPassedThrough rather than wrapped in another object.
 func TestSelectJSONIsPassedThrough(t *testing.T) {
-	out := formatRowsAsJSON([][]string{{"[json]"}, {`{"id": 1}`}, {`{"id": 2}`}})
+	out := formatRowsAsJSON([][]string{{"[json]"}, {`{"id": 1}`}, {`{"id": 2}`}}, nil)
 
 	assert.Equal(t, "{\"id\": 1}\n{\"id\": 2}\n", out)
 }
 
 func TestNoRowsIsNoJSON(t *testing.T) {
-	assert.Empty(t, formatRowsAsJSON([][]string{{"id"}}))
-	assert.Empty(t, formatRowsAsJSON(nil))
+	assert.Empty(t, formatRowsAsJSON([][]string{{"id"}}, nil))
+	assert.Empty(t, formatRowsAsJSON(nil, nil))
 }
 
 // resultsModel puts content into the Results view as a given format, the way a
@@ -225,7 +239,8 @@ func resultsModel(t *testing.T, format config.OutputFormat, data [][]string) *Ma
 
 	m := queryResultModel(t)
 	m.columnWidths = []int{8, 8} // left over from an earlier table render
-	m.showQueryResult(data, nil, format)
+	require.NoError(t, m.sessionManager.SetOutputFormat(format))
+	m.showQueryResult(data, nil)
 	return m
 }
 
@@ -310,4 +325,16 @@ func TestNarrowContentDoesNotScrollSideways(t *testing.T) {
 	m.handleMouseWheelRight()
 
 	assert.Zero(t, m.horizontalOffset)
+}
+
+// rowValues is a row as the values behind it, which a real result carries and a
+// test has to make up.
+func rowValues(headers []string, row []string) map[string]interface{} {
+	values := make(map[string]interface{}, len(headers))
+	for i, header := range headers {
+		if i < len(row) {
+			values[header] = row[i]
+		}
+	}
+	return values
 }

--- a/internal/ui/result_view.go
+++ b/internal/ui/result_view.go
@@ -1,0 +1,181 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/axonops/cqlai/internal/router"
+)
+
+// Drawing a result into the Results view.
+//
+// One function does it, for every format and from every path that puts rows on
+// screen: the first display of a result, another page of rows arriving, and now
+// a change of OUTPUT while the result is still up.
+//
+// It was four display functions and a refresh, each setting some of what the
+// view needs and leaving the rest. That is why the format ended up written in
+// three places - the session manager, m.resultFormat, and whichever display
+// function last ran - and why the width the sideways scrolling clamps against
+// was only ever set when a result first arrived.
+
+// outputFormat is what OUTPUT is set to, or TABLE when there is nothing to ask.
+func (m *MainModel) outputFormat() config.OutputFormat {
+	if m.sessionManager == nil {
+		return config.OutputFormatTable
+	}
+	return m.sessionManager.GetOutputFormat()
+}
+
+// renderResults draws allData - its first row the headers - into the Results
+// view, and leaves behind everything that describes what it drew.
+//
+// Paging snaps scroll offsets to tableRowBoundaries. Those are line numbers, so
+// they only mean anything for the layout that produced them and have to be
+// replaced whenever the content is. Leaving stale ones behind caps scrolling:
+// boundaries from the boxed table, where a record is one line, cannot reach past
+// the row count in expand format, where a record is as tall as the table is wide.
+func (m *MainModel) renderResults(allData [][]string) {
+	format := m.outputFormat()
+	m.resultFormat = format
+
+	var (
+		content    string
+		boundaries []int
+	)
+	switch format {
+	case config.OutputFormatASCII:
+		content = FormatASCIITableWithTypes(allData, m.columnTypes)
+	case config.OutputFormatJSON:
+		content = formatRowsAsJSON(allData, m.rawRows())
+	case config.OutputFormatExpand:
+		content, boundaries = FormatExpandTableWithBoundaries(allData, m.styles)
+	default:
+		content = m.formatTableForViewport(allData)
+		boundaries = m.tableRowBoundaries // filled in while rendering
+	}
+
+	content += m.moreRowsNotice(format)
+	if content == "" {
+		content = "No results"
+	}
+
+	m.tableRowBoundaries = boundaries
+	m.tableViewport.SetContent(content)
+
+	// What was drawn, so the cache check and anything else asking what is on
+	// screen agree with the screen. Set after rendering: isSameTableData
+	// compares against it to decide whether the boxed table needs rebuilding,
+	// and setting it first would answer yes to every question.
+	m.lastTableData = allData
+
+	// A boxed table's width is the width of the whole table rather than of what
+	// is on screen, since the content has already been cut to the window by the
+	// horizontal offset; formatTableForViewport measures it before cutting.
+	// Everything else is text, and as wide as its longest line.
+	if format != config.OutputFormatTable {
+		m.tableWidth = widestLine(content)
+	}
+}
+
+// onePassFormat reports whether a format is drawn in one go from the rows in
+// hand, rather than growing a row at a time as they arrive.
+//
+// ASCII art and JSON lines are: the whole thing is laid out at once, so what is
+// on screen is exactly the rows fetched so far. The boxed table and expand
+// format are read a screen at a time and page in as you scroll. It decides two
+// things - whether to pull the rest of the rows in first, and whether to say
+// how many are showing - and both follow from the same fact.
+func onePassFormat(format config.OutputFormat) bool {
+	return format == config.OutputFormatASCII || format == config.OutputFormatJSON
+}
+
+// moreRowsNotice says how much of a streaming result is showing, for the
+// formats that are built in one pass.
+//
+// The boxed table and expand format grow as you page through them, and a line
+// at the bottom saying there is more is what the scrollbar already says. ASCII
+// art and JSON lines are drawn from whatever rows are in hand, so what is on
+// screen can be a fraction of the answer with nothing to say so.
+func (m *MainModel) moreRowsNotice(format config.OutputFormat) string {
+	if !onePassFormat(format) {
+		return ""
+	}
+	if m.slidingWindow == nil || !m.slidingWindow.hasMoreData {
+		return ""
+	}
+
+	return "\n" + m.styles.MutedText.Render(fmt.Sprintf(
+		"(Showing %d rows. More data available. Use PgDn/Space to load more, or AUTOFETCH ON to fetch all.)",
+		len(m.slidingWindow.Rows)))
+}
+
+// redrawResults draws the result already on screen again, in whatever OUTPUT is
+// now set to.
+//
+// The rows are in hand either way, so changing the format is a redraw rather
+// than a reason to ask Cassandra the same question again. Nothing is fetched
+// that would not have been fetched anyway: fetchAllPages does nothing unless
+// AUTOFETCH is on, and a format switch turning into a full table scan is not
+// what anyone pressing it is asking for.
+func (m *MainModel) redrawResults() {
+	if !m.hasTable || len(m.lastTableData) == 0 {
+		return
+	}
+
+	// Everything that describes the layout is about to stop being true.
+	m.cachedTableLines = nil
+	m.initialColumnWidths = nil
+	m.columnWidths = nil
+	m.tableRowBoundaries = nil
+	m.resetHorizontalScroll()
+
+	format := m.outputFormat()
+	m.fetchAllPages(string(format))
+
+	m.renderResults(m.resultRows())
+
+	// Back to the top: row 500 of a boxed table is not line 500 of JSON, and
+	// there is no honest way to hold the place across the change.
+	m.tableViewport.GotoTop()
+}
+
+// resultRows is the result on screen: the header row, then the rows in hand.
+//
+// A streaming result grows as pages arrive, so the sliding window is the newer
+// answer whenever there is one for this result. A complete result has none -
+// showQueryResult clears it - and what was drawn is what it was given.
+func (m *MainModel) resultRows() [][]string {
+	if m.slidingWindow != nil && len(m.slidingWindow.Headers) > 0 {
+		return append([][]string{m.slidingWindow.Headers}, m.slidingWindow.Rows...)
+	}
+	return m.lastTableData
+}
+
+// processCommand runs a command, and draws the result on screen again if the
+// command changed how results are drawn.
+//
+// Comparing the format either side of the command, rather than looking at the
+// command itself: OUTPUT sets it, EXPAND ON and OFF set it, the control on the
+// status line sets it by running OUTPUT, and none of them have to know that
+// anything is on screen. Anything else that comes to set it is covered for
+// free, which is the opposite of how the format used to be handled.
+func (m *MainModel) processCommand(command string) interface{} {
+	before := m.outputFormat()
+	result := router.ProcessCommand(command, m.session, m.sessionManager)
+
+	if m.outputFormat() != before {
+		m.redrawResults()
+	}
+	return result
+}
+
+// rawRows is the values behind the rows on screen, where they are still in
+// hand: a streaming result keeps them beside its window of rows, and a complete
+// one keeps what it was given.
+func (m *MainModel) rawRows() []map[string]interface{} {
+	if m.slidingWindow != nil && len(m.slidingWindow.Headers) > 0 {
+		return m.slidingWindow.RawRows
+	}
+	return m.lastRawData
+}

--- a/internal/ui/result_view_test.go
+++ b/internal/ui/result_view_test.go
@@ -1,0 +1,334 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/cqlai/internal/config"
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/axonops/cqlai/internal/router"
+	"github.com/axonops/cqlai/internal/session"
+)
+
+// shownModel is a result on screen, drawn in the given format, with the router
+// pointed at the same session manager the model holds - which is what decides
+// what OUTPUT does.
+func shownModel(t *testing.T, format config.OutputFormat) *MainModel {
+	t.Helper()
+
+	manager := session.NewManager(&config.Config{})
+	require.NoError(t, manager.SetOutputFormat(format))
+	router.InitRouter(manager)
+	t.Cleanup(func() { router.InitRouter(nil) })
+
+	m := &MainModel{
+		styles:          DefaultStyles(),
+		sessionManager:  manager,
+		windowWidth:     100,
+		windowHeight:    30,
+		viewMode:        "history",
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+		tableViewport:   viewport.New(viewport.WithWidth(100), viewport.WithHeight(10)),
+	}
+	m.showQueryResult([][]string{
+		{"id", "name"},
+		{"1", "alice"},
+		{"2", "bob"},
+	}, []string{"int", "text"})
+	return m
+}
+
+func shown(m *MainModel) string {
+	return stripAnsiForTest(m.tableViewport.GetContent())
+}
+
+// TestSwitchingOutputRedrawsWhatIsOnScreen, which is the point: the rows are
+// already in hand, so looking at them another way is a redraw rather than a
+// reason to ask Cassandra the same question again.
+func TestSwitchingOutputRedrawsWhatIsOnScreen(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+	require.Contains(t, shown(m), "│", "the boxed table should be boxed")
+
+	m.processCommand("OUTPUT JSON")
+
+	assert.Equal(t, config.OutputFormatJSON, m.resultFormat)
+	assert.Contains(t, shown(m), `{"id":"1","name":"alice"}`)
+	assert.NotContains(t, shown(m), "│")
+
+	// The same rows throughout - nothing was re-queried, and nothing was lost.
+	for _, value := range []string{"alice", "bob"} {
+		assert.Contains(t, shown(m), value)
+	}
+}
+
+// TestEveryFormatCanBeSwitchedToAndBack.
+func TestEveryFormatCanBeSwitchedToAndBack(t *testing.T) {
+	formats := config.OutputFormats()
+
+	for _, from := range formats {
+		for _, to := range formats {
+			parsedTo, err := config.ParseOutputFormat(to)
+			require.NoError(t, err)
+			parsedFrom, err := config.ParseOutputFormat(from)
+			require.NoError(t, err)
+
+			m := shownModel(t, parsedFrom)
+			m.processCommand("OUTPUT " + to)
+
+			assert.Equal(t, parsedTo, m.resultFormat, "%s to %s", from, to)
+			assert.Contains(t, shown(m), "alice", "%s to %s: the rows should still be there", from, to)
+			assert.Positive(t, m.tableWidth, "%s to %s: scrolling sideways needs a width", from, to)
+		}
+	}
+}
+
+// TestSwitchingOutputMovesTheWidthWithIt.
+//
+// The width is what sideways scrolling clamps against, and it was only ever set
+// when a result first arrived. JSON lines are far wider than the boxed table of
+// the same rows, so a switch left it describing the wrong thing.
+func TestSwitchingOutputMovesTheWidthWithIt(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+	boxed := m.tableWidth
+
+	m.processCommand("OUTPUT JSON")
+	assert.NotEqual(t, boxed, m.tableWidth)
+	assert.Equal(t, widestLine(shown(m)), m.tableWidth)
+
+	m.processCommand("OUTPUT TABLE")
+	assert.Equal(t, boxed, m.tableWidth, "back where it started")
+}
+
+// TestSwitchingOutputStartsAtTheTopLeft: row 500 of a boxed table is not line
+// 500 of JSON, and column 40 is not column 40.
+func TestSwitchingOutputStartsAtTheTopLeft(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+	m.horizontalOffset = 20
+	m.tableViewport.SetYOffset(2)
+
+	m.processCommand("OUTPUT ASCII")
+
+	assert.Zero(t, m.horizontalOffset)
+	assert.Zero(t, m.tableViewport.XOffset())
+	assert.Zero(t, m.tableViewport.YOffset())
+}
+
+// TestExpandOnAndOffRedrawTheResultToo.
+//
+// The redraw comes from the format changing rather than from the command
+// saying OUTPUT, so EXPAND - which sets the same setting by another name - gets
+// it without knowing anything about the view.
+func TestExpandOnAndOffRedrawTheResultToo(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+
+	m.processCommand("EXPAND ON")
+	assert.Equal(t, config.OutputFormatExpand, m.resultFormat)
+	assert.Contains(t, shown(m), "@ Row 1")
+
+	m.processCommand("EXPAND OFF")
+	assert.Equal(t, config.OutputFormatTable, m.resultFormat)
+	assert.NotContains(t, shown(m), "@ Row 1")
+}
+
+// TestACommandThatChangesNothingRedrawsNothing: a redraw rebuilds the table and
+// throws the scroll position away, so it has to be the format changing that
+// causes one, not any command at all.
+func TestACommandThatChangesNothingRedrawsNothing(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+
+	// Somewhere to scroll to: a viewport shorter than the result.
+	m.tableViewport.SetHeight(3)
+	m.tableViewport.SetYOffset(2)
+	require.Equal(t, 2, m.tableViewport.YOffset())
+
+	m.processCommand("OUTPUT") // asks what the format is
+	assert.Equal(t, 2, m.tableViewport.YOffset())
+
+	m.processCommand("OUTPUT TABLE") // already TABLE
+	assert.Equal(t, 2, m.tableViewport.YOffset())
+}
+
+// TestSwitchingOutputWithNothingOnScreen still sets the format for next time.
+func TestSwitchingOutputWithNothingOnScreen(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+	m.hasTable = false
+	m.lastTableData = nil
+	m.tableViewport.SetContent("")
+
+	m.processCommand("OUTPUT JSON")
+
+	assert.Equal(t, config.OutputFormatJSON, m.outputFormat())
+	assert.Empty(t, shown(m))
+}
+
+// TestADescribeGridFollowsTheFormatToo.
+//
+// These grids - DESCRIBE TABLES and the listings - used to force the boxed
+// table whatever OUTPUT said. That was a rule nothing else followed, and one a
+// redraw would have broken anyway: drawn one way, redrawn another.
+func TestADescribeGridFollowsTheFormatToo(t *testing.T) {
+	m := shownModel(t, config.OutputFormatJSON)
+	m.processTableResult("DESCRIBE TABLES", [][]string{{"keyspace_name"}, {"system"}})
+
+	assert.Equal(t, config.OutputFormatJSON, m.resultFormat)
+	assert.Contains(t, shown(m), `{"keyspace_name":"system"}`)
+
+	m.processCommand("OUTPUT TABLE")
+	assert.Contains(t, shown(m), "│")
+	assert.Contains(t, shown(m), "system")
+}
+
+// TestMoreRowsArrivingMovesTheWidthWithThem.
+//
+// The width is set from the content, so it has to be set again when the content
+// changes. It was only ever set when a result first arrived: a long value in a
+// later page widened the text and left the sideways scrolling clamped to the
+// first page's width, with the end of the line out of reach.
+func TestMoreRowsArrivingMovesTheWidthWithThem(t *testing.T) {
+	m := outputModel(t, false, config.OutputFormatASCII)
+	m.displayResult(m.slidingWindow.Headers, nil)
+	first := m.tableWidth
+
+	// The second page holds a value far wider than anything on the first.
+	wide := []string{"3", strings.Repeat("c", 200)}
+	m.slidingWindow.streamingResult.LoadMore = func(_ context.Context, _ int) (db.Page, error) {
+		return db.Page{
+			Rows: [][]string{wide},
+			Raw:  []map[string]interface{}{rowValues(m.slidingWindow.Headers, wide)},
+		}, nil
+	}
+	m.loadMoreTableDataHelper()
+
+	require.Contains(t, stripAnsiForTest(m.tableViewport.GetContent()), "ccc")
+	assert.Greater(t, m.tableWidth, first, "the width should have grown with the content")
+	assert.Equal(t, widestLine(stripAnsiForTest(m.tableViewport.GetContent())), m.tableWidth)
+}
+
+// TestTheNoticeFollowsTheRowsInHand: it is drawn with the content, so it says
+// what is true at the time rather than what was true when the result arrived.
+func TestTheNoticeFollowsTheRowsInHand(t *testing.T) {
+	m := outputModel(t, false, config.OutputFormatTable)
+	m.displayResult(m.slidingWindow.Headers, nil)
+
+	// A boxed table pages in as you scroll, and the scrollbar says as much.
+	assert.NotContains(t, shown(m), "More data available")
+
+	// ASCII is drawn in one pass, so what is on screen can be a fraction of the
+	// answer with nothing else to say so.
+	m.processCommand("OUTPUT ASCII")
+	assert.Contains(t, shown(m), "More data available")
+	assert.Contains(t, shown(m), "Showing 2 rows")
+
+	// And it goes when the rest arrives.
+	m.loadMoreTableDataHelper()
+	assert.NotContains(t, shown(m), "More data available")
+	assert.Contains(t, shown(m), "dave")
+}
+
+// TestSwitchingFormatFetchesNothingExtra.
+//
+// AUTOFETCH decides how much is pulled in. A format switch is a redraw of the
+// rows in hand, not a reason to read the rest of a table.
+func TestSwitchingFormatFetchesNothingExtra(t *testing.T) {
+	m := outputModel(t, false, config.OutputFormatTable)
+	m.displayResult(m.slidingWindow.Headers, nil)
+	require.Len(t, m.slidingWindow.Rows, 2)
+
+	m.processCommand("OUTPUT JSON")
+
+	assert.Len(t, m.slidingWindow.Rows, 2, "switching format fetched more rows")
+	assert.True(t, m.slidingWindow.hasMoreData)
+}
+
+// TestAJSONResultGoesBackToBeingATable.
+//
+// OUTPUT JSON used to rewrite the query as SELECT JSON, so what came back was
+// one column of documents rather than the columns asked for. Switching to TABLE
+// then drew that one column: the JSON, in a table, with the columns nowhere to
+// be found. The format decides how a result is drawn and nothing else, so the
+// columns are still there to go back to.
+func TestAJSONResultGoesBackToBeingATable(t *testing.T) {
+	m := shownModel(t, config.OutputFormatJSON)
+	require.Contains(t, shown(m), `"name":"alice"`)
+	require.NotContains(t, shown(m), "│")
+
+	m.processCommand("OUTPUT TABLE")
+
+	drawn := shown(m)
+	assert.Contains(t, drawn, "│", "the result should be a table again")
+	assert.NotContains(t, drawn, `{"id"`, "the table is drawn from the values, not from the JSON")
+
+	// Both columns, in their own right.
+	for _, column := range []string{"id", "name"} {
+		assert.Contains(t, drawn, column)
+	}
+	assert.Contains(t, drawn, "alice")
+	assert.Contains(t, drawn, "bob")
+}
+
+// TestJSONKeepsTheTypesOfTheValues, which is what a JSON document is for.
+//
+// The values are kept beside the strings drawn in the cells, so a number is a
+// number rather than the text of one - which is all that would be left if JSON
+// were built from what is on screen.
+func TestJSONKeepsTheTypesOfTheValues(t *testing.T) {
+	m := shownModel(t, config.OutputFormatTable)
+	m.slidingWindow = NewSlidingWindowTable(1000, 10)
+	m.slidingWindow.Headers = []string{"id", "name", "active", "score", "when"}
+	m.slidingWindow.AddRow(
+		[]string{"7", "alice", "true", "1.5", "2026-09-11 10:00:00"},
+		map[string]interface{}{
+			"id":     7,
+			"name":   "alice",
+			"active": true,
+			"score":  1.5,
+			"when":   time.Date(2026, 9, 11, 10, 0, 0, 0, time.UTC),
+		})
+	m.tableHeaders = m.slidingWindow.Headers
+	m.hasTable = true
+	m.lastTableData = m.resultRows()
+
+	m.processCommand("OUTPUT JSON")
+
+	line := strings.TrimSpace(shown(m))
+	assert.Contains(t, line, `"id":7`, "a number should not be quoted")
+	assert.Contains(t, line, `"active":true`, "a boolean should not be quoted")
+	assert.Contains(t, line, `"score":1.5`)
+	assert.Contains(t, line, `"name":"alice"`)
+	assert.Contains(t, line, `"when":"2026-09-11T10:00:00Z"`)
+
+	// And the columns come out in the order they were asked for.
+	assert.Less(t, strings.Index(line, `"id"`), strings.Index(line, `"name"`))
+}
+
+// TestJSONFallsBackToWhatIsDrawn, for a grid that never had values behind it:
+// DESCRIBE and the listings are made up by the shell rather than read from a
+// table.
+func TestJSONFallsBackToWhatIsDrawn(t *testing.T) {
+	m := shownModel(t, config.OutputFormatJSON)
+	m.processTableResult("DESCRIBE TABLES", [][]string{{"keyspace_name"}, {"system"}})
+
+	assert.Contains(t, shown(m), `{"keyspace_name":"system"}`)
+}
+
+// TestAnExplicitSelectJSONIsLeftAlone: asking Cassandra for JSON is a different
+// thing from asking cqlai to draw JSON, and it still comes back as one column
+// of documents.
+func TestAnExplicitSelectJSONIsLeftAlone(t *testing.T) {
+	m := shownModel(t, config.OutputFormatJSON)
+	m.showQueryResult([][]string{{"[json]"}, {`{"id": 1, "name": "alice"}`}}, nil)
+
+	assert.Equal(t, `{"id": 1, "name": "alice"}`, strings.TrimSpace(shown(m)))
+
+	// And drawn as a table it is the column it is: one document per row.
+	m.processCommand("OUTPUT TABLE")
+	assert.Contains(t, shown(m), "[json]")
+	assert.Contains(t, shown(m), `{"id": 1`)
+}

--- a/internal/ui/setting_chooser.go
+++ b/internal/ui/setting_chooser.go
@@ -352,7 +352,7 @@ func (m *MainModel) applySettingChoice(choice string) (*MainModel, tea.Cmd) {
 // It does not switch view: you clicked a control, so whatever you were reading
 // should still be in front of you.
 func (m *MainModel) runCommand(command string) (*MainModel, tea.Cmd) {
-	result := router.ProcessCommand(command, m.session, m.sessionManager)
+	result := m.processCommand(command)
 
 	m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
 

--- a/internal/ui/sliding_window.go
+++ b/internal/ui/sliding_window.go
@@ -20,6 +20,12 @@ type SlidingWindowTable struct {
 	Rows        [][]string // Current window of rows
 	ColumnTypes []string   // Column types (always kept)
 
+	// RawRows is the same window of rows as the values they were before they
+	// were formatted for a table cell, kept in step with Rows. JSON is built
+	// from these: a timestamp drawn for a cell, or a collection written the way
+	// cqlsh writes one, cannot be turned back into what it came from.
+	RawRows []map[string]interface{}
+
 	// Window tracking
 	FirstRowIndex int64 // Global index of first row in window
 	TotalRowsSeen int64 // Total rows processed (may be more than in memory)
@@ -43,6 +49,7 @@ func NewSlidingWindowTable(maxRows int, maxMemoryMB int) *SlidingWindowTable {
 		MaxRows:        maxRows,
 		MaxMemoryBytes: int64(maxMemoryMB * 1024 * 1024),
 		Rows:           make([][]string, 0),
+		RawRows:        make([]map[string]interface{}, 0),
 		FirstRowIndex:  0,
 		TotalRowsSeen:  0,
 		CurrentMemory:  0,
@@ -50,8 +57,11 @@ func NewSlidingWindowTable(maxRows int, maxMemoryMB int) *SlidingWindowTable {
 	}
 }
 
-// AddRow adds a row to the sliding window, potentially evicting old rows
-func (swt *SlidingWindowTable) AddRow(row []string) {
+// AddRow adds a row to the sliding window, potentially evicting old rows.
+//
+// raw is the same row as the values behind it, and may be nil for rows that
+// never had any - a grid the shell made up rather than a result over a table.
+func (swt *SlidingWindowTable) AddRow(row []string, raw map[string]interface{}) {
 	// Calculate approximate memory for this row
 	rowMemory := swt.calculateRowMemory(row)
 
@@ -62,6 +72,7 @@ func (swt *SlidingWindowTable) AddRow(row []string) {
 
 	// Add the new row
 	swt.Rows = append(swt.Rows, row)
+	swt.RawRows = append(swt.RawRows, raw)
 	swt.CurrentMemory += rowMemory
 	swt.TotalRowsSeen++
 
@@ -115,19 +126,31 @@ func (swt *SlidingWindowTable) evictOldestRows(neededMemory int64) {
 			rowsToEvict, freedMemory)
 
 		swt.Rows = swt.Rows[rowsToEvict:]
+		// In step with the rows they belong to, or JSON would be drawn from the
+		// values of rows that have scrolled off the top.
+		if rowsToEvict < len(swt.RawRows) {
+			swt.RawRows = swt.RawRows[rowsToEvict:]
+		} else {
+			swt.RawRows = nil
+		}
 		swt.FirstRowIndex += int64(rowsToEvict)
 		swt.CurrentMemory -= freedMemory
 		swt.DataDroppedAtStart = true
 	}
 }
 
-// calculateRowMemory estimates memory usage for a row
+// calculateRowMemory estimates memory usage for a row.
+//
+// Doubled, because a row is kept twice: the strings drawn in the cells, and the
+// values they were made from. The second copy is roughly the size of the first
+// for the types a cell can hold, and a budget that ignored it would let twice
+// as much into memory as it was set to.
 func (swt *SlidingWindowTable) calculateRowMemory(row []string) int64 {
 	memory := int64(24) // Slice overhead
 	for _, cell := range row {
 		memory += int64(len(cell)) + 24 // String content + string header
 	}
-	return memory
+	return memory * 2
 }
 
 // GetVisibleRows returns rows for display within the specified range
@@ -179,7 +202,7 @@ func (swt *SlidingWindowTable) LoadMoreRows(maxRows int) int {
 	}
 
 	ctx := context.Background()
-	rows, hasMore, err := swt.streamingResult.LoadMore(ctx, maxRows)
+	page, err := swt.streamingResult.LoadMore(ctx, maxRows)
 	if err != nil {
 		logger.DebugfToFile("SlidingWindowTable", "Error loading more rows: %v", err)
 		swt.hasMoreData = false
@@ -188,17 +211,17 @@ func (swt *SlidingWindowTable) LoadMoreRows(maxRows int) int {
 	}
 
 	// Add the loaded rows
-	for _, row := range rows {
-		swt.AddRow(row)
+	for i, row := range page.Rows {
+		swt.AddRow(row, rawAt(page.Raw, i))
 	}
 
-	swt.hasMoreData = hasMore
-	if !hasMore {
+	swt.hasMoreData = page.HasMore
+	if !page.HasMore {
 		swt.streamingResult = nil
 	}
 
-	logger.DebugfToFile("SlidingWindowTable", "Loaded %d more rows", len(rows))
-	return len(rows)
+	logger.DebugfToFile("SlidingWindowTable", "Loaded %d more rows", len(page.Rows))
+	return len(page.Rows)
 }
 
 // GetUncapturedRows returns rows that haven't been written to capture file yet
@@ -243,4 +266,12 @@ func (swt *SlidingWindowTable) Reset() {
 	swt.streamingResult = nil
 	swt.hasMoreData = false
 	swt.LastCapturedRow = 0
+}
+
+// rawAt is the raw values for a row, or nil when the batch carried none.
+func rawAt(raw []map[string]interface{}, i int) map[string]interface{} {
+	if i < len(raw) {
+		return raw[i]
+	}
+	return nil
 }

--- a/internal/ui/table_renderer.go
+++ b/internal/ui/table_renderer.go
@@ -1,52 +1,14 @@
 package ui
 
 import (
-	"charm.land/lipgloss/v2"
 	"fmt"
 	"regexp"
 	"strings"
 
-	"github.com/axonops/cqlai/internal/config"
+	"charm.land/lipgloss/v2"
+
 	"github.com/axonops/cqlai/internal/logger"
 )
-
-// refreshTableContent re-renders the current result in the active output format
-// and sets the viewport content together with the row boundaries describing it.
-//
-// Paging snaps scroll offsets to tableRowBoundaries. Those are line numbers, so
-// they only mean anything for the layout that produced them and have to be
-// replaced whenever the content is. Leaving stale ones behind caps scrolling:
-// boundaries from the boxed table, where a record is one line, cannot reach past
-// the row count in expand format, where a record is as tall as the table is wide.
-//
-// The boxed renderer fills the boundaries in as it builds; the other formats
-// either report them or have none.
-func (m *MainModel) refreshTableContent(allData [][]string) {
-	var (
-		content    string
-		boundaries []int
-	)
-
-	format := config.OutputFormatTable
-	if m.sessionManager != nil {
-		format = m.sessionManager.GetOutputFormat()
-	}
-
-	switch format {
-	case config.OutputFormatASCII:
-		content = FormatASCIITableWithTypes(allData, m.columnTypes)
-	case config.OutputFormatExpand:
-		content, boundaries = FormatExpandTableWithBoundaries(allData, m.styles)
-	case config.OutputFormatJSON:
-		content = m.formatTableAsJSON()
-	default:
-		content = m.formatTableForViewport(allData)
-		boundaries = m.tableRowBoundaries // filled in while rendering
-	}
-
-	m.tableRowBoundaries = boundaries
-	m.tableViewport.SetContent(content)
-}
 
 // formatTableForViewport formats a 2D array of strings as a table for the viewport
 func (m *MainModel) formatTableForViewport(data [][]string) string {


### PR DESCRIPTION
Closes #171.

Run a query, change the Output setting on the status line - or type `OUTPUT
JSON`, `OUTPUT ASCII`, `EXPAND ON` - and the result already on screen is redrawn
in the new format. The rows are in hand, so this is a redraw rather than a
second trip to Cassandra.

310 lines added against 482 removed, because most of the work was deleting
copies.

### The format was written in three places

`sessionManager.GetOutputFormat()`, which the refresh read; `m.resultFormat`,
which the sticky header, the sideways scrolling and the selection read; and each
of four display functions, which set it themselves and were chosen by a switch
somewhere else. Move one and not the others and a boxed header floats over JSON,
or a sideways scroll rebuilds a table out of JSON lines.

One function draws a result now - every format, every path that puts rows on
screen - and sets the format, the content, the row boundaries and the width
together. The four display functions differed in two lines, so that is all that
is left of them. JSON had two renderers, and the one reading the sliding window
directly was what the paging path used; it is gone.

`m.tableWidth`, which sideways scrolling clamps against, was only ever set when a
result first arrived. A long value in a later page widened the text and left the
scrolling clamped to the first page's width, with the end of the line out of
reach. There is a test for it.

### OUTPUT JSON did not draw JSON

It rewrote the query as `SELECT JSON` before sending it, so what came back was
one column of documents rather than the columns asked for. Redrawing that as a
table gave a one-column table of JSON text - the rendered output drawn again -
because the columns had never been fetched.

The rewrite is gone. Rows are kept twice instead: the strings drawn in the cells,
and the values behind them. Neither can be got from the other - a timestamp
formatted for a cell, or a collection written the way cqlsh writes one, cannot be
turned back into what it came from. The streaming loader already had the values
from `MapScan` and dropped them after formatting; they travel with the rows now,
and the sliding window's memory budget counts both copies.

JSON is written from those values through `db.JSONValue`, which handles what
Cassandra has and JSON does not: a UUID is sixteen bytes, which `json` writes as
an array of numbers; a blob is bytes, which it writes as base64 rather than the
`0x` form everything else prints; decimals, varints, inet, durations and
timestamps likewise, walking into lists, sets, maps and UDTs. Columns come out in
the order they were asked for, and a map with UUID keys - which `json.Marshal`
refuses outright - comes out keyed by its text form.

Typing `SELECT JSON` yourself still does what it always did.

### Found on the way

- **`EXPAND ON` did nothing.** It set a flag on the meta handler that nothing
  read: the command said results would be shown vertically and no code anywhere
  drew them that way. It sets the output format now.
- **The meta handler kept its own session manager**, captured on the first
  command of the process, so pointing the router at another one left two
  managers answering the same question. `InitRouter` keeps them in step.
- **DESCRIBE grids forced the boxed table** whatever OUTPUT said - a rule nothing
  else followed, and one a redraw would have broken anyway.

### Behaviour

A switch fetches nothing extra: AUTOFETCH still decides how much is pulled in,
and a partly-loaded result says how many rows are showing. The view goes back to
the top and to the left, because row 500 of a boxed table is not line 500 of
JSON.

Eighteen new tests, docs in the README and the in-app help.
