### PR TITLE
An empty path field completes from the root, not from where cqlai was started

### DIFF
--- a/internal/ui/path_complete.go
+++ b/internal/ui/path_complete.go
@@ -37,6 +37,18 @@ func completePath(input string) pathCompletion {
 
 	dir, prefix := splitPath(input)
 
+	// Nothing typed at all: start at the root rather than in whatever directory
+	// cqlai was started from, which is rarely where the file is and is not
+	// somewhere you can see - the field looks empty and Tab produces a listing
+	// you had no reason to expect. It is also the one case with no directory to
+	// offer a way up out of.
+	//
+	// A name with no directory in front of it - report.csv - is a different
+	// thing, and still completes here, which is what typing a bare name means.
+	if dir == "" && prefix == "" {
+		dir = pathRoot
+	}
+
 	entries, err := os.ReadDir(expandHome(dir))
 	if err != nil {
 		return none

--- a/internal/ui/path_complete_test.go
+++ b/internal/ui/path_complete_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/cqlai/internal/config"
 )
 
 // pathFixture builds a directory to complete against.
@@ -195,4 +197,66 @@ func TestParentDir(t *testing.T) {
 	} {
 		assert.Equal(t, want, parentDir(input), "above %q", input)
 	}
+}
+
+// TestNothingTypedStartsAtTheRoot.
+//
+// It used to list the directory cqlai was started from: a field that looks
+// empty, a listing you had no reason to expect, and no way up out of it, since
+// the way up is offered relative to a directory and an empty field names none.
+// The COPY forms never hit it because their File field is seeded with "/"; the
+// preferences window cannot do that, because its fields hold what is in the
+// configuration file.
+func TestNothingTypedStartsAtTheRoot(t *testing.T) {
+	got := completePath("")
+
+	require.NotEmpty(t, got.Matches, "nothing offered at all")
+	assert.Equal(t, pathRoot, got.Completed[:1], "completion should start at the root")
+
+	// What the root holds, rather than what the working directory holds.
+	root := completePath(pathRoot)
+	assert.Equal(t, root.Matches, got.Matches)
+}
+
+// TestWalkingUpFromTheRootListing: the root has nothing above it, and every
+// directory below it does.
+func TestWalkingUpFromTheRootListing(t *testing.T) {
+	assert.NotContains(t, completePath(pathRoot).Matches, parentEntry,
+		"the root should offer no way up")
+
+	// A directory of our own, so the test does not depend on what is on the
+	// machine running it.
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "below"), 0o750))
+
+	listing := completePath(dir + string(filepath.Separator) + "below" + string(filepath.Separator))
+	assert.Equal(t, parentEntry, listing.Matches[0], "the way up should be first")
+}
+
+// TestABareNameStillCompletesWhereYouAre: typing a name with no directory in
+// front of it means the working directory, which is what it means at a shell.
+func TestABareNameStillCompletesWhereYouAre(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "report.csv"), nil, 0o600))
+
+	here, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(here) })
+
+	assert.Equal(t, "report.csv", completePath("rep").Completed)
+}
+
+// TestAnEmptyPathSettingOffersTheRoot, which is where the complaint came from:
+// the preferences window holds path settings that start empty.
+func TestAnEmptyPathSettingOffersTheRoot(t *testing.T) {
+	m := prefModel(t, &config.Config{})
+	i := prefIndex(t, m, "HistoryFile")
+	m.preferences.focusField(i)
+	require.Empty(t, m.preferences.fields[i].value())
+
+	m = press(m, "tab")
+
+	assert.Equal(t, pathRoot, m.preferences.fields[i].value())
+	assert.Equal(t, completePath(pathRoot).Matches, m.preferences.matches)
 }


### PR DESCRIPTION
Closes #173.

Tab on an empty path setting in the PREFERENCES window - Command history, Chat
history, the SSL certificate and key - listed whatever directory cqlai happened
to be started in, and offered no `..` to walk up out of it.

```
""              -> ai_commands.go  ai_cql_modal.go  ai_modal.go  ...
"/home/hayato/" -> ..  Downloads/  JAVATOOLS/  Pipfile  ...
```

Both halves of that first line are what the COPY forms had before #156: a
listing of somewhere you cannot see and had no reason to expect, and no way up -
because the way up is offered relative to the directory being listed, and an
empty field names no directory at all.

The forms escape it by seeding `File` with `/` when they open. The preferences
window cannot: its fields hold what is in the configuration file, and seeding one
with `/` would save `historyFile: "/"` for a setting nobody set. So the default
goes where the decision is made - with nothing typed, `completePath` looks at the
root. Every directory below it offers `..`, as everywhere else.

A name with no directory in front of it - `report.csv` - still completes against
the working directory, which is what typing a bare name means, and there is a
test pinning that. The prompt is unaffected: with nothing typed after `SOURCE `
it shows its hint rather than completing anything, which its own test still
covers.
