### PR TITLE
SCHEMA: a browser for the cluster's keyspaces and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,19 +314,41 @@ cqlai -e "SELECT * FROM large_table;" --page-size 50
 #### The tab line
 
 ```
- FILE (Alt+F)    CONSOLE (F2)    RESULTS (F3)    TRACE (F4)    CHAT (F5)    HELP (F1/Alt+H)
+ FILE (Alt+F)  CONSOLE (F2)  SCHEMA (F3)  RESULTS (F4)  TRACE (F5)  CHAT (F6)  HELP (F1/Alt+H)
 ```
 
-The four views are shown as tabs, so you can see which one you are in and what
+The five views are shown as tabs, so you can see which one you are in and what
 the others are. Click a tab, or use the key on it. A view with nothing to show
 yet is dimmed, as is `CHAT` with no AI provider configured.
 
 | Shortcut | Tab | Shows |
 |----------|-----|-------|
 | `F2` | Console | The running transcript of commands and messages |
-| `F3` | Results | The last query's output, in whatever `OUTPUT` format is set |
-| `F4` | Trace | Query trace, when tracing is enabled |
-| `F5` | Chat | The AI conversation |
+| `F3` | Schema | The cluster's keyspaces and tables, with their definitions |
+| `F4` | Results | The last query's output, in whatever `OUTPUT` format is set |
+| `F5` | Trace | Query trace, when tracing is enabled |
+| `F6` | Chat | The AI conversation |
+
+Schema sits next to the console because what is in the database comes before
+anything a query has made of it. The keys read along the line with the tabs, so
+Results and Trace have moved from `F3` and `F4` to `F4` and `F5`.
+
+#### The schema browser
+
+`SCHEMA` is the cluster's keyspaces and tables as a tree, with the definition of
+whatever is selected beside it. Click a keyspace to see it and open it, click it
+again to fold it, and click a table for its `CREATE TABLE`.
+
+The arrows walk the tree - right opens a keyspace, left closes it - and the
+wheel moves whichever pane it is over. `Alt+Up` and `Alt+Down` scroll the
+definition. Everything else still goes to the prompt, so a query can be typed
+while looking at the table it is about. Pressing `F3` again, or clicking the tab
+you are already on, asks the cluster for the schema afresh.
+
+Nothing is fetched until the tab is opened: the keyspaces on first use, a
+keyspace's tables when it is first opened, and a definition when it is first
+shown. The definitions are the ones `DESCRIBE` produces, so the two cannot
+disagree.
 
 `FILE` and `HELP` are not views. They open a menu and a window over whatever you
 are looking at, and leave it there. On a narrow terminal the labels shorten and
@@ -467,7 +489,7 @@ only reports vertical wheel spins as key presses.
 **Note for macOS Users:**
 - Most `Ctrl` shortcuts work as-is on macOS, but you can also use `⌘` (Command) key as an alternative
 - `Alt` key is labeled as `Option` on Mac keyboards
-- Function keys (F1-F5) may require holding `Fn` key depending on your Mac settings
+- Function keys (F1-F6) may require holding `Fn` key depending on your Mac settings
 
 ### Tab Completion
 

--- a/internal/router/meta_commands_help.go
+++ b/internal/router/meta_commands_help.go
@@ -95,6 +95,8 @@ func HelpRows() [][]string {
 		// Keyboard Shortcuts
 		{"─────────", "─────────", "─────────────"},
 		{"Keys", "F1 or Alt+H", "Open this help (F1 is taken by some terminals)"},
+		{"", "F2 to F6", "Console, Schema, Results, Trace, Chat"},
+		{"", "F3", "Browse keyspaces and tables, and their definitions"},
 		{"", "↑/↓ or Ctrl+P/N", "Navigate command history"},
 		{"", "Ctrl+R", "Search history"},
 		{"", "Tab", "Auto-complete"},

--- a/internal/ui/help_window_test.go
+++ b/internal/ui/help_window_test.go
@@ -270,13 +270,13 @@ func TestTheButtonGivesWayToTheTabNames(t *testing.T) {
 	assert.Contains(t, wide, "HELP")
 
 	// Room for the names and the button, but not the key hints.
-	medium := stripAnsiForTest(m.ViewTabBar(60))
+	medium := stripAnsiForTest(m.ViewTabBar(64))
 	assert.Contains(t, medium, "CONSOLE")
 	assert.NotContains(t, medium, "(F2)")
 	assert.Contains(t, medium, "HELP")
 
 	// Room for the names only. The button goes rather than the names.
-	tight := stripAnsiForTest(m.ViewTabBar(40))
+	tight := stripAnsiForTest(m.ViewTabBar(50))
 	assert.Contains(t, tight, "CONSOLE")
 	assert.NotContains(t, tight, "HELP")
 }
@@ -286,7 +286,7 @@ func TestTheButtonGivesWayToTheTabNames(t *testing.T) {
 func TestTheButtonNamesBothKeys(t *testing.T) {
 	m := helpModel()
 
-	wide := stripAnsiForTest(m.ViewTabBar(100))
+	wide := stripAnsiForTest(m.ViewTabBar(120))
 	assert.Contains(t, wide, "HELP (F1/Alt+H)")
 }
 
@@ -301,7 +301,7 @@ func TestTheButtonNamesBothKeys(t *testing.T) {
 func TestTheLabelShortensBeforeTheButtonGoes(t *testing.T) {
 	m := helpModel()
 
-	for _, width := range []int{70, 55, 50} {
+	for _, width := range []int{85, 70, 62} {
 		found := false
 		for _, span := range m.layoutTabs(width) {
 			if span.mode == helpMode {
@@ -321,7 +321,7 @@ func TestTheLabelShortensBeforeTheButtonGoes(t *testing.T) {
 func TestTheTabsDoNotGiveUpTheirNamesForALabelThatWillNotBeDrawn(t *testing.T) {
 	m := helpModel()
 
-	bar := stripAnsiForTest(m.ViewTabBar(50))
+	bar := stripAnsiForTest(m.ViewTabBar(58))
 	assert.Contains(t, bar, "CONSOLE", "the names should survive here")
 	assert.Contains(t, bar, "?", "and the buttons shorten rather than going")
 }

--- a/internal/ui/keybinding_test.go
+++ b/internal/ui/keybinding_test.go
@@ -96,23 +96,34 @@ func TestAltArrowsScrollTheViewport(t *testing.T) {
 	assert.Less(t, m.tableViewport.YOffset(), down, "Alt+Up must scroll back up")
 }
 
-// TestFunctionKeysSwitchMode covers the four mode keys, which are the most
-// visible bindings and were all rewritten.
+// TestFunctionKeysSwitchMode covers the mode keys, which are the most visible
+// bindings, and that they land in the order the tabs are drawn in.
 func TestFunctionKeysSwitchMode(t *testing.T) {
 	tests := []struct {
 		code rune
 		want string
 	}{
 		{tea.KeyF2, "history"},
-		{tea.KeyF3, "table"},
-		{tea.KeyF4, "trace"},
+		{tea.KeyF3, "schema"},
+		{tea.KeyF4, "table"},
+		{tea.KeyF5, "trace"},
 	}
 
 	for _, tt := range tests {
 		m := tableModel(t)
 		m.hasTrace = true
+		m.session = connectedSession()
+		// The tree is already in hand, so switching to it asks the cluster
+		// nothing: what is under test is which key lands on which view.
+		m.schema = schemaBrowser{loaded: true, keyspaces: []string{"system"}, tables: map[string][]string{}, expanded: map[string]bool{}, definitions: map[string]string{}}
 		m.handleKeyboardInput(tea.KeyPressMsg{Code: tt.code})
 		assert.Equal(t, tt.want, m.viewMode, "%v should switch to %q", tt.code, tt.want)
+	}
+
+	// And they are the keys the tabs say they are.
+	for i, tab := range modeTabs {
+		assert.Equal(t, tab.key, []string{"F2", "F3", "F4", "F5", "F6"}[i],
+			"%s says %s", tab.label, tab.key)
 	}
 }
 

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -106,6 +106,16 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 		// Key wasn't handled, let it fall through to main switch
 	}
 
+	// The schema tree takes the keys that move around it while it is showing.
+	// Up and down are command history everywhere else, and there is no history
+	// to walk through while reading a tree; everything else still goes to the
+	// prompt, so a query can be typed while looking at the table it is about.
+	if m.viewMode == "schema" && !m.historySearchMode {
+		if updated, cmd, handled := m.schemaKey(msg); handled {
+			return updated, cmd
+		}
+	}
+
 	switch msg.String() {
 	case "ctrl+c":
 		return m.handleCtrlC()
@@ -155,13 +165,13 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 		return m.handleTabKey()
 
 	case "f2":
-		return m.handleF2()
+		return m.showConsole()
 
 	case "f3":
-		return m.handleF3()
+		return m.showSchema()
 
 	case "f4":
-		return m.handleF4()
+		return m.showResults()
 
 	// Alt+H as well as F1: Terminator, Konsole and others take F1 for their
 	// own help before an application ever sees it, so a key that only works on
@@ -170,7 +180,7 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 		return m.toggleHelp()
 
 	// Alt+F opens the FILE menu, matching Alt+H. There is no F-key for it:
-	// F2 to F5 are the views, and a menu is not one.
+	// F2 to F6 are the views, and a menu is not one.
 	case "alt+f":
 		span, ok := m.tabSpanFor(m.windowWidth, fileMode)
 		if !ok {
@@ -179,7 +189,10 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 		return m.openFileMenu(span.start)
 
 	case "f5":
-		return m.handleF5()
+		return m.showTrace()
+
+	case "f6":
+		return m.showChat()
 
 	case "space":
 		// A space is part of what you are searching for. Without this it went

--- a/internal/ui/keyboard_handler_ai_conversation.go
+++ b/internal/ui/keyboard_handler_ai_conversation.go
@@ -201,7 +201,7 @@ func (m *MainModel) handleAIConversationInput(msg tea.KeyPressMsg) (*MainModel, 
 		// Scroll conversation down by multiple lines
 		m.aiConversationViewport.ScrollDown(3)
 		return m, nil
-	case "f2", "f3", "f4", "f5":
+	case "f2", "f3", "f4", "f5", "f6":
 		// Don't handle function keys here - let them fall through to main handler
 		// by not returning anything in this case
 	default:

--- a/internal/ui/keyboard_handler_function_keys.go
+++ b/internal/ui/keyboard_handler_function_keys.go
@@ -6,8 +6,15 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-// handleF2 handles F2 key - switch to query/history view
-func (m *MainModel) handleF2() (*MainModel, tea.Cmd) {
+// The views, one function each.
+//
+// Named for what they show rather than for the key that reaches them. They were
+// handleF2 to handleF6, and moving a tab along the line meant renaming three
+// functions and everything that called them - which is a rename with nothing
+// behind it, since none of them has anything to do with a particular key.
+
+// showConsole switches to the running transcript.
+func (m *MainModel) showConsole() (*MainModel, tea.Cmd) {
 	if m.viewMode != "history" {
 		m.viewMode = "history"
 		// If in AI conversation mode, also deactivate it
@@ -23,8 +30,8 @@ func (m *MainModel) handleF2() (*MainModel, tea.Cmd) {
 	return m, nil
 }
 
-// handleF3 handles F3 key - switch to table view
-func (m *MainModel) handleF3() (*MainModel, tea.Cmd) {
+// showResults switches to the last query's output.
+func (m *MainModel) showResults() (*MainModel, tea.Cmd) {
 	if m.viewMode != "table" {
 		m.viewMode = "table"
 		// If in AI conversation mode, also deactivate it
@@ -45,8 +52,8 @@ func (m *MainModel) handleF3() (*MainModel, tea.Cmd) {
 	return m, nil
 }
 
-// handleF4 handles F4 key - switch to trace view
-func (m *MainModel) handleF4() (*MainModel, tea.Cmd) {
+// showTrace switches to the query trace.
+func (m *MainModel) showTrace() (*MainModel, tea.Cmd) {
 	if m.viewMode != "trace" {
 		m.viewMode = "trace"
 		// If in AI conversation mode, also deactivate it
@@ -69,8 +76,21 @@ func (m *MainModel) handleF4() (*MainModel, tea.Cmd) {
 	return m, nil
 }
 
-// handleF5 handles F5 key - switch to AI view
-func (m *MainModel) handleF5() (*MainModel, tea.Cmd) {
+// showSchema switches to the schema browser, or asks the cluster again when it
+// is already showing.
+func (m *MainModel) showSchema() (*MainModel, tea.Cmd) {
+	if !m.connected() {
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Not connected.") +
+			m.styles.MutedText.Render(" There is no schema to browse.") + "\n"
+		m.updateHistoryWrapping()
+		m.historyViewport.GotoBottom()
+		return m, nil
+	}
+	return m.openSchema()
+}
+
+// showChat switches to the AI conversation.
+func (m *MainModel) showChat() (*MainModel, tea.Cmd) {
 	// Say why rather than doing nothing. A key that silently does nothing is
 	// how someone concludes the build is broken.
 	if !m.aiAvailable() {
@@ -85,7 +105,7 @@ func (m *MainModel) handleF5() (*MainModel, tea.Cmd) {
 		m.viewMode = "ai"
 		m.aiConversationActive = true
 
-		// Clear any existing conversation ID when entering AI view via F5
+		// Clear any existing conversation ID when entering the chat view
 		// This ensures we start fresh
 		m.aiConversationID = ""
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -124,6 +124,7 @@ type MainModel struct {
 	help             helpWindow     // Open help window, if any
 	capture          capturePanel   // Open capture window, if any
 	preferences      preferences    // Open PREFERENCES window, if any
+	schema           schemaBrowser  // The SCHEMA view's tree and what it is showing
 
 	// lastRawData is the values behind lastTableData for a result that arrived
 	// whole, so JSON is written from what came back rather than from what was

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -279,6 +279,15 @@ func (m *MainModel) handleMousePress(mouse tea.Mouse) (*MainModel, tea.Cmd) {
 		return m.clickStatusSetting(mouse.X)
 	}
 
+	// A press on the schema tree picks what it lands on. The definition beside
+	// it is text like any other view, and a press there starts a selection, so
+	// what is on screen can still be copied out.
+	if m.viewMode == "schema" {
+		if _, hit := m.schemaRowAt(mouse.X, mouse.Y); hit {
+			return m.clickSchema(mouse.X, mouse.Y)
+		}
+	}
+
 	return m.beginSelection(mouse.X, mouse.Y)
 }
 
@@ -314,6 +323,18 @@ func (m *MainModel) pressOpensCapture(mouse tea.Mouse) bool {
 
 // handleMouseWheel scrolls the view under the pointer.
 func (m *MainModel) handleMouseWheel(mouse tea.Mouse) (*MainModel, tea.Cmd) {
+	// The schema view is two panes, and the wheel moves whichever one it is
+	// over rather than whichever was touched last.
+	if m.viewMode == "schema" && !m.preferences.active && !m.form.active && !m.help.active {
+		switch mouse.Button {
+		case tea.MouseWheelUp:
+			return m.scrollSchema(mouse.X, -wheelLines)
+		case tea.MouseWheelDown:
+			return m.scrollSchema(mouse.X, wheelLines)
+		}
+		return m, nil
+	}
+
 	// The preferences window is longer than the screen, so the wheel over it
 	// moves whichever of its two lists is under the pointer.
 	if m.preferences.active {
@@ -539,13 +560,15 @@ func (m *MainModel) clickTab(col int) (*MainModel, tea.Cmd) {
 
 	switch mode {
 	case "history":
-		return m.handleF2()
+		return m.showConsole()
 	case "table":
-		return m.handleF3()
+		return m.showResults()
 	case "trace":
-		return m.handleF4()
+		return m.showTrace()
+	case "schema":
+		return m.showSchema()
 	case "ai":
-		return m.handleF5()
+		return m.showChat()
 	}
 	return m, nil
 }

--- a/internal/ui/schema_browser.go
+++ b/internal/ui/schema_browser.go
@@ -1,0 +1,428 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/axonops/cqlai/internal/logger"
+)
+
+// The SCHEMA view: the cluster's keyspaces and tables as a tree, with the
+// definition of whatever is selected beside it.
+//
+// Reading a table's definition meant typing DESCRIBE TABLE and knowing the name
+// already. What you usually want first is to look - which keyspaces are there,
+// what is in them, and what does that table look like.
+//
+// The definitions are the ones DESCRIBE produces, through the same calls, so
+// the pane and the command cannot come to disagree about what a table is.
+
+// schemaRow is one line of the tree: a keyspace, or a table inside one.
+type schemaRow struct {
+	keyspace string
+	table    string // empty on a keyspace row
+}
+
+// key names a row, for the definitions kept against it.
+func (r schemaRow) key() string {
+	if r.table == "" {
+		return r.keyspace
+	}
+	return r.keyspace + "." + r.table
+}
+
+// schemaBrowser is the state of the view.
+type schemaBrowser struct {
+	loaded    bool
+	keyspaces []string
+	tables    map[string][]string
+	expanded  map[string]bool
+
+	// definitions are kept as they are fetched. A definition is a round trip to
+	// the cluster, and walking back up a tree should not repeat it.
+	definitions map[string]string
+
+	selected int // index into rows()
+	scroll   int // first row of the tree showing
+
+	detail       []string // the definition of the selected row, by line
+	detailScroll int
+	detailWidth  int // the widest line, for scrolling sideways later
+
+	message string // what to say when there is no tree to draw
+}
+
+// rows is the tree as it stands: every keyspace, and the tables of the ones
+// that are open.
+//
+// Drawing, clicking and moving the selection all come from this, so a click
+// cannot land on a different row from the one drawn there.
+func (s schemaBrowser) rows() []schemaRow {
+	rows := make([]schemaRow, 0, len(s.keyspaces)*2)
+	for _, keyspace := range s.keyspaces {
+		rows = append(rows, schemaRow{keyspace: keyspace})
+		if !s.expanded[keyspace] {
+			continue
+		}
+		for _, table := range s.tables[keyspace] {
+			rows = append(rows, schemaRow{keyspace: keyspace, table: table})
+		}
+	}
+	return rows
+}
+
+// current is the selected row.
+func (s schemaBrowser) current() (schemaRow, bool) {
+	rows := s.rows()
+	if s.selected < 0 || s.selected >= len(rows) {
+		return schemaRow{}, false
+	}
+	return rows[s.selected], true
+}
+
+// openSchema switches to the view, fetching the keyspaces the first time.
+//
+// Nothing is fetched until then: a cluster can hold hundreds of keyspaces, and
+// this should cost nothing to anyone not looking at it.
+func (m *MainModel) openSchema() (*MainModel, tea.Cmd) {
+	if m.viewMode == "schema" {
+		// Already here: the tab is the way to ask for it again, for a cluster
+		// that has changed underneath you.
+		return m.refreshSchema()
+	}
+
+	m.viewMode = "schema"
+	m.leaveAIConversation()
+	m.input.Focus()
+
+	if !m.schema.loaded {
+		m.loadSchema()
+	}
+	return m, nil
+}
+
+// refreshSchema drops everything and asks the cluster again.
+func (m *MainModel) refreshSchema() (*MainModel, tea.Cmd) {
+	open := m.schema.expanded
+	m.schema = schemaBrowser{}
+	m.loadSchema()
+
+	// The keyspaces that were open stay open, so asking for the schema again
+	// does not close the tree you were reading.
+	for keyspace, wasOpen := range open {
+		if wasOpen {
+			m.schema.expanded[keyspace] = true
+			m.schema.tables[keyspace] = m.tablesOf(keyspace)
+		}
+	}
+	m.showSchemaDetail()
+	return m, nil
+}
+
+// loadSchema fetches the keyspaces.
+func (m *MainModel) loadSchema() {
+	m.schema.loaded = true
+	m.schema.tables = map[string][]string{}
+	m.schema.expanded = map[string]bool{}
+	m.schema.definitions = map[string]string{}
+	m.schema.message = ""
+
+	if !m.connected() {
+		m.schema.message = "Not connected."
+		return
+	}
+
+	m.schema.keyspaces = m.keyspaceChoices()
+	if len(m.schema.keyspaces) == 0 {
+		m.schema.message = "No keyspaces."
+		return
+	}
+
+	// Open on the keyspace in use, if there is one: it is the one the session
+	// is already about.
+	if current := m.currentKeyspace(); current != "" {
+		for i, keyspace := range m.schema.keyspaces {
+			if keyspace == current {
+				m.schema.selected = i
+				m.schema.expanded[keyspace] = true
+				m.schema.tables[keyspace] = m.tablesOf(keyspace)
+				break
+			}
+		}
+	}
+	m.showSchemaDetail()
+}
+
+// tablesOf is the tables of a keyspace, fetched the first time they are wanted.
+func (m *MainModel) tablesOf(keyspace string) []string {
+	if names, ok := m.schema.tables[keyspace]; ok {
+		return names
+	}
+
+	names := m.tableChoices(keyspace)
+	m.schema.tables[keyspace] = names
+	return names
+}
+
+// showSchemaDetail puts the definition of the selected row in the right-hand
+// pane, fetching it the first time it is asked for.
+func (m *MainModel) showSchemaDetail() {
+	m.schema.detail = nil
+	m.schema.detailScroll = 0
+	m.schema.detailWidth = 0
+
+	row, ok := m.schema.current()
+	if !ok {
+		return
+	}
+
+	text, known := m.schema.definitions[row.key()]
+	if !known {
+		text = m.describeSchemaRow(row)
+		m.schema.definitions[row.key()] = text
+	}
+
+	m.schema.detail = strings.Split(text, "\n")
+	for _, line := range m.schema.detail {
+		m.schema.detailWidth = max(m.schema.detailWidth, lipglossWidthOf(line))
+	}
+}
+
+// describeSchemaRow asks the cluster what something is.
+//
+// The same calls DESCRIBE makes: a keyspace is its whole schema, the way
+// DESCRIBE KEYSPACE gives it, and a table is its CREATE TABLE.
+func (m *MainModel) describeSchemaRow(row schemaRow) string {
+	if !m.connected() {
+		return "Not connected."
+	}
+
+	if row.table == "" {
+		schema, err := m.session.DBDescribeFullSchema(m.sessionManager, row.keyspace)
+		if err != nil {
+			logger.DebugfToFile("Schema", "Describing keyspace %s: %v", row.keyspace, err)
+			return fmt.Sprintf("Cannot describe %s: %v", row.keyspace, err)
+		}
+		if text, ok := schema.(string); ok {
+			return text
+		}
+		return fmt.Sprint(schema)
+	}
+
+	info, err := m.session.DescribeTableQuery(row.keyspace, row.table)
+	if err != nil {
+		logger.DebugfToFile("Schema", "Describing table %s: %v", row.key(), err)
+		return fmt.Sprintf("Cannot describe %s: %v", row.key(), err)
+	}
+	if info == nil {
+		return fmt.Sprintf("%s not found.", row.key())
+	}
+	// Without the "Table: ks.name" line it puts at the top: the heading over
+	// the pane says which table this is, and saying it twice wastes the first
+	// two rows of every definition.
+	return db.FormatTableCreateStatement(info, false)
+}
+
+// selectSchemaRow moves the selection and shows what it lands on.
+func (m *MainModel) selectSchemaRow(i int) (*MainModel, tea.Cmd) {
+	rows := m.schema.rows()
+	if len(rows) == 0 {
+		return m, nil
+	}
+
+	m.schema.selected = min(max(i, 0), len(rows)-1)
+	m.showSchemaDetail()
+	return m, nil
+}
+
+// moveSchemaSelection moves it by n rows, stopping at the ends.
+func (m *MainModel) moveSchemaSelection(n int) (*MainModel, tea.Cmd) {
+	return m.selectSchemaRow(m.schema.selected + n)
+}
+
+// toggleSchemaRow opens or closes a keyspace.
+//
+// A table has nothing to open, so pressing Enter on one shows it again - which
+// is what it does anyway, and is better than doing nothing.
+func (m *MainModel) toggleSchemaRow() (*MainModel, tea.Cmd) {
+	row, ok := m.schema.current()
+	if !ok || row.table != "" {
+		return m, nil
+	}
+
+	if m.schema.expanded[row.keyspace] {
+		m.schema.expanded[row.keyspace] = false
+		return m, nil
+	}
+
+	m.schema.expanded[row.keyspace] = true
+	m.tablesOf(row.keyspace)
+	return m, nil
+}
+
+// expandSchemaRow opens a keyspace, or steps into it when it is already open.
+func (m *MainModel) expandSchemaRow() (*MainModel, tea.Cmd) {
+	row, ok := m.schema.current()
+	if !ok || row.table != "" {
+		return m, nil
+	}
+
+	if !m.schema.expanded[row.keyspace] {
+		return m.toggleSchemaRow()
+	}
+	if len(m.schema.tables[row.keyspace]) > 0 {
+		return m.moveSchemaSelection(1)
+	}
+	return m, nil
+}
+
+// collapseSchemaRow closes a keyspace, or goes up to the one holding a table.
+func (m *MainModel) collapseSchemaRow() (*MainModel, tea.Cmd) {
+	row, ok := m.schema.current()
+	if !ok {
+		return m, nil
+	}
+
+	if row.table != "" {
+		// Up to the keyspace it is in, which is where closing happens.
+		for i, r := range m.schema.rows() {
+			if r.keyspace == row.keyspace && r.table == "" {
+				return m.selectSchemaRow(i)
+			}
+		}
+		return m, nil
+	}
+
+	m.schema.expanded[row.keyspace] = false
+	return m, nil
+}
+
+// scrollSchemaDetail moves the right-hand pane.
+func (m *MainModel) scrollSchemaDetail(n, height int) (*MainModel, tea.Cmd) {
+	if len(m.schema.detail) <= height {
+		m.schema.detailScroll = 0
+		return m, nil
+	}
+
+	m.schema.detailScroll = min(max(m.schema.detailScroll+n, 0), len(m.schema.detail)-height)
+	return m, nil
+}
+
+// leaveAIConversation puts the chat view away, which every other view has to do
+// when it takes over.
+func (m *MainModel) leaveAIConversation() {
+	if !m.aiConversationActive {
+		return
+	}
+
+	m.aiConversationActive = false
+	m.aiConversationInput.SetValue("")
+	m.aiProcessing = false
+	m.input.Placeholder = "Enter CQL command..."
+	m.input.SetValue("")
+}
+
+// lipglossWidthOf is the drawn width of a line, ignoring any colour in it.
+func lipglossWidthOf(line string) int {
+	return len([]rune(stripAnsi(line)))
+}
+
+// schemaKey handles the keys that work the tree, and reports whether it took
+// the press.
+//
+// Only the keys that move around the view: everything else goes to the prompt,
+// which still works from here. Typing a query while looking at a table's
+// definition is the whole point of having both on one screen.
+func (m *MainModel) schemaKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd, bool) {
+	height := m.schemaHeight()
+
+	switch msg.String() {
+	case "up":
+		updated, cmd := m.moveSchemaSelection(-1)
+		return updated, cmd, true
+	case "down":
+		updated, cmd := m.moveSchemaSelection(1)
+		return updated, cmd, true
+	case "left":
+		updated, cmd := m.collapseSchemaRow()
+		return updated, cmd, true
+	case "right":
+		updated, cmd := m.expandSchemaRow()
+		return updated, cmd, true
+	case "enter":
+		// Only on a keyspace, and only when the prompt is empty: a typed
+		// statement is what Enter is for everywhere in cqlai, and this view
+		// does not take that away.
+		if strings.TrimSpace(m.input.Value()) != "" {
+			return m, nil, false
+		}
+		updated, cmd := m.toggleSchemaRow()
+		return updated, cmd, true
+	case "pgup":
+		updated, cmd := m.moveSchemaSelection(-height)
+		return updated, cmd, true
+	case "pgdown":
+		updated, cmd := m.moveSchemaSelection(height)
+		return updated, cmd, true
+	case "home":
+		updated, cmd := m.selectSchemaRow(0)
+		return updated, cmd, true
+	case "end":
+		updated, cmd := m.selectSchemaRow(len(m.schema.rows()) - 1)
+		return updated, cmd, true
+	case "alt+up":
+		updated, cmd := m.scrollSchemaDetail(-1, height)
+		return updated, cmd, true
+	case "alt+down":
+		updated, cmd := m.scrollSchemaDetail(1, height)
+		return updated, cmd, true
+	}
+	return m, nil, false
+}
+
+// clickSchema selects the row under the pointer, and opens or closes a keyspace
+// when the row was already selected.
+//
+// A first click says which one you mean and shows it; the second folds it.
+// Clicking a keyspace shut the moment you asked to see it would make its
+// schema, which is what the click was for, flash past.
+func (m *MainModel) clickSchema(col, row int) (*MainModel, tea.Cmd) {
+	i, ok := m.schemaRowAt(col, row)
+	if !ok {
+		return m, nil
+	}
+
+	if i == m.schema.selected {
+		return m.toggleSchemaRow()
+	}
+	return m.selectSchemaRow(i)
+}
+
+// scrollSchema moves whichever pane the pointer is over.
+//
+// Which side of the divider decides it, and nothing else: the wheel arrives
+// over any row of the view, the headings included, and all of them belong to
+// the pane they are drawn in.
+func (m *MainModel) scrollSchema(col, delta int) (*MainModel, tea.Cmd) {
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	if col >= g.treeWidth {
+		return m.scrollSchemaDetail(delta, g.height)
+	}
+
+	// The tree scrolls by moving the selection, so what is showing and what is
+	// selected cannot drift apart - and the definition follows, which is what
+	// scrolling a tree of schema objects is for.
+	return m.moveSchemaSelection(delta)
+}
+
+// connected reports whether there is a cluster to ask.
+//
+// The session is built before it is connected, so having one is not the same as
+// being able to query through it: a half-built session takes a query straight
+// into a nil pointer inside the driver.
+func (m *MainModel) connected() bool {
+	return m.session != nil && m.session.Session != nil
+}

--- a/internal/ui/schema_browser_test.go
+++ b/internal/ui/schema_browser_test.go
@@ -1,0 +1,333 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// connectedSession is a session that passes the connected check without being
+// able to answer anything.
+//
+// Enough for the tab to be available and the view to be reachable; a test that
+// wants a tree gives the browser one directly, since what is being tested is
+// the tree and the panes rather than the trip to Cassandra.
+func connectedSession() *db.Session {
+	return &db.Session{Session: &gocql.Session{}}
+}
+
+// schemaModel is the SCHEMA view on a cluster of three keyspaces, with the
+// definitions already in hand: what is being tested is the tree and the panes,
+// not the trip to Cassandra.
+func schemaModel(t *testing.T) *MainModel {
+	t.Helper()
+
+	m := &MainModel{
+		styles:          DefaultStyles(),
+		viewMode:        "schema",
+		windowWidth:     100,
+		windowHeight:    24,
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(8)),
+	}
+	m.input.Focus() // as it is for as long as cqlai is running
+	m.schema = schemaBrowser{
+		loaded:    true,
+		keyspaces: []string{"my_keyspace", "system", "system_schema"},
+		tables:    map[string][]string{"my_keyspace": {"events", "users"}},
+		expanded:  map[string]bool{},
+		definitions: map[string]string{
+			"my_keyspace": "CREATE KEYSPACE my_keyspace WITH replication = {...};",
+			// As FormatTableCreateStatement gives it with no header line: the
+			// pane's heading already says which table this is.
+			"my_keyspace.users": "CREATE TABLE my_keyspace.users (\n    id uuid PRIMARY KEY\n);",
+		},
+	}
+	m.showSchemaDetail()
+	return m
+}
+
+func treeRows(m *MainModel) []string {
+	rows := make([]string, 0, len(m.schema.rows()))
+	for _, row := range m.schema.rows() {
+		name := strings.TrimSpace(m.schemaLine(row))
+		name = strings.TrimPrefix(strings.TrimPrefix(name, "▾ "), "▸ ")
+		rows = append(rows, name)
+	}
+	return rows
+}
+
+// TestTheTreeIsKeyspacesUntilOneIsOpened.
+func TestTheTreeIsKeyspacesUntilOneIsOpened(t *testing.T) {
+	m := schemaModel(t)
+	assert.Equal(t, []string{"my_keyspace", "system", "system_schema"}, treeRows(m))
+
+	m, _ = m.toggleSchemaRow()
+	assert.Equal(t, []string{"my_keyspace", "events", "users", "system", "system_schema"}, treeRows(m))
+
+	m, _ = m.toggleSchemaRow()
+	assert.Equal(t, []string{"my_keyspace", "system", "system_schema"}, treeRows(m),
+		"the keyspace should have folded shut again")
+}
+
+// TestTheMarkerSaysWhichWayAKeyspaceIsFolded.
+func TestTheMarkerSaysWhichWayAKeyspaceIsFolded(t *testing.T) {
+	m := schemaModel(t)
+	row := m.schema.rows()[0]
+
+	assert.Equal(t, "▸ my_keyspace", m.schemaLine(row))
+	m, _ = m.toggleSchemaRow()
+	assert.Equal(t, "▾ my_keyspace", m.schemaLine(row))
+}
+
+// TestSelectingARowShowsItsSchema, which is what the right-hand pane is for.
+func TestSelectingARowShowsItsSchema(t *testing.T) {
+	m := schemaModel(t)
+	assert.Contains(t, strings.Join(m.schema.detail, "\n"), "CREATE KEYSPACE my_keyspace")
+
+	m, _ = m.toggleSchemaRow()
+	m, _ = m.selectSchemaRow(2) // my_keyspace.users
+	assert.Contains(t, strings.Join(m.schema.detail, "\n"), "CREATE TABLE my_keyspace.users")
+}
+
+// TestClickingARowSelectsIt, and clicking the selected keyspace folds it.
+//
+// A first click says which one you mean and shows it; the second folds it.
+// Folding on the first would make the schema, which is what the click was for,
+// flash past.
+func TestClickingARowSelectsIt(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow() // my_keyspace open: keyspace, events, users, ...
+
+	// The row a click lands on is the row drawn there, below the heading.
+	for i, row := range m.schema.rows() {
+		got, hit := m.schemaRowAt(1, tabBarHeight+schemaHeaderRows+i)
+		require.True(t, hit, "nothing at the row %s is drawn on", row.key())
+		assert.Equal(t, i, got, "clicking %s landed on %s", row.key(), m.schema.rows()[got].key())
+	}
+
+	m, _ = m.clickSchema(1, tabBarHeight+schemaHeaderRows+2) // users
+	assert.Equal(t, 2, m.schema.selected)
+	assert.Contains(t, strings.Join(m.schema.detail, "\n"), "CREATE TABLE my_keyspace.users")
+
+	// Clicking the open keyspace again folds it.
+	m, _ = m.clickSchema(1, tabBarHeight+schemaHeaderRows)
+	require.Equal(t, 0, m.schema.selected)
+	m, _ = m.clickSchema(1, tabBarHeight+schemaHeaderRows)
+	assert.False(t, m.schema.expanded["my_keyspace"])
+}
+
+// TestAPressOnTheDefinitionIsNotAClickOnTheTree: the right-hand pane is text,
+// and a press there starts a selection so it can be copied out.
+func TestAPressOnTheDefinitionIsNotAClickOnTheTree(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow()
+
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	_, hit := m.schemaRowAt(g.treeWidth+4, tabBarHeight+schemaHeaderRows)
+	assert.False(t, hit)
+	assert.True(t, m.inSchemaDetail(g.treeWidth+4, tabBarHeight+schemaHeaderRows))
+
+	// And the heading itself is not a row of the tree.
+	_, hit = m.schemaRowAt(1, tabBarHeight)
+	assert.False(t, hit, "the heading is not a keyspace")
+}
+
+// TestTheArrowsWalkTheTree: down and up move, right opens, left closes.
+func TestTheArrowsWalkTheTree(t *testing.T) {
+	m := schemaModel(t)
+
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.True(t, m.schema.expanded["my_keyspace"], "right should have opened it")
+
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	row, ok := m.schema.current()
+	require.True(t, ok)
+	assert.Equal(t, "events", row.table)
+
+	// Left from a table goes up to the keyspace holding it; left again closes.
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	row, _ = m.schema.current()
+	assert.Equal(t, "", row.table)
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.False(t, m.schema.expanded["my_keyspace"])
+
+	// And it stops at the ends rather than wrapping.
+	m, _ = m.selectSchemaRow(0)
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, 0, m.schema.selected)
+	m, _ = m.selectSchemaRow(len(m.schema.rows()) - 1)
+	m, _, _ = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, len(m.schema.rows())-1, m.schema.selected)
+}
+
+// TestTypingStillGoesToThePrompt. The view takes the keys that move around it
+// and no others: a query can be typed while looking at the table it is about.
+func TestTypingStillGoesToThePrompt(t *testing.T) {
+	m := schemaModel(t)
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: 'e', Text: "e"})
+
+	assert.Equal(t, "se", m.input.Value())
+	assert.Equal(t, "schema", m.viewMode, "typing should not have left the view")
+}
+
+// TestEnterRunsWhatIsTypedRatherThanFoldingTheTree.
+func TestEnterRunsWhatIsTypedRatherThanFoldingTheTree(t *testing.T) {
+	m := schemaModel(t)
+	m.input.SetValue("SELECT * FROM users")
+
+	_, _, handled := m.schemaKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.False(t, handled, "Enter with a statement typed belongs to the prompt")
+
+	m.input.SetValue("")
+	_, _, handled = m.schemaKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.True(t, handled)
+}
+
+// TestTheSelectionStaysOnScreen as it moves down a tree longer than the view.
+func TestTheSelectionStaysOnScreen(t *testing.T) {
+	m := schemaModel(t)
+	m.schema.keyspaces = nil
+	for i := range 40 {
+		m.schema.keyspaces = append(m.schema.keyspaces, "keyspace_"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+	}
+
+	for i := range 40 {
+		m, _ = m.selectSchemaRow(i)
+		g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+		assert.GreaterOrEqual(t, m.schema.selected, g.treeFirst, "row %d scrolled off the top", i)
+		assert.Less(t, m.schema.selected, g.treeFirst+g.height, "row %d scrolled off the bottom", i)
+	}
+}
+
+// TestTheViewIsAsWideAndTallAsTheScreen, with the panes side by side.
+func TestTheViewIsAsWideAndTallAsTheScreen(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow()
+
+	for _, size := range [][2]int{{100, 16}, {80, 8}, {200, 40}, {40, 6}} {
+		drawn := m.viewSchema(size[0], size[1])
+		lines := strings.Split(drawn, "\n")
+		assert.Len(t, lines, size[1], "%v: wrong number of rows", size)
+		for _, line := range lines {
+			assert.Equal(t, size[0], lipglossWidthOf(line), "%v: ragged row %q", size, stripAnsi(line))
+		}
+	}
+}
+
+// TestTheDefinitionScrollsOnItsOwn, since it is longer than the tree beside it.
+func TestTheDefinitionScrollsOnItsOwn(t *testing.T) {
+	m := schemaModel(t)
+	m.schema.detail = strings.Split(strings.Repeat("line\n", 40), "\n")
+	height := m.schemaHeight()
+
+	m, _ = m.scrollSchemaDetail(5, height)
+	assert.Equal(t, 5, m.schema.detailScroll)
+	assert.Equal(t, 0, m.schema.selected, "the tree should not have moved")
+
+	for range 100 {
+		m, _ = m.scrollSchemaDetail(5, height)
+	}
+	assert.Equal(t, len(m.schema.detail)-height, m.schema.detailScroll, "it should stop at the end")
+
+	for range 100 {
+		m, _ = m.scrollSchemaDetail(-5, height)
+	}
+	assert.Zero(t, m.schema.detailScroll)
+}
+
+// TestTheWheelMovesThePaneItIsOver.
+func TestTheWheelMovesThePaneItIsOver(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow() // five rows, so there is somewhere to scroll to
+	m, _ = m.selectSchemaRow(0)
+	m.schema.detail = strings.Split(strings.Repeat("line\n", 40), "\n")
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+
+	m, _ = m.scrollSchema(g.treeWidth+4, wheelLines)
+	assert.Equal(t, wheelLines, m.schema.detailScroll)
+	assert.Equal(t, 0, m.schema.selected)
+
+	m, _ = m.scrollSchema(1, wheelLines)
+	assert.Equal(t, wheelLines, m.schema.selected, "over the tree it moves the selection")
+}
+
+// TestAKeyspaceOpensOnTheOneInUse, which is the one the session is about.
+func TestNothingConnectedSaysSo(t *testing.T) {
+	m := schemaModel(t)
+	m.schema = schemaBrowser{}
+	m.loadSchema()
+
+	assert.Equal(t, "Not connected.", m.schema.message)
+	assert.Empty(t, m.schema.rows())
+
+	// And the view still draws, rather than leaving an empty screen.
+	assert.Contains(t, stripAnsi(m.viewSchema(m.windowWidth, 8)), "Not connected.")
+}
+
+// TestEachPaneSaysWhatItIs: a column of names with nothing over it, beside a
+// block of text with nothing over that, leaves both to be worked out.
+func TestEachPaneSaysWhatItIs(t *testing.T) {
+	m := schemaModel(t)
+
+	drawn := strings.Split(stripAnsi(m.viewSchema(m.windowWidth, 8)), "\n")
+	require.GreaterOrEqual(t, len(drawn), 2)
+	assert.Contains(t, drawn[0], schemaTreeHeading)
+	assert.Contains(t, drawn[1], "───", "a rule under the headings")
+
+	// The right-hand heading says what is being shown, not just that something
+	// is: which keyspace, or which table.
+	assert.Contains(t, drawn[0], "KEYSPACE  my_keyspace")
+
+	m, _ = m.toggleSchemaRow()
+	m, _ = m.selectSchemaRow(2)
+	drawn = strings.Split(stripAnsi(m.viewSchema(m.windowWidth, 8)), "\n")
+	assert.Contains(t, drawn[0], "TABLE  my_keyspace.users")
+
+	// And the definition does not repeat it: the pane says which table this is,
+	// so the CREATE statement starts on the first row rather than the third.
+	assert.Contains(t, drawn[2], "CREATE TABLE")
+}
+
+// TestTheHeadingsStayWhileTheTreeScrolls: they are the two rows that say what
+// each side is, so they cannot be the first thing to scroll away.
+func TestTheHeadingsStayWhileTheTreeScrolls(t *testing.T) {
+	m := schemaModel(t)
+	m.schema.keyspaces = nil
+	for i := range 40 {
+		m.schema.keyspaces = append(m.schema.keyspaces, "keyspace_"+string(rune('a'+i%26)))
+	}
+	m, _ = m.selectSchemaRow(39)
+
+	drawn := strings.Split(stripAnsi(m.viewSchema(m.windowWidth, 8)), "\n")
+	assert.Contains(t, drawn[0], schemaTreeHeading)
+	assert.Contains(t, drawn[1], "───")
+}
+
+// TestSchemaSitsNextToTheConsole: what is in the database comes before anything
+// a query has made of it, and the three that follow are all views of a result.
+func TestSchemaSitsNextToTheConsole(t *testing.T) {
+	order := make([]string, 0, len(modeTabs))
+	for _, tab := range modeTabs {
+		order = append(order, tab.mode)
+	}
+	assert.Equal(t, []string{"history", "schema", "table", "trace", "ai"}, order)
+
+	// And the keys read along the line with them: a bar whose keys are out of
+	// order is one you have to read rather than count along.
+	keys := make([]string, 0, len(modeTabs))
+	for _, tab := range modeTabs {
+		keys = append(keys, tab.key)
+	}
+	assert.Equal(t, []string{"F2", "F3", "F4", "F5", "F6"}, keys)
+}

--- a/internal/ui/schema_view.go
+++ b/internal/ui/schema_view.go
@@ -1,0 +1,233 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Drawing the SCHEMA view, and working out what a click landed on.
+//
+// One description of the layout: where the tree stops and the definition
+// starts, and which row is which. Two copies of that is how a click selects the
+// keyspace above the one pointed at.
+
+const (
+	// schemaTreeMin and schemaTreeMax bound the left-hand pane. Wide enough for
+	// a keyspace name and the marker in front of it, and never so wide that the
+	// definition beside it has nowhere to go.
+	schemaTreeMin = 18
+	schemaTreeMax = 40
+
+	// schemaDivider separates the panes, in the same grey as the one on the
+	// COPY forms.
+	schemaDivider = " │ "
+
+	// schemaIndent is how far a table sits inside its keyspace: under the name
+	// above it, clear of the marker.
+	schemaIndent = "    "
+
+	// schemaHeaderRows is the heading over each pane and the rule under it.
+	// Two rows of a screen, so that neither column is a list of names with
+	// nothing saying what they are or what the text beside them describes.
+	schemaHeaderRows = 2
+
+	// schemaTreeHeading names the left-hand pane. The tables are inside the
+	// keyspaces rather than beside them, so the keyspaces are what it lists.
+	schemaTreeHeading = "KEYSPACES"
+)
+
+// schemaGeometry is where the panes are, and which rows they show.
+type schemaGeometry struct {
+	width, height int
+	treeWidth     int // the left pane, including its scrollbar column
+	detailWidth   int
+	treeFirst     int // the first tree row drawn
+	detailFirst   int // the first line of the definition drawn
+}
+
+// schemaGeometryFor places the panes for a screen.
+func (m *MainModel) schemaGeometry(width, height int) schemaGeometry {
+	tree := min(max(m.schemaTreeWidth(), schemaTreeMin), schemaTreeMax)
+	tree = min(tree, max(width/2, 1))
+
+	g := schemaGeometry{
+		width:       width,
+		height:      max(height-schemaHeaderRows, 1),
+		treeWidth:   tree,
+		detailWidth: max(width-tree-lipgloss.Width(schemaDivider), 1),
+	}
+
+	// The selection stays on screen, and the pane moves only as far as it takes
+	// to keep it there: walking a long list should not jump it about.
+	rows := len(m.schema.rows())
+	first := min(m.schema.scroll, m.schema.selected)
+	first = max(first, m.schema.selected-g.height+1)
+	first = min(first, max(rows-g.height, 0))
+	g.treeFirst = max(first, 0)
+
+	g.detailFirst = min(max(m.schema.detailScroll, 0), max(len(m.schema.detail)-g.height, 0))
+	return g
+}
+
+// schemaTreeWidth is how wide the tree wants to be: its widest row, and a
+// column for the scrollbar.
+func (m *MainModel) schemaTreeWidth() int {
+	width := lipgloss.Width(schemaTreeHeading)
+	for _, row := range m.schema.rows() {
+		width = max(width, lipgloss.Width(m.schemaLine(row)))
+	}
+	if m.schema.message != "" {
+		width = max(width, lipgloss.Width(m.schema.message))
+	}
+	return width + 2
+}
+
+// schemaDetailHeading names what the right-hand pane is showing: a table's
+// definition, a keyspace's, or nothing yet.
+func (m *MainModel) schemaDetailHeading() string {
+	row, ok := m.schema.current()
+	if !ok {
+		return "DEFINITION"
+	}
+	if row.table != "" {
+		return "TABLE  " + row.key()
+	}
+	return "KEYSPACE  " + row.keyspace
+}
+
+// schemaLine is a row as it is drawn: a keyspace with the marker saying which
+// way it is folded, or a table indented under the one holding it.
+//
+// Drawing and measuring both come from here, so the pane cannot be sized for
+// one thing and drawn with another.
+func (m *MainModel) schemaLine(row schemaRow) string {
+	if row.table != "" {
+		return schemaIndent + row.table
+	}
+	if m.schema.expanded[row.keyspace] {
+		return "▾ " + row.keyspace
+	}
+	return "▸ " + row.keyspace
+}
+
+// viewSchema draws the whole view: the tree, the divider and the definition.
+func (m *MainModel) viewSchema(width, height int) string {
+	g := m.schemaGeometry(width, height)
+
+	rows := m.schema.rows()
+	treeStyle := lipgloss.NewStyle().Foreground(m.styles.MutedText.GetForeground())
+	keyspaceStyle := lipgloss.NewStyle().Foreground(m.styles.Accent)
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#1c1c1c")).
+		Background(m.styles.Accent).
+		Bold(true)
+	ruleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
+	thumbStyle := lipgloss.NewStyle().Foreground(m.styles.Accent)
+	trackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3a3a3a"))
+
+	// The scrollbars say how much of each side you are looking at. A schema is
+	// a long thing in both panes and neither has a border to hint at it.
+	treeBar := scrollbarColumn(min(g.height, len(rows)), g.treeFirst, len(rows))
+	detailBar := scrollbarColumn(min(g.height, len(m.schema.detail)), g.detailFirst, len(m.schema.detail))
+
+	headingStyle := lipgloss.NewStyle().Foreground(m.styles.Accent).Bold(true)
+
+	lines := make([]string, 0, g.height+schemaHeaderRows)
+	lines = append(lines,
+		headingStyle.Render(pad(schemaTreeHeading, g.treeWidth))+
+			ruleStyle.Render(schemaDivider)+
+			headingStyle.Render(pad(m.schemaDetailHeading(), g.detailWidth)),
+		ruleStyle.Render(strings.Repeat("─", g.treeWidth)+schemaDivider+strings.Repeat("─", g.detailWidth)),
+	)
+
+	for i := range g.height {
+		// The left-hand pane.
+		text, style := "", treeStyle
+		switch {
+		case i == 0 && m.schema.message != "":
+			text = m.schema.message
+		case g.treeFirst+i < len(rows):
+			row := rows[g.treeFirst+i]
+			text = m.schemaLine(row)
+			switch {
+			case g.treeFirst+i == m.schema.selected:
+				style = selectedStyle
+			case row.table == "":
+				style = keyspaceStyle
+			}
+		}
+
+		left := style.Render(pad(text, g.treeWidth-1))
+		left += scrollbarCell(treeBar, i, len(rows) > g.height, thumbStyle, trackStyle)
+
+		// The right-hand pane.
+		definition := ""
+		if g.detailFirst+i < len(m.schema.detail) {
+			definition = m.schema.detail[g.detailFirst+i]
+		}
+		right := treeStyle.Render(pad(cut(definition, g.detailWidth-1), g.detailWidth-1))
+		right += scrollbarCell(detailBar, i, len(m.schema.detail) > g.height, thumbStyle, trackStyle)
+
+		lines = append(lines, left+ruleStyle.Render(schemaDivider)+right)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// scrollbarCell is one row of a scrollbar column, or a space where there is no
+// bar to draw.
+func scrollbarCell(thumb []bool, i int, scrolls bool, thumbStyle, trackStyle lipgloss.Style) string {
+	if !scrolls {
+		return " "
+	}
+	if i < len(thumb) && thumb[i] {
+		return thumbStyle.Render("█")
+	}
+	return trackStyle.Render("░")
+}
+
+// cut trims a line to the width it is drawn in, so a wide definition does not
+// push the panes apart.
+func cut(line string, width int) string {
+	runes := []rune(line)
+	if len(runes) <= width || width <= 0 {
+		return line
+	}
+	return string(runes[:width])
+}
+
+// schemaRowAt returns the tree row a press covers.
+func (m *MainModel) schemaRowAt(col, row int) (int, bool) {
+	if m.viewMode != "schema" {
+		return 0, false
+	}
+
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	if col < 0 || col >= g.treeWidth {
+		return 0, false
+	}
+
+	i := g.treeFirst + row - tabBarHeight - schemaHeaderRows
+	if i < g.treeFirst || i >= g.treeFirst+g.height || i >= len(m.schema.rows()) {
+		return 0, false
+	}
+	return i, true
+}
+
+// inSchemaDetail reports whether a press landed on the right-hand pane.
+func (m *MainModel) inSchemaDetail(col, row int) bool {
+	if m.viewMode != "schema" {
+		return false
+	}
+
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	return col >= g.treeWidth &&
+		row >= tabBarHeight+schemaHeaderRows &&
+		row < tabBarHeight+schemaHeaderRows+g.height
+}
+
+// schemaHeight is how many rows the view has, which is what every other view
+// gets: the window without the tabs, the bars and the prompt.
+func (m *MainModel) schemaHeight() int {
+	return m.historyViewport.Height()
+}

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -28,15 +28,19 @@ var modeTabs = []modeTab{
 	// is a different thing, and this view is the running transcript of what you
 	// typed and what came back.
 	{mode: "history", label: "CONSOLE", short: "C", key: "F2"},
+	// The cluster itself, next to the console: what is in the database comes
+	// before anything a query has made of it, and the three that follow are all
+	// views of a result.
+	{mode: "schema", label: "SCHEMA", short: "S", key: "F3"},
 	// "Results" rather than "Table": the same view shows EXPAND, ASCII and JSON
 	// output, none of which is a table, and "table" already means a schema
 	// object to anyone using this.
-	{mode: "table", label: "RESULTS", short: "R", key: "F3"},
-	{mode: "trace", label: "TRACE", short: "T", key: "F4"},
+	{mode: "table", label: "RESULTS", short: "R", key: "F4"},
+	{mode: "trace", label: "TRACE", short: "T", key: "F5"},
 	// "Chat" rather than "AI": it is a conversation, and what it is a
 	// conversation with is not the useful half of the name. Two letters
 	// because the console has the C.
-	{mode: "ai", label: "CHAT", short: "Ch", key: "F5"},
+	{mode: "ai", label: "CHAT", short: "Ch", key: "F6"},
 }
 
 // hasResults reports whether there is anything for SAVE to write.
@@ -52,6 +56,10 @@ func (m *MainModel) hasResults() bool {
 // did before, so nobody loses a shortcut they were used to.
 func (m *MainModel) tabAvailable(mode string) bool {
 	switch mode {
+	case "schema":
+		// There is no schema to browse with nothing connected, and the tab says
+		// so by being dimmed rather than by opening on an apology.
+		return m.connected()
 	case "table":
 		return m.hasTable
 	case "trace":

--- a/internal/ui/tabbar_test.go
+++ b/internal/ui/tabbar_test.go
@@ -48,12 +48,12 @@ func TestTabBarShowsKeysWhenThereIsRoom(t *testing.T) {
 	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
 
 	wide := stripAnsiForTest(m.ViewTabBar(120))
-	for _, want := range []string{"CONSOLE (F2)", "RESULTS (F3)", "TRACE (F4)", "CHAT (F5)"} {
+	for _, want := range []string{"CONSOLE (F2)", "SCHEMA (F3)", "RESULTS (F4)", "TRACE (F5)", "CHAT (F6)"} {
 		assert.Contains(t, wide, want)
 	}
 
 	// Narrower: names survive, key hints are dropped rather than wrapping.
-	medium := stripAnsiForTest(m.ViewTabBar(40))
+	medium := stripAnsiForTest(m.ViewTabBar(50))
 	assert.Contains(t, medium, "CONSOLE")
 	assert.Contains(t, medium, "RESULTS")
 	assert.NotContains(t, medium, "(F2)")
@@ -140,10 +140,10 @@ func TestTabAvailability(t *testing.T) {
 // tab line has to resolve back to the mode drawn there.
 func TestModeAtMapsClicksToTabs(t *testing.T) {
 	const width = 120
-	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
+	m := &MainModel{viewMode: "history", hasTable: true, hasTrace: true, session: connectedSession(), aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
 
 	spans := m.layoutTabs(width)
-	require.Len(t, modeSpans(spans), 4)
+	require.Len(t, modeSpans(spans), len(modeTabs))
 
 	for _, span := range spans {
 		for _, col := range []int{span.start, (span.start + span.end) / 2, span.end - 1} {
@@ -169,12 +169,14 @@ func TestModeAtMapsClicksToTabs(t *testing.T) {
 // unavailable must not respond.
 func TestUnavailableTabsIgnoreClicks(t *testing.T) {
 	const width = 120
-	m := &MainModel{viewMode: "history", aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}} // no results, no trace
+	// No results, no trace, and nothing connected: three of the five have
+	// nothing to show.
+	m := &MainModel{viewMode: "history", aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
 
 	for _, span := range m.layoutTabs(width) {
 		mode, ok := m.modeAt(width, (span.start+span.end)/2)
 		switch mode {
-		case "table", "trace":
+		case "table", "trace", "schema":
 			assert.False(t, ok, "%q has nothing to show and must not be clickable", mode)
 		default:
 			assert.True(t, ok, "%q should be clickable", mode)
@@ -389,9 +391,9 @@ func TestTheBarStillFitsWithoutAI(t *testing.T) {
 	}
 }
 
-// TestF5SaysWhyWhenAIIsNotConfigured. A key that silently does nothing is how
+// TestF6SaysWhyWhenAIIsNotConfigured. A key that silently does nothing is how
 // someone concludes the build is broken.
-func TestF5SaysWhyWhenAIIsNotConfigured(t *testing.T) {
+func TestF6SaysWhyWhenAIIsNotConfigured(t *testing.T) {
 	m := &MainModel{
 		viewMode:        "history",
 		styles:          DefaultStyles(),
@@ -399,9 +401,9 @@ func TestF5SaysWhyWhenAIIsNotConfigured(t *testing.T) {
 		historyViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
 	}
 
-	m.handleF5()
+	m.showChat()
 
-	assert.Equal(t, "history", m.viewMode, "F5 should not have opened an empty AI view")
+	assert.Equal(t, "history", m.viewMode, "F6 should not have opened an empty AI view")
 	assert.False(t, m.aiConversationActive)
 
 	said := stripAnsiForTest(m.fullHistoryContent)
@@ -409,8 +411,8 @@ func TestF5SaysWhyWhenAIIsNotConfigured(t *testing.T) {
 	assert.Contains(t, said, "cqlai.json", "it should say where to set it")
 }
 
-// TestF5StillOpensAIWhenConfigured.
-func TestF5StillOpensAIWhenConfigured(t *testing.T) {
+// TestF6StillOpensAIWhenConfigured.
+func TestF6StillOpensAIWhenConfigured(t *testing.T) {
 	m := &MainModel{
 		viewMode:        "history",
 		styles:          DefaultStyles(),
@@ -419,19 +421,19 @@ func TestF5StillOpensAIWhenConfigured(t *testing.T) {
 		historyViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
 	}
 
-	m.handleF5()
+	m.showChat()
 
 	assert.Equal(t, "ai", m.viewMode)
 	assert.True(t, m.aiConversationActive)
 	assert.Empty(t, m.fullHistoryContent, "nothing to explain when it is configured")
 }
 
-// TestF5IsNotAdvertisedWhenAIIsNotConfigured. Suggesting a key that then tells
+// TestF6IsNotAdvertisedWhenAIIsNotConfigured. Suggesting a key that then tells
 // you it cannot do anything is the same defect as showing the tab.
-func TestF5IsNotAdvertisedWhenAIIsNotConfigured(t *testing.T) {
+func TestF6IsNotAdvertisedWhenAIIsNotConfigured(t *testing.T) {
 	without := &MainModel{styles: DefaultStyles()}
 	with := &MainModel{styles: DefaultStyles(), aiConfig: configuredAI(), lastTableData: [][]string{{"id"}, {"1"}}}
 
-	assert.NotContains(t, stripAnsiForTest(without.getWelcomeMessage()), "F5")
-	assert.Contains(t, stripAnsiForTest(with.getWelcomeMessage()), "F5")
+	assert.NotContains(t, stripAnsiForTest(without.getWelcomeMessage()), "F6")
+	assert.Contains(t, stripAnsiForTest(with.getWelcomeMessage()), "F6")
 }

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -141,6 +141,11 @@ func (m *MainModel) View() tea.View {
 		// For AI view, just get the viewport content
 		viewportWidth = m.aiConversationViewport.Width()
 		viewportContent = m.aiConversationViewport.View()
+	case m.viewMode == "schema":
+		// Drawn as one block rather than through a viewport: it is two panes
+		// side by side, each scrolling on its own.
+		viewportWidth = m.windowWidth
+		viewportContent = m.viewSchema(m.windowWidth, m.historyViewport.Height())
 	case m.viewMode == "trace":
 		viewportWidth = m.historyViewport.Width()
 		if m.hasTrace {
@@ -376,7 +381,9 @@ func (m *MainModel) getWelcomeMessage() string {
 	welcome.WriteString(m.styles.MutedText.Render("  • F4 - Switch to trace view"))
 	welcome.WriteString("\n")
 	if m.aiAvailable() {
-		welcome.WriteString(m.styles.MutedText.Render("  • F5 - Switch to the Chat view"))
+		welcome.WriteString(m.styles.MutedText.Render("  • F5 - Browse the schema"))
+		welcome.WriteString("\n")
+		welcome.WriteString(m.styles.MutedText.Render("  • F6 - Switch to the Chat view"))
 		welcome.WriteString("\n")
 	}
 	welcome.WriteString("\n")


### PR DESCRIPTION
Closes #175.

```
 FILE (Alt+F)    CONSOLE (F2)    SCHEMA (F3)    RESULTS (F4)    TRACE (F5)    CHAT (F6)    HELP

KEYSPACES          │ TABLE  my_keyspace.users
────────────────── │ ──────────────────────────────────────────────
▾ my_keyspace      │ CREATE TABLE my_keyspace.users (
    events         │     id uuid PRIMARY KEY,
    users          │     name text
▸ system           │ ) WITH bloom_filter_fp_chance = 0.01;
▸ system_schema    │
```

Reading a table's definition meant typing `DESCRIBE TABLE` and knowing the name
already. What you usually want first is to look.

Clicking a keyspace shows it and opens it; clicking it again folds it - a first
click that folded would make the schema it was asking for flash past. Clicking a
table shows its `CREATE TABLE`. The arrows walk the tree (right opens, left
closes, left from a table goes up to its keyspace), the wheel moves whichever
pane it is over, and `Alt+Up`/`Alt+Down` scroll the definition. Both panes have a
scrollbar.

Everything else still reaches the prompt, so a query can be typed while looking
at the table it is about. Enter folds the tree only when the prompt is empty.

### What is fetched, and when

Nothing until the tab is opened: the keyspaces on first use, a keyspace's tables
when it is first opened, a definition when it is first shown - each kept
afterwards. It opens on the keyspace in use. Pressing `F3` again, or clicking the
tab you are on, asks the cluster afresh and keeps the keyspaces you had open.

The definitions come from the same calls `DESCRIBE` makes - `DescribeTableQuery`
with `FormatTableCreateStatement`, and `DBDescribeFullSchema` for a keyspace - so
the pane and the command cannot disagree about what a table is.

### Headings

Each pane has one, with a rule under it: `KEYSPACES` on the left, and on the
right what is being shown rather than that something is - `KEYSPACE
my_keyspace`, `TABLE my_keyspace.users`. Both stay put while either pane scrolls.
`FormatTableCreateStatement`'s `Table: ks.name` line goes with it, since the
heading says that and saying it twice cost the first two rows of every
definition.

### The tabs

Schema sits next to the console because what is in the database comes before
anything a query has made of it, and the three that follow are all views of a
result. The keys read along the line with the tabs, which moves **Results to F4,
Trace to F5 and Chat to F6**.

The view handlers are now named for what they show - `showConsole`, `showSchema`,
`showResults`, `showTrace`, `showChat` - where they were `handleF2` to
`handleF6`. Named after keys, this reshuffle would have renamed three functions
and every call to them, for a rename with nothing behind it.

### One bug found on the way

The tab's availability checked `m.session != nil`, but a `db.Session` is built
before it is connected: querying through a half-built one goes straight into a
nil pointer inside the driver. Both the tab and the browser's fetches check that
there is a connection.

### Tests

Sixteen: the tree folding and unfolding, the marker, every row clickable where it
is drawn, the heading not being a row, the arrows including the ends, typing and
Enter still reaching the prompt, the panes scrolling independently, the wheel
choosing by which side of the divider it is on, the selection staying on screen
through a forty-keyspace tree, ragged-row checks at four terminal sizes, the
headings surviving a scroll, and the tab order and key sequence pinned together.
