### PR TITLE
A batch of UI fixes: the views, the prompt, pasting and the file windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ yet is dimmed, as is `CHAT` with no AI provider configured.
 | `F5` | Trace | Query trace, when tracing is enabled |
 | `F6` | Chat | The AI conversation |
 
+Text is selected by dragging with the mouse, and lands on the system clipboard
+when you let go.
+
+A right click pastes. It asks three things, in order, and takes the first
+answer: the terminal, through OSC 52, which is the only route that works through
+ssh and tmux and which most terminals refuse - a program that can read the
+clipboard can read what you copied out of a password manager; then the machine
+CQLAI is running on, through whichever of `wl-paste`, `xclip`, `xsel`, `pbpaste`
+or `powershell.exe Get-Clipboard` is there, which covers a local desktop
+including WSL; and failing both, whatever CQLAI itself last copied.
+
+The terminal's own paste works too, and both go wherever the keys are going: the
+prompt, a form, or the preferences window.
+
 Schema sits next to the console because what is in the database comes before
 anything a query has made of it. The keys read along the line with the tabs, so
 Results and Trace have moved from `F3` and `F4` to `F4` and `F5`.

--- a/internal/router/meta_commands_help.go
+++ b/internal/router/meta_commands_help.go
@@ -113,7 +113,8 @@ func HelpRows() [][]string {
 		{"", "Ctrl+W", "Cut previous word"},
 		{"", "Alt+D", "Delete next word"},
 		{"", "Ctrl+Y", "Paste cut text"},
-		{"", "Terminal paste", "Goes into the prompt, a form, or preferences"},
+		{"", "Right click", "Paste into the prompt, a form, or preferences"},
+		{"", "Terminal paste", "The same, from the terminal's own paste"},
 
 		// Navigation
 		{"─────────", "─────────", "─────────────"},

--- a/internal/ui/capture_panel.go
+++ b/internal/ui/capture_panel.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -166,8 +167,18 @@ func (m *MainModel) openCapturePanelCentred() (*MainModel, tea.Cmd) {
 // pointing at nothing. Typing SAVE has nothing to point at either, so both
 // routes land in the same place.
 func (m *MainModel) openSavePanel() (*MainModel, tea.Cmd) {
+	// Asked with nothing on screen, it says so rather than opening a window
+	// that can only be cancelled. Both ways in come through here, so the menu
+	// entry and the typed command give the same answer.
+	if !m.hasResults() {
+		return m.report(noResultsToSave)
+	}
 	return m.showFilePanel(saving, 0, true)
 }
+
+// noResultsToSave is what there is to say when SAVE is asked for and there is
+// nothing to write.
+const noResultsToSave = "No query results available to save. Execute a query first."
 
 func (m *MainModel) showFilePanel(kind fileKind, anchorX int, centred bool) (*MainModel, tea.Cmd) {
 	if m.capture.active {
@@ -344,14 +355,51 @@ func (m *MainModel) useMatch() (*MainModel, tea.Cmd) {
 
 // listCapturePath shows what is in the directory the path names, without
 // filling anything in.
+//
+// The nearest directory at or above it that exists, because the name suggested
+// for AutoSave is a directory that is not there yet - it is about to be made -
+// and listing nothing says less than listing where it will go.
 func (m *MainModel) listCapturePath() (*MainModel, tea.Cmd) {
-	dir, _ := splitPath(m.capture.input.Value())
-
+	dir, name := splitPath(m.capture.input.Value())
 	m.clearMatches()
-	if got := completePath(dir); got.worthListing() {
-		m.capture.matches = got.Matches
+
+	for {
+		// An empty directory here is the one cqlai was started in, which is
+		// where a bare name is written. completePath reads an empty path as the
+		// root, which is the answer to a different question.
+		at := dir
+		if at == "" {
+			at = "." + string(filepath.Separator)
+		}
+
+		if matches := completePath(at).Matches; len(matches) > 0 {
+			m.capture.matches = matches
+			m.showNamed(name)
+			return m, nil
+		}
+
+		// Above a bare name there is the directory cqlai was started in, which
+		// parentDir gives as "" - the end of the walk rather than a step off
+		// it, so it is tried before giving up.
+		if dir == "" {
+			return m, nil
+		}
+		dir = parentDir(dir)
 	}
-	return m, nil
+}
+
+// showNamed opens the list on the entry a name refers to, so it arrives showing
+// where you are rather than at its alphabetical start.
+func (m *MainModel) showNamed(name string) {
+	if name == "" {
+		return
+	}
+	for i, match := range m.capture.matches {
+		if match == name || strings.TrimSuffix(match, string(filepath.Separator)) == name {
+			m.showMatch(i)
+			return
+		}
+	}
 }
 
 // clearMatches takes the list down.
@@ -508,7 +556,13 @@ func (m *MainModel) handleCaptureKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) 
 
 	default:
 		// While the candidates are showing they are what the arrows and Enter
-		// are aimed at; Escape puts them away and leaves the path alone.
+		// are aimed at.
+		//
+		// Escape is not among them any more: the listing is there from the
+		// moment the step opens rather than being something you asked for, so
+		// putting it away would leave the field where it was with the browser
+		// gone. Escape goes back a step, which is what it does everywhere else
+		// in this window.
 		if len(m.capture.matches) > 0 {
 			switch msg.String() {
 			case "up":
@@ -519,9 +573,6 @@ func (m *MainModel) handleCaptureKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) 
 				return m, nil
 			case "enter":
 				return m.useMatch()
-			case "esc":
-				m.clearMatches()
-				return m, nil
 			}
 		}
 
@@ -557,21 +608,43 @@ func (m *MainModel) chooseCaptureFormat() (*MainModel, tea.Cmd) {
 	m.capture.input.SetValue(m.defaultCaptureName())
 	m.capture.input.CursorEnd()
 	m.capture.input.Focus()
-	return m, nil
+	return m.listCapturePath()
 }
 
-// defaultCaptureName is a filename to start from, so there is something to edit
+// defaultCaptureName is a path to start from, so there is something to edit
 // rather than an empty box.
+//
+// Under the home directory: a bare name goes to whatever directory cqlai was
+// started in, which is not somewhere you can see from here and is rarely where
+// you want a file you will go looking for later. It also gives the listing that
+// opens with this step somewhere worth showing.
 func (m *MainModel) defaultCaptureName() string {
 	// AutoSave is given a directory and names the files inside it itself, so
 	// what it wants here is somewhere to put them - not a filename, which is
 	// what it used to offer and what it no longer takes.
 	if m.capture.kind == capturing {
-		return "autosave_" + time.Now().Format("20060102") + string(filepath.Separator)
+		return inHome("autosave_" + time.Now().Format("20060102") + string(filepath.Separator))
 	}
 
-	return fmt.Sprintf("results_%s%s", time.Now().Format("20060102_150405"),
-		extensionFor(m.capture.formats[m.capture.format]))
+	return inHome(fmt.Sprintf("results_%s%s", time.Now().Format("20060102_150405"),
+		extensionFor(m.capture.formats[m.capture.format])))
+}
+
+// inHome puts a name in the user's home directory, or leaves it where it is
+// when there is no home to put it in.
+func inHome(name string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return name
+	}
+
+	path := filepath.Join(home, name)
+	// Join drops a trailing separator, and here that separator is the
+	// difference between a directory to write files into and a file to write.
+	if strings.HasSuffix(name, string(filepath.Separator)) {
+		path += string(filepath.Separator)
+	}
+	return path
 }
 
 // completeCapturePath fills in as much of the path as the candidates agree on.

--- a/internal/ui/capture_panel_test.go
+++ b/internal/ui/capture_panel_test.go
@@ -504,16 +504,21 @@ func TestTheWayUpWalksBackOut(t *testing.T) {
 		"and it lists where it has arrived")
 }
 
-// TestEscapePutsTheListAwayWithoutLosingThePath.
-func TestEscapePutsTheListAwayWithoutLosingThePath(t *testing.T) {
+// TestEscapeGoesBackAStepEvenWithTheListShowing.
+//
+// It used to put the list away and leave you on the path. The listing is there
+// from the moment the step opens now, rather than being something you asked
+// for, so putting it away would leave the field where it was with the browser
+// gone - and Escape does the same thing everywhere else in this window.
+func TestEscapeGoesBackAStepEvenWithTheListShowing(t *testing.T) {
 	m := listingModel(t, 4)
-	path := m.capture.input.Value()
+	require.NotEmpty(t, m.capture.matches)
 
 	m.handleCaptureKey(tea.KeyPressMsg{Code: tea.KeyEscape})
 
+	assert.Equal(t, captureChooseFormat, m.capture.step, "back to the format")
+	assert.True(t, m.capture.active, "back a step, not closed")
 	assert.Empty(t, m.capture.matches)
-	assert.Equal(t, path, m.capture.input.Value())
-	assert.Equal(t, captureEnterPath, m.capture.step, "still asking for a path")
 }
 
 // TestTheWheelMovesTheList.
@@ -647,6 +652,7 @@ func TestTheWindowAndTheCommandAgreeAboutParquet(t *testing.T) {
 // TestTheDefaultNameSuitsTheKind.
 func TestTheDefaultNameSuitsTheKind(t *testing.T) {
 	m := helpModel()
+	m.lastTableData = [][]string{{"id"}, {"1"}} // something to save
 
 	m.openSavePanel()
 	m.capture.format = slices.Index(m.capture.formats, "JSON")
@@ -669,6 +675,7 @@ func TestBothWindowsAreTheSameWindow(t *testing.T) {
 
 	save := helpModel()
 	save.windowHeight = h
+	save.lastTableData = [][]string{{"id"}, {"1"}} // something to save
 	save.openSavePanel()
 	saveLayer, ok := save.viewCapturePanel(w, h)
 	require.True(t, ok)
@@ -694,6 +701,7 @@ func TestTabCompletesThePathInTheSaveWindowToo(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "results.csv"), nil, 0o600))
 
 	m := helpModel()
+	m.lastTableData = [][]string{{"id"}, {"1"}} // something to save
 	m.openSavePanel()
 	m.chooseCaptureFormat()
 	m.capture.input.SetValue(filepath.Join(dir, "res"))
@@ -726,4 +734,100 @@ func TestClickingATabWithTheSaveWindowOpenSwitchesView(t *testing.T) {
 
 	assert.False(t, m.capture.active, "the window should have gone")
 	assert.Equal(t, "table", m.viewMode, "and the tab should have acted")
+}
+
+// TestThePathStepOpensOnTheFileBrowser.
+//
+// The box used to arrive holding a name with nothing around it, and finding out
+// where that name was going meant pressing Tab to see.
+func TestThePathStepOpensOnTheFileBrowser(t *testing.T) {
+	for _, kind := range []fileKind{capturing, saving} {
+		m := captureModel()
+		m.lastTableData = [][]string{{"id"}, {"1"}}
+		m, _ = m.showFilePanel(kind, 0, true)
+		m, _ = m.chooseCaptureFormat()
+
+		require.Equal(t, captureEnterPath, m.capture.step)
+		assert.NotEmpty(t, m.capture.matches, "%v: no listing when the step opened", kind)
+	}
+}
+
+// TestTheListingWalksUpToADirectoryThatIsThere.
+//
+// AutoSave suggests a directory that does not exist yet - it is about to be
+// made - so the listing is of the nearest one above it, which is where it will
+// be made.
+func TestTheListingWalksUpToADirectoryThatIsThere(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "already-here.csv"), nil, 0o600))
+
+	m := captureModel()
+	m, _ = m.showFilePanel(capturing, 0, true)
+	m.capture.step = captureEnterPath
+	m.capture.input.SetValue(filepath.Join(dir, "not_made_yet") + string(filepath.Separator))
+
+	m, _ = m.listCapturePath()
+
+	assert.Contains(t, m.capture.matches, "already-here.csv")
+}
+
+// TestTheListingOpensOnWhatIsTyped rather than at its alphabetical start.
+func TestTheListingOpensOnWhatIsTyped(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"alpha.csv", "beta.csv", "gamma.csv"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+
+	m := captureModel()
+	m, _ = m.showFilePanel(saving, 0, true)
+	m.capture.step = captureEnterPath
+	m.capture.input.SetValue(filepath.Join(dir, "gamma.csv"))
+
+	m, _ = m.listCapturePath()
+
+	require.NotEmpty(t, m.capture.matches)
+	assert.Equal(t, "gamma.csv", m.capture.matches[m.capture.match])
+}
+
+// TestTheSuggestedPathIsUnderHome.
+//
+// A bare name goes to whatever directory cqlai was started in, which is not
+// somewhere you can see from this window and is rarely where you want a file
+// you will go looking for later.
+func TestTheSuggestedPathIsUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, kind := range []fileKind{capturing, saving} {
+		m := captureModel()
+		m.lastTableData = [][]string{{"id"}, {"1"}}
+		m, _ = m.showFilePanel(kind, 0, true)
+		m, _ = m.chooseCaptureFormat()
+
+		path := m.capture.input.Value()
+		assert.True(t, strings.HasPrefix(path, home+string(filepath.Separator)),
+			"%v: %q is not under %q", kind, path, home)
+
+		// AutoSave is given a directory, and the separator on the end is what
+		// says so.
+		if kind == capturing {
+			assert.True(t, strings.HasSuffix(path, string(filepath.Separator)),
+				"AutoSave should suggest a directory: %q", path)
+		} else {
+			assert.False(t, strings.HasSuffix(path, string(filepath.Separator)))
+		}
+	}
+}
+
+// TestTheListingOpensOnHome, which is where the suggested path is.
+func TestTheListingOpensOnHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.Mkdir(filepath.Join(home, "exports"), 0o750))
+
+	m := captureModel()
+	m, _ = m.showFilePanel(capturing, 0, true)
+	m, _ = m.chooseCaptureFormat()
+
+	assert.Contains(t, m.capture.matches, "exports"+string(filepath.Separator))
 }

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Reading the clipboard of the machine cqlai is running on.
+//
+// A right click asks the terminal first, through OSC 52, which is the only
+// route that works through ssh and tmux. Most terminals refuse it - a program
+// that can read the clipboard can read what you copied out of a password
+// manager - and then there is nothing to paste but what cqlai itself copied,
+// which is no use for text copied from another application.
+//
+// So it also asks the machine, the way every other program does: the same
+// command line the desktop's own clipboard tool offers. On a terminal running
+// against a local desktop - including WSL, where the clipboard belongs to
+// Windows - that answers. Over ssh with no forwarding it does not, and nothing
+// else could.
+
+// clipboardWait bounds the command. A clipboard read that has not answered in
+// this long is not going to.
+const clipboardWait = 2 * time.Second
+
+// systemClipboardMsg is what the machine says its clipboard holds.
+type systemClipboardMsg struct {
+	request int
+	text    string
+}
+
+// clipboardReaders are the commands that can say what the clipboard holds, in
+// the order they are tried.
+//
+// Wayland first, then X, then macOS, then Windows - which is also how WSL
+// reaches the clipboard it shares with the desktop it runs on.
+func clipboardReaders() [][]string {
+	powershell := []string{"powershell.exe", "-NoProfile", "-Command", "Get-Clipboard"}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return [][]string{{"pbpaste"}}
+	case "windows":
+		return [][]string{powershell}
+	}
+
+	return [][]string{
+		{"wl-paste", "--no-newline"},
+		{"xclip", "-selection", "clipboard", "-out"},
+		{"xsel", "--clipboard", "--output"},
+		powershell,
+	}
+}
+
+// readSystemClipboard asks the machine what its clipboard holds.
+func readSystemClipboard(request int) tea.Cmd {
+	return func() tea.Msg {
+		return systemClipboardMsg{request: request, text: systemClipboard()}
+	}
+}
+
+// systemClipboard is the clipboard's contents, or "" when nothing here can say.
+//
+// Failures are silent on purpose: this runs because someone right-clicked, and
+// the answer to "your terminal will not say and this machine has no clipboard
+// tool" is to paste what cqlai copied, not to write an error into the console
+// every time. What is read is never logged - it is the clipboard.
+func systemClipboard() string {
+	for _, reader := range clipboardReaders() {
+		path, err := exec.LookPath(reader[0])
+		if err != nil {
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), clipboardWait)
+		// #nosec G204 - the command and its arguments are from the fixed table
+		// above; only which of them exists on this machine varies.
+		out, err := exec.CommandContext(ctx, path, reader[1:]...).Output()
+		cancel()
+		if err != nil {
+			continue
+		}
+
+		// Windows hands it back with CRLF line endings and a trailing newline
+		// the clipboard itself does not have.
+		if text := strings.TrimRight(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n"); text != "" {
+			return text
+		}
+	}
+	return ""
+}

--- a/internal/ui/file_form.go
+++ b/internal/ui/file_form.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -359,14 +360,26 @@ func (f fileForm) describe() string {
 	return "The statements run as if you had typed them."
 }
 
-// pathRoot is where the File field starts.
+// pathRoot is the top of the filesystem, and where a File field starts when
+// there is no home directory to start it in.
 //
 // Completion used to begin wherever cqlai was started from, which is rarely
 // where the file is and is not somewhere you can see: the field looked empty
-// and Tab produced a directory listing you had no reason to expect. From the
-// root the field says where it is looking, and every path from there is one you
-// could have typed.
+// and Tab produced a directory listing you had no reason to expect.
 const pathRoot = "/"
+
+// pathStart is where a File field starts: the user's home directory.
+//
+// Nearer to the file than the root is - a script to run or a table to write is
+// usually somewhere under it - and it says where it is looking, which is the
+// half that matters. The root is the fallback, for a user with no home.
+func pathStart() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return pathRoot
+	}
+	return strings.TrimSuffix(home, string(filepath.Separator)) + string(filepath.Separator)
+}
 
 // formPlaceholderColour is the grey an empty field's instruction is drawn in:
 // dim enough to read as a prompt rather than as something you typed, and the
@@ -473,14 +486,14 @@ func actionFields(action formAction, keyspace string) []formField {
 		return []formField{
 			{label: "Keyspace", kind: fieldKeyspace, input: newFormInput(keyspace, "Tab to list keyspaces")},
 			{label: "Table", kind: fieldTable, input: newFormInput("", "Tab to list tables")},
-			{label: "File", kind: fieldPath, input: newFormInput(pathRoot, ""), hint: "Tab completes"},
+			{label: "File", kind: fieldPath, input: newFormInput(pathStart(), ""), hint: "Tab completes"},
 			{label: "Columns", kind: fieldColumns, input: newFormInput("", "all of them"), hint: "or tick them off", optional: true},
 		}
 	case copyingFrom:
 		return []formField{
 			{label: "Keyspace", kind: fieldKeyspace, input: newFormInput(keyspace, "Tab to list keyspaces")},
 			{label: "Table", kind: fieldTable, input: newFormInput("", "Tab to list tables")},
-			{label: "File", kind: fieldPath, input: newFormInput(pathRoot, ""), hint: "Tab completes"},
+			{label: "File", kind: fieldPath, input: newFormInput(pathStart(), ""), hint: "Tab completes"},
 			// On the FROM form and not the TO form because this is where
 			// getting it wrong costs you: a CSV whose first row is column
 			// names, read with HEADER=false, inserts that row as data.
@@ -493,7 +506,7 @@ func actionFields(action formAction, keyspace string) []formField {
 		}
 	}
 	return []formField{
-		{label: "File", kind: fieldPath, input: newFormInput(pathRoot, ""), hint: "Tab completes"},
+		{label: "File", kind: fieldPath, input: newFormInput(pathStart(), ""), hint: "Tab completes"},
 	}
 }
 
@@ -1869,9 +1882,11 @@ func (m *MainModel) fieldError(i int) string {
 
 	case fieldPath:
 		switch {
-		case value == "" || value == pathRoot:
+		case value == "":
 			return "a file is needed"
-		case strings.HasSuffix(value, "/"):
+		case strings.HasSuffix(value, string(filepath.Separator)):
+			// Including the directory the field starts in, which is a place to
+			// look rather than an answer.
 			return "that is a directory"
 		}
 

--- a/internal/ui/file_form_test.go
+++ b/internal/ui/file_form_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -153,7 +154,8 @@ func TestWhatIsChecked(t *testing.T) {
 		{"Keyspace", "", "a keyspace is needed"},
 		{"Keyspace", "nosuch", "no keyspace of that name"},
 		{"Table", "nosuch", "no table of that name in this keyspace"},
-		{"File", pathRoot, "a file is needed"},
+		{"File", "", "a file is needed"},
+		{"File", pathRoot, "that is a directory"},
 		{"File", "/tmp/", "that is a directory"},
 		{"SKIPROWS", "many", "a whole number"},
 		{"DELIMITER", ";;", "one character"},
@@ -371,4 +373,31 @@ func TestEveryFieldHasAnInput(t *testing.T) {
 				"%s has no usable input", field.label)
 		}
 	}
+}
+
+// TestTheFileFieldStartsAtHome.
+//
+// The root is a long way from the file: a script to run, or a table to write,
+// is usually somewhere under the home directory, and starting there is a
+// listing worth reading rather than the top of the filesystem.
+func TestTheFileFieldStartsAtHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, action := range []formAction{sourcing, copyingTo, copyingFrom} {
+		m := formModel(t, action)
+		assert.Equal(t, home+string(filepath.Separator), m.form.field("File"),
+			"%v should start in the home directory", action)
+	}
+}
+
+// TestTheStartingDirectoryIsNotAnAnswer: it is a place to look, and the form
+// says so rather than offering to run with it.
+func TestTheStartingDirectoryIsNotAnAnswer(t *testing.T) {
+	m := formModel(t, sourcing)
+	require.False(t, m.formReady())
+	assert.Contains(t, collect(m.formErrors()), "that is a directory")
+
+	set(t, m, "File", filepath.Join(t.TempDir(), "schema.cql"))
+	assert.True(t, m.formReady())
 }

--- a/internal/ui/file_menu.go
+++ b/internal/ui/file_menu.go
@@ -50,10 +50,12 @@ type fileMenu struct {
 
 // fileMenuItems is what the menu offers, in the order it offers them.
 //
-// AutoSave first: it is a decision about everything that comes next, and the
-// one you are most likely to be here to make.
+// SAVE RESULTS first: it acts on what is on screen, which is what you were
+// looking at when you opened the menu. AutoSave next, because it is a decision
+// about everything that comes after it.
 func fileMenuItems() []fileMenuItem {
 	return []fileMenuItem{
+		{label: "SAVE RESULTS", kind: saving},
 		{label: "AUTOSAVE", kind: capturing},
 		{label: "SOURCE", form: sourcing, asks: true},
 		{label: "COPY TO", form: copyingTo, asks: true},
@@ -71,10 +73,11 @@ func fileMenuItems() []fileMenuItem {
 
 // available reports whether an item can be picked.
 //
-// SAVE RESULTS was here and is not any more. Everything left is a file
-// operation that stands on its own; saving what is on screen depends on there
-// being something on screen, which made it the one entry that was sometimes
-// dimmed. The SAVE command is unchanged and still opens the same window.
+// SAVE RESULTS is pickable whether or not there is anything to save. It was
+// dimmed until a query had run, which is a fair description of the state and a
+// poor thing to look at: a menu entry greyed out on a freshly started shell
+// reads as one that is not there. Picking it with nothing on screen says so, in
+// the same words the SAVE command uses.
 func (m *MainModel) fileItemAvailable(item fileMenuItem) bool {
 	if item.rule {
 		return false
@@ -232,7 +235,7 @@ func (m *MainModel) viewFileMenu(screenWidth, screenHeight int) (Layer, bool) {
 	}
 
 	itemStyle := lipgloss.NewStyle().Foreground(m.styles.Accent)
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#585858"))
+	dimStyle := lipgloss.NewStyle().Foreground(dimmedColour)
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#1c1c1c")).
 		Background(m.styles.Accent).

--- a/internal/ui/file_menu_test.go
+++ b/internal/ui/file_menu_test.go
@@ -53,7 +53,7 @@ func TestTheMenuIsThreeGroups(t *testing.T) {
 	groups = append(groups, group)
 
 	assert.Equal(t, [][]string{
-		{"AUTOSAVE", "SOURCE", "COPY TO", "COPY FROM"},
+		{"SAVE RESULTS", "AUTOSAVE", "SOURCE", "COPY TO", "COPY FROM"},
 		{"PREFERENCES"},
 		{"QUIT"},
 	}, groups)
@@ -241,4 +241,32 @@ func TestTheMenuIsDrawnWhereItIsClicked(t *testing.T) {
 		}
 		assert.Contains(t, drawn, item.label)
 	}
+}
+
+// TestSaveResultsIsThereBeforeThereAreResults.
+//
+// It was dimmed until a query had run - a fair description of the state and a
+// poor thing to look at, since a greyed-out entry on a freshly started shell
+// reads as one that is not there.
+func TestSaveResultsIsThereBeforeThereAreResults(t *testing.T) {
+	m := menuModel(t)
+	save := fileMenuItems()[menuEntry(t, "SAVE RESULTS")]
+	require.Empty(t, m.lastTableData)
+
+	assert.True(t, m.fileItemAvailable(save), "it should be pickable from the start")
+
+	// Picking it says why rather than opening a window that can only be
+	// cancelled.
+	m.fileMenu.selected = menuEntry(t, "SAVE RESULTS")
+	m, _ = m.chooseFileMenuItem()
+	assert.False(t, m.capture.active)
+	assert.Contains(t, stripAnsiForTest(m.fullHistoryContent), "Execute a query first")
+
+	// And with something on screen it opens the window.
+	m = menuModel(t)
+	m.lastTableData = [][]string{{"id"}, {"1"}}
+	m.fileMenu.selected = menuEntry(t, "SAVE RESULTS")
+	m, _ = m.chooseFileMenuItem()
+	assert.True(t, m.capture.active)
+	assert.Equal(t, saving, m.capture.kind)
 }

--- a/internal/ui/history_wrapper.go
+++ b/internal/ui/history_wrapper.go
@@ -122,6 +122,27 @@ func visibleLength(s string) int {
 func (m *MainModel) updateHistoryWrapping() {
 	if m.historyViewport.Width() > 0 {
 		wrapped := m.wrapHistoryContent(m.historyViewport.Width())
-		m.historyViewport.SetContent(wrapped)
+		m.historyViewport.SetContent(m.consoleContent(wrapped))
 	}
+}
+
+// consoleContent puts the transcript at the foot of the view, which is where a
+// shell puts it.
+//
+// A viewport draws its content from the top, so a session that had said little
+// so far left the welcome message at the top of the screen and the command you
+// had just run below it, with blank space between that and the prompt it was
+// typed at. Filled from the bottom, the answer appears where it was asked for,
+// and the top of the screen fills in as the session goes on.
+func (m *MainModel) consoleContent(wrapped string) string {
+	height := m.historyViewport.Height()
+	if height <= 0 || wrapped == "" {
+		return wrapped
+	}
+
+	blank := height - len(strings.Split(wrapped, "\n"))
+	if blank <= 0 {
+		return wrapped
+	}
+	return strings.Repeat("\n", blank) + wrapped
 }

--- a/internal/ui/keyboard_handler.go
+++ b/internal/ui/keyboard_handler.go
@@ -110,7 +110,7 @@ func (m *MainModel) handleKeyboardInput(msg tea.KeyPressMsg) (*MainModel, tea.Cm
 	// Up and down are command history everywhere else, and there is no history
 	// to walk through while reading a tree; everything else still goes to the
 	// prompt, so a query can be typed while looking at the table it is about.
-	if m.viewMode == "schema" && !m.historySearchMode {
+	if m.schemaOwnsKeys() {
 		if updated, cmd, handled := m.schemaKey(msg); handled {
 			return updated, cmd
 		}

--- a/internal/ui/keyboard_handler_enter.go
+++ b/internal/ui/keyboard_handler_enter.go
@@ -122,6 +122,11 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 			!strings.HasPrefix(upperCommand, "EXIT") &&
 			!strings.HasPrefix(upperCommand, "QUIT"))
 
+	// echoed says the statement is already in the console: one typed over
+	// several lines is written there a line at a time as it is typed, and
+	// writing the whole thing again when it runs would be two of it.
+	echoed := false
+
 	// For CQL statements, check for semicolon (skip for AI-generated commands)
 	if isCQLStatement {
 		switch {
@@ -130,11 +135,13 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 			if !m.multiLineMode {
 				m.multiLineMode = true
 				m.multiLineBuffer = []string{command}
-				m.input.Placeholder = "... (multi-line mode, end with ;)"
+				m.continueStatement()
 			} else {
 				// Add to buffer (including empty lines for proper formatting)
 				m.multiLineBuffer = append(m.multiLineBuffer, command)
 			}
+			m.echoInput(command)
+
 			// Create a new empty textinput to ensure it's properly reset
 			newInput := textinput.New()
 			newInput.Placeholder = m.input.Placeholder
@@ -151,10 +158,10 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 		case m.multiLineMode:
 			// We have a semicolon and we're in multi-line mode
 			m.multiLineBuffer = append(m.multiLineBuffer, command)
+			m.echoInput(command)
 			command = strings.Join(m.multiLineBuffer, " ")
-			m.multiLineMode = false
-			m.multiLineBuffer = nil
-			m.input.Placeholder = "Enter CQL command..."
+			echoed = true
+			m.endStatement()
 		}
 	}
 
@@ -164,9 +171,11 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 		m.modal = NewConfirmationModal(command)
 
 		// Add command to history
-		m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
-		m.updateHistoryWrapping()
-		m.historyViewport.GotoBottom()
+		if !echoed {
+			m.fullHistoryContent += "\n" + m.styles.AccentText.Render(promptMark+command)
+			m.updateHistoryWrapping()
+			m.historyViewport.GotoBottom()
+		}
 
 		m.input.Reset()
 		return m, nil
@@ -196,7 +205,9 @@ func (m *MainModel) handleEnterKey() (*MainModel, tea.Cmd) {
 	m.lastQueryTime = time.Since(start)
 
 	// Add command to history viewport
-	m.fullHistoryContent += "\n" + m.styles.AccentText.Render("> "+command)
+	if !echoed {
+		m.fullHistoryContent += "\n" + m.styles.AccentText.Render(promptMark+command)
+	}
 	m.updateHistoryWrapping()
 	m.historyViewport.GotoBottom()
 

--- a/internal/ui/keyboard_handler_enter_comments.go
+++ b/internal/ui/keyboard_handler_enter_comments.go
@@ -36,7 +36,8 @@ func (m *MainModel) handleBlockComment(command string) (*MainModel, tea.Cmd) {
 		// Multi-line block comment - enter special mode
 		m.multiLineMode = true
 		m.multiLineBuffer = []string{command}
-		m.input.Placeholder = "... (in block comment, end with */)"
+		m.continueStatement()
+		m.input.Placeholder = "end the comment with */"
 		m.input.Reset()
 		return m, nil
 	}
@@ -50,9 +51,7 @@ func (m *MainModel) handleMultiLineBlockComment(command string) (*MainModel, tea
 		// End of multi-line block comment
 		m.multiLineBuffer = append(m.multiLineBuffer, command)
 		fullComment := strings.Join(m.multiLineBuffer, "\n")
-		m.multiLineMode = false
-		m.multiLineBuffer = nil
-		m.input.Placeholder = "Enter CQL command..."
+		m.endStatement()
 		m.input.Reset()
 
 		// Add to history

--- a/internal/ui/keyboard_handler_enter_result.go
+++ b/internal/ui/keyboard_handler_enter_result.go
@@ -23,9 +23,8 @@ import (
 // wrote no file, showed no error and said nothing at all. It had been that way
 // for every format since the window was shared in #129.
 func (m *MainModel) runSaveCommand(v *router.SaveCommand) (*MainModel, tea.Cmd) {
-	if len(m.lastTableData) == 0 {
-		errorMsg := "No query results available to save. Execute a query first."
-		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+errorMsg)
+	if !m.hasResults() {
+		m.fullHistoryContent += "\n" + m.styles.ErrorText.Render("Error: "+noResultsToSave)
 		m.updateHistoryWrapping()
 		m.historyViewport.GotoBottom()
 		m.input.Reset()

--- a/internal/ui/keyboard_handler_escape.go
+++ b/internal/ui/keyboard_handler_escape.go
@@ -34,9 +34,7 @@ func (m *MainModel) handleEscapeKey() (*MainModel, tea.Cmd) {
 
 	// If in multi-line mode, exit it
 	if m.multiLineMode {
-		m.multiLineMode = false
-		m.multiLineBuffer = nil
-		m.input.Placeholder = "Enter CQL command..."
+		m.endStatement()
 		m.input.Reset()
 
 		// Add cancellation message to history

--- a/internal/ui/keyboard_handler_space.go
+++ b/internal/ui/keyboard_handler_space.go
@@ -79,8 +79,12 @@ func (m *MainModel) handleSpaceKey(msg tea.KeyPressMsg) (*MainModel, tea.Cmd) {
 
 	// Check if we should page down when there's more data
 	if m.viewMode == "table" && m.slidingWindow != nil && m.slidingWindow.hasMoreData {
-		// If input is empty and we're in table view with more data, use Space for paging
-		if m.input.Value() == "" {
+		// If input is empty and we're in table view with more data, use Space for paging.
+		//
+		// Not while a statement is being typed over several lines: the line is
+		// empty at the start of every one of them, and a space there is the
+		// first character of the next line rather than a page down.
+		if m.input.Value() == "" && !m.multiLineMode {
 			// Page down (same as PgDn)
 			return m.handlePageDown(msg)
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -126,6 +126,14 @@ type MainModel struct {
 	preferences      preferences    // Open PREFERENCES window, if any
 	schema           schemaBrowser  // The SCHEMA view's tree and what it is showing
 
+	// lastCopied is what cqlai last put on the clipboard, and what a right
+	// click pastes when the terminal will not say what its clipboard holds.
+	lastCopied string
+
+	// pasteRequest counts right clicks, so an answer that arrives after the
+	// fallback has already pasted is ignored rather than pasted twice.
+	pasteRequest int
+
 	// lastRawData is the values behind lastTableData for a result that arrived
 	// whole, so JSON is written from what came back rather than from what was
 	// drawn in the cells.
@@ -513,7 +521,7 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.fullHistoryContent = welcomeMsg
 			// Wrap content for initial display
 			wrapped := m.wrapHistoryContent(consoleWidth(newWidth))
-			m.historyViewport.SetContent(wrapped)
+			m.historyViewport.SetContent(m.consoleContent(wrapped))
 			m.ready = true
 		} else {
 			// Resize viewports
@@ -538,21 +546,13 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// The prompt and the trailing cursor cell are drawn outside the width
-		// the textinput is given, so it renders three columns wider than it is
-		// told. At newWidth-2 the input row was a column wider than the
-		// terminal and wrapped onto the next one. Measured from the prompt
-		// rather than written as a number, so the two cannot drift.
-		//
-		// Clamped because v2's textinput sizes its placeholder buffer from the
-		// width and panics on a negative one; v1 tolerated it. A terminal that
-		// reports no size, or one only a couple of columns wide, is enough to
-		// hit that.
-		inputWidth := max(newWidth-lipgloss.Width(m.input.Prompt)-1, 0)
-		m.input.SetWidth(inputWidth)
+		// Sized from the prompt in front of it, which is not the same width
+		// while a statement is being continued as it is at a fresh one.
+		width := inputWidth(newWidth, m.input.Prompt)
+		m.input.SetWidth(width)
 		// Also update AI conversation input width if initialized
 		if m.aiConversationInput.Value() != "" || m.aiConversationActive {
-			m.aiConversationInput.SetWidth(inputWidth)
+			m.aiConversationInput.SetWidth(width)
 		}
 		return m, nil
 
@@ -562,6 +562,18 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.PasteMsg:
 		updatedModel, cmd := m.handlePaste(msg)
+		return updatedModel, cmd
+
+	case tea.ClipboardMsg:
+		updatedModel, cmd := m.handleClipboard(msg)
+		return updatedModel, cmd
+
+	case systemClipboardMsg:
+		updatedModel, cmd := m.handleSystemClipboard(msg)
+		return updatedModel, cmd
+
+	case pasteFallbackMsg:
+		updatedModel, cmd := m.handlePasteFallback(msg)
 		return updatedModel, cmd
 
 	case tea.MouseMsg:

--- a/internal/ui/mouse_handler.go
+++ b/internal/ui/mouse_handler.go
@@ -19,9 +19,13 @@ func (m *MainModel) handleMouseInput(msg tea.MouseMsg) (*MainModel, tea.Cmd) {
 	case tea.MouseClickMsg:
 		logger.DebugfToFile("Mouse", "Press Button=%v X=%d Y=%d Mod=%v",
 			mouse.Button, mouse.X, mouse.Y, mouse.Mod)
-		// Only the left button does anything. A right click is left alone so
-		// the terminal's own context menu, and whatever it binds paste to,
-		// still work.
+		// The right button pastes. Taking the mouse takes the terminal's own
+		// context menu away, and with it the paste everyone reaches for; most
+		// terminals still hand a shifted click back to themselves for anyone
+		// who wants the menu.
+		if mouse.Button == tea.MouseRight {
+			return m.requestPaste()
+		}
 		if mouse.Button != tea.MouseLeft {
 			return m, nil
 		}

--- a/internal/ui/multiline.go
+++ b/internal/ui/multiline.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"charm.land/lipgloss/v2"
+)
+
+// Typing a statement over several lines.
+//
+// A statement without a semicolon is not finished, so cqlai keeps the prompt
+// open and waits for the rest. The lines already typed used to be drawn above
+// the prompt, which is a block that grows: the window is laid out with one row
+// for the input, so the second line pushed the connection bar off the bottom of
+// the screen, the third took the query line with it, and what was left was the
+// statement sitting on top of the bars it had overwritten.
+//
+// They go into the console instead, a line at a time as they are typed, the way
+// a shell does it. The transcript then reads as what you typed, the view
+// scrolls as it always did, and nothing below the prompt moves.
+
+const (
+	// promptMark is what a line typed at the prompt is written with, and
+	// continuationMark what the lines of an unfinished statement carry.
+	promptMark       = "> "
+	continuationMark = "... "
+)
+
+// setInputPrompt changes what the prompt says and keeps the input sized to it.
+//
+// The prompt and the trailing cursor cell are drawn outside the width the
+// textinput is given, so the width has to be worked out from the prompt in
+// front of it. It was only ever worked out on a resize, which is fine for a
+// prompt that never changes and wrong for one that does.
+func (m *MainModel) setInputPrompt(prompt string) {
+	m.input.Prompt = m.styles.AccentText.Render(prompt)
+	m.input.SetWidth(inputWidth(m.windowWidth, m.input.Prompt))
+}
+
+// inputWidth is how wide the text box can be with a given prompt in front of it.
+//
+// The prompt and the trailing cursor cell are drawn outside the width the
+// textinput is given, so it renders wider than it is told. Measured from the
+// prompt rather than written as a number, so the two cannot drift - and in one
+// place, because the prompt is not the same width while a statement is being
+// continued as it is at a fresh one.
+//
+// Clamped because v2's textinput sizes its placeholder buffer from the width
+// and panics on a negative one.
+func inputWidth(windowWidth int, prompt string) int {
+	return max(windowWidth-lipgloss.Width(prompt)-1, 0)
+}
+
+// continueStatement puts the prompt into the state of waiting for the rest of a
+// statement.
+func (m *MainModel) continueStatement() {
+	m.input.Placeholder = "end the statement with ;"
+	m.setInputPrompt(continuationMark)
+}
+
+// endStatement puts it back to waiting for a new one.
+func (m *MainModel) endStatement() {
+	m.multiLineMode = false
+	m.multiLineBuffer = nil
+	m.input.Placeholder = "Enter CQL command..."
+	m.setInputPrompt(promptMark)
+}
+
+// echoInput writes a line into the console as it was typed, under the prompt it
+// was typed at.
+//
+// Only for the lines of a statement that is still being typed. A statement
+// finished on one line is written out when it runs, which is also when anything
+// it has to say arrives - and writing it twice would be two of it.
+func (m *MainModel) echoInput(line string) {
+	mark := promptMark
+	if len(m.multiLineBuffer) > 1 {
+		mark = continuationMark
+	}
+
+	m.fullHistoryContent += "\n" + m.styles.AccentText.Render(mark+line)
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
+}

--- a/internal/ui/multiline_test.go
+++ b/internal/ui/multiline_test.go
@@ -1,0 +1,248 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/axonops/cqlai/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// promptModelFor is a console at the prompt, sized like a real terminal.
+func multiLineModel(t *testing.T) *MainModel {
+	t.Helper()
+
+	m := &MainModel{
+		styles:          DefaultStyles(),
+		viewMode:        "history",
+		windowWidth:     100,
+		windowHeight:    24,
+		ready:           true,
+		input:           newTestInput(),
+		historyViewport: viewport.New(viewport.WithWidth(100), viewport.WithHeight(18)),
+	}
+	m.input.Focus()
+	m.setInputPrompt(promptMark)
+	return m
+}
+
+// typeLine types a line at the prompt and presses Enter.
+func typeLine(m *MainModel, line string) *MainModel {
+	m.input.SetValue(line)
+	updated, _ := m.handleEnterKey()
+	return updated
+}
+
+func consoleLines(m *MainModel) []string {
+	return strings.Split(stripAnsiForTest(m.fullHistoryContent), "\n")
+}
+
+// TestAnUnfinishedStatementGoesIntoTheConsole.
+//
+// The lines were drawn above the prompt instead, which is a block that grows:
+// the window has one row for the input, so the second line pushed the
+// connection bar off the bottom and the third took the query line with it.
+func TestAnUnfinishedStatementGoesIntoTheConsole(t *testing.T) {
+	m := multiLineModel(t)
+
+	m = typeLine(m, "SELECT *")
+	require.True(t, m.multiLineMode)
+	assert.Contains(t, consoleLines(m), "> SELECT *")
+	assert.Empty(t, m.input.Value(), "the prompt should be clear for the next line")
+
+	m = typeLine(m, "FROM users")
+	assert.Contains(t, consoleLines(m), "... FROM users")
+
+	// Nothing is drawn above the prompt: the view is the tabs, the content, the
+	// two bars and one row of input, whatever is being typed.
+	assert.NotContains(t, m.View().Content, "\n... FROM users\n> ")
+}
+
+// TestTheContinuedStatementIsWrittenOnce.
+//
+// Each line is in the console as it was typed, so writing the whole statement
+// out again when it runs would be two of it.
+func TestTheContinuedStatementIsWrittenOnce(t *testing.T) {
+	m := multiLineModel(t)
+	m = typeLine(m, "SELECT *")
+	m = typeLine(m, "FROM users;")
+
+	assert.False(t, m.multiLineMode, "the semicolon ends it")
+	assert.Equal(t, "SELECT * FROM users;", m.lastCommand)
+
+	console := stripAnsiForTest(m.fullHistoryContent)
+	assert.Equal(t, 1, strings.Count(console, "SELECT *"), "written twice: %q", console)
+	assert.NotContains(t, console, "> SELECT * FROM users;")
+}
+
+// TestThePromptSaysWhichLineYouAreOn.
+func TestThePromptSaysWhichLineYouAreOn(t *testing.T) {
+	m := multiLineModel(t)
+	require.Contains(t, m.input.Prompt, promptMark)
+
+	m = typeLine(m, "SELECT *")
+	assert.Contains(t, m.input.Prompt, continuationMark, "a continued statement says so")
+
+	m = typeLine(m, "FROM users;")
+	assert.Contains(t, m.input.Prompt, promptMark)
+	assert.NotContains(t, m.input.Prompt, continuationMark)
+}
+
+// TestTheBoxFitsBesideWhicheverPromptIsInFront.
+//
+// The prompt is drawn outside the width the textinput is given, so a wider one
+// has to take that width off the box, or the row runs past the terminal and
+// wraps onto the next.
+func TestTheBoxFitsBesideWhicheverPromptIsInFront(t *testing.T) {
+	m := multiLineModel(t)
+	atPrompt := m.input.Width()
+
+	m = typeLine(m, "SELECT *")
+	assert.Equal(t, atPrompt-2, m.input.Width(), "... is two columns wider than >")
+
+	m = typeLine(m, "FROM users;")
+	assert.Equal(t, atPrompt, m.input.Width())
+}
+
+// TestEscapeGivesTheStatementUpAndThePromptBack.
+func TestEscapeGivesTheStatementUpAndThePromptBack(t *testing.T) {
+	m := multiLineModel(t)
+	m = typeLine(m, "SELECT *")
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	assert.False(t, m.multiLineMode)
+	assert.Empty(t, m.multiLineBuffer)
+	assert.Contains(t, m.input.Prompt, promptMark)
+	assert.Contains(t, stripAnsiForTest(m.fullHistoryContent), "Multi-line mode cancelled")
+}
+
+// TestTheBarsStayPutHoweverManyLinesAreTyped, which is the bug: the layout is
+// the tabs, the content, two bars and one row of input, and a statement being
+// typed cannot be allowed to grow into them.
+func TestTheBarsStayPutHoweverManyLinesAreTyped(t *testing.T) {
+	m := multiLineModel(t)
+	m = typeLine(m, "SELECT")
+	require.True(t, m.multiLineMode)
+
+	height := len(strings.Split(m.View().Content, "\n"))
+	bars := stripAnsiForTest(m.View().Content)
+	require.Contains(t, bars, "Connection")
+	require.Contains(t, bars, "History:")
+
+	for _, line := range []string{"id,", "name,", "created_at", "FROM users", "WHERE id = 1"} {
+		m = typeLine(m, line)
+	}
+
+	assert.Len(t, strings.Split(m.View().Content, "\n"), height,
+		"the view grew with the statement being typed")
+
+	// And both bars are still on it: they were pushed off the bottom a line at
+	// a time, the connection bar first and the query line after it.
+	bars = stripAnsiForTest(m.View().Content)
+	assert.Contains(t, bars, "Connection")
+	assert.Contains(t, bars, "History:")
+}
+
+// TestThePromptRowIsNotSharedWithTheMoreRowsHint.
+//
+// The hint was written over the input's placeholder, so with a partly loaded
+// result on screen it landed on the row a statement was being typed on: the
+// continuation prompt and "MORE DATA AVAILABLE" side by side, and no sign of
+// what ends the statement.
+func TestThePromptRowIsNotSharedWithTheMoreRowsHint(t *testing.T) {
+	m := multiLineModel(t)
+	m.viewMode = "table"
+	m.hasTable = true
+	m.tableViewport = viewport.New(viewport.WithWidth(100), viewport.WithHeight(14))
+	m.session = &db.Session{}
+	m.slidingWindow = NewSlidingWindowTable(1000, 10)
+	m.slidingWindow.Headers = []string{"id"}
+	m.slidingWindow.hasMoreData = true
+
+	m = typeLine(m, "SELECT *")
+
+	rows := strings.Split(stripAnsiForTest(m.View().Content), "\n")
+	prompt := ""
+	for _, row := range rows {
+		if strings.HasPrefix(row, continuationMark) {
+			prompt = row
+		}
+	}
+	require.NotEmpty(t, prompt, "the continuation prompt should be on screen")
+
+	assert.Contains(t, prompt, "end the statement with ;")
+	assert.NotContains(t, prompt, "MORE DATA")
+	assert.NotContains(t, prompt, "load more")
+}
+
+// TestSpaceStartsALineRatherThanPagingWhileAStatementIsBeingTyped.
+//
+// Space pages a partly loaded result when the prompt is empty - and the prompt
+// is empty at the start of every continuation line, so a statement could not
+// begin a line with a space without turning the page instead.
+func TestSpaceStartsALineRatherThanPagingWhileAStatementIsBeingTyped(t *testing.T) {
+	m := multiLineModel(t)
+	m.viewMode = "table"
+	m.hasTable = true
+	m.tableViewport = viewport.New(viewport.WithWidth(100), viewport.WithHeight(14))
+	m.session = &db.Session{}
+	m.slidingWindow = NewSlidingWindowTable(1000, 10)
+	m.slidingWindow.Headers = []string{"id"}
+	m.slidingWindow.hasMoreData = true
+	m.slidingWindow.AddRow([]string{"1"}, nil)
+
+	m = typeLine(m, "SELECT *")
+	rows := len(m.slidingWindow.Rows)
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: ' ', Text: " "})
+
+	assert.Equal(t, " ", m.input.Value(), "the space belongs to the statement")
+	assert.Len(t, m.slidingWindow.Rows, rows, "and should not have turned the page")
+}
+
+// TestTheConsoleFillsFromTheBottom.
+//
+// A viewport draws its content from the top, so a session that had said little
+// so far left the welcome message at the top of the screen and the command you
+// had just run below it, with blank space between that and the prompt it was
+// typed at. The answer belongs where the question was asked.
+func TestTheConsoleFillsFromTheBottom(t *testing.T) {
+	m := multiLineModel(t)
+	m.historyViewport.SetHeight(8)
+	m.fullHistoryContent = "Welcome to cqlai"
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
+
+	m.fullHistoryContent += "\n" + promptMark + "HELP\nsome answer"
+	m.updateHistoryWrapping()
+	m.historyViewport.GotoBottom()
+
+	rows := strings.Split(stripAnsiForTest(m.historyViewport.View()), "\n")
+	require.Len(t, rows, 8)
+
+	// The last thing said is on the last row, against the prompt.
+	assert.Equal(t, "some answer", strings.TrimRight(rows[len(rows)-1], " "))
+	assert.Contains(t, rows[len(rows)-2], "> HELP")
+	assert.Contains(t, rows[len(rows)-3], "Welcome to cqlai")
+
+	// And what is above it is empty rather than the transcript.
+	for _, row := range rows[:len(rows)-3] {
+		assert.Empty(t, strings.TrimSpace(row))
+	}
+}
+
+// TestALongTranscriptIsNotPadded: once it fills the view there is nothing to
+// push down, and padding it would scroll the top of it off for nothing.
+func TestALongTranscriptIsNotPadded(t *testing.T) {
+	m := multiLineModel(t)
+	m.historyViewport.SetHeight(4)
+	m.fullHistoryContent = strings.TrimSuffix(strings.Repeat("line\n", 20), "\n")
+	m.updateHistoryWrapping()
+
+	assert.Equal(t, 20, len(strings.Split(m.historyViewport.GetContent(), "\n")))
+}

--- a/internal/ui/paste.go
+++ b/internal/ui/paste.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -20,9 +21,16 @@ import (
 
 // handlePaste puts pasted text where the keys are going.
 func (m *MainModel) handlePaste(msg tea.PasteMsg) (*MainModel, tea.Cmd) {
-	if msg.Content == "" {
+	return m.pasteText(msg.Content)
+}
+
+// pasteText puts text where the keys are going, whether it arrived from the
+// terminal's own paste or from a right click asking for the clipboard.
+func (m *MainModel) pasteText(text string) (*MainModel, tea.Cmd) {
+	if text == "" {
 		return m, nil
 	}
+	msg := tea.PasteMsg{Content: text}
 
 	// A confirmation dialog is a yes or no question. Pasting into the prompt
 	// behind it would put the text somewhere that cannot be seen.
@@ -85,4 +93,91 @@ func firstLine(text string) string {
 		return text[:i]
 	}
 	return text
+}
+
+// Right-click paste.
+//
+// The terminal's own right-click menu is gone as soon as cqlai takes the mouse,
+// and with it the paste everyone reaches for. Asking the terminal for the
+// clipboard is possible - OSC 52 has a read as well as a write - but most
+// terminals refuse it, because a program that can read your clipboard can read
+// what you copied out of your password manager.
+//
+// So a right click does both: it asks, and if nothing comes back it pastes what
+// cqlai itself last copied. Text selected here always pastes; text copied from
+// another application pastes wherever the terminal allows the read.
+
+// pasteAnswerWait is how long to wait before giving up on both the terminal and
+// the machine and pasting what cqlai itself copied.
+//
+// Longer than a local clipboard command takes to answer - reading it through
+// WSL is a few hundred milliseconds - because the machine's clipboard is what
+// was asked for, and beating it to the punch with an older copy of our own
+// would paste the wrong thing.
+const pasteAnswerWait = 700 * time.Millisecond
+
+// pasteFallbackMsg says that a right click went unanswered.
+type pasteFallbackMsg struct{ request int }
+
+// requestPaste asks the terminal for the clipboard, and arranges to fall back
+// to cqlai's own last copy if it says nothing.
+func (m *MainModel) requestPaste() (*MainModel, tea.Cmd) {
+	m.pasteRequest++
+	request := m.pasteRequest
+
+	return m, tea.Batch(
+		// The terminal, which is the only route that works through ssh and
+		// tmux. ReadClipboard is the message rather than a command returning
+		// one, so it is already the shape Batch wants.
+		tea.ReadClipboard,
+
+		// And the machine, for the terminals that refuse - which is most of
+		// them. Whichever answers first is the one pasted.
+		readSystemClipboard(request),
+
+		tea.Tick(pasteAnswerWait, func(time.Time) tea.Msg {
+			return pasteFallbackMsg{request: request}
+		}),
+	)
+}
+
+// handleClipboard pastes what the terminal sent back.
+//
+// Only when something asked for it: a clipboard message arriving on its own is
+// not a paste anyone requested, and pasting into the prompt on its own is how a
+// stray sequence ends up as a query.
+func (m *MainModel) handleClipboard(msg tea.ClipboardMsg) (*MainModel, tea.Cmd) {
+	if m.pasteRequest == 0 {
+		return m, nil
+	}
+
+	m.pasteRequest = 0
+	return m.pasteText(msg.Content)
+}
+
+// handleSystemClipboard pastes what the machine says its clipboard holds.
+//
+// An empty answer leaves the request open rather than closing it: it means this
+// machine has nothing that can read a clipboard, and the terminal may yet
+// answer - and failing that, what cqlai copied is still better than nothing.
+func (m *MainModel) handleSystemClipboard(msg systemClipboardMsg) (*MainModel, tea.Cmd) {
+	if msg.request != m.pasteRequest || msg.text == "" {
+		return m, nil
+	}
+
+	m.pasteRequest = 0
+	return m.pasteText(msg.text)
+}
+
+// handlePasteFallback pastes what cqlai last copied, when neither the terminal
+// nor the machine answered the right click that asked for it.
+func (m *MainModel) handlePasteFallback(msg pasteFallbackMsg) (*MainModel, tea.Cmd) {
+	// A later right click has been and gone, or the terminal answered this one:
+	// either way this is not the request still waiting.
+	if msg.request != m.pasteRequest {
+		return m, nil
+	}
+
+	m.pasteRequest = 0
+	return m.pasteText(m.lastCopied)
 }

--- a/internal/ui/paste_test.go
+++ b/internal/ui/paste_test.go
@@ -124,3 +124,139 @@ func TestPastingWithAQuestionOnScreenDoesNothing(t *testing.T) {
 	m = paste(m, "yes")
 	assert.Empty(t, m.input.Value())
 }
+
+// TestRightClickPastesWhatTheTerminalSaysItHolds.
+func TestRightClickPastesWhatTheTerminalSaysItHolds(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+
+	m, cmd := m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	require.NotNil(t, cmd, "a right click should have asked for the clipboard")
+	assert.Equal(t, 1, m.pasteRequest)
+
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: "SELECT * FROM users"})
+	assert.Equal(t, "SELECT * FROM users", m.input.Value())
+	assert.Zero(t, m.pasteRequest, "the request should be answered")
+}
+
+// TestRightClickFallsBackToWhatCqlaiCopied.
+//
+// Most terminals refuse to say what their clipboard holds - a program that can
+// read it can read what you copied out of a password manager - so a right click
+// that goes unanswered pastes what was last copied here.
+func TestRightClickFallsBackToWhatCqlaiCopied(t *testing.T) {
+	m := selectionModel(5, "CREATE TABLE users (", "    id uuid PRIMARY KEY")
+	m.input = newTestInput()
+	m.input.Focus()
+	drag(m, 0, 1, 20, 1)
+	require.Equal(t, "CREATE TABLE users (", m.lastCopied)
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	m, _ = m.handlePasteFallback(pasteFallbackMsg{request: m.pasteRequest})
+
+	assert.Equal(t, "CREATE TABLE users (", m.input.Value())
+}
+
+// TestAnAnsweredRightClickDoesNotPasteTwice: the fallback is for a click the
+// terminal ignored, and a late answer to one already served is not a paste.
+func TestAnAnsweredRightClickDoesNotPasteTwice(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+	m.lastCopied = "from cqlai"
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	request := m.pasteRequest
+
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: "from the terminal"})
+	m, _ = m.handlePasteFallback(pasteFallbackMsg{request: request})
+	assert.Equal(t, "from the terminal", m.input.Value())
+
+	// And the other way round: the fallback pastes, the answer turns up late.
+	m.input.SetValue("")
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	m, _ = m.handlePasteFallback(pasteFallbackMsg{request: m.pasteRequest})
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: "from the terminal"})
+	assert.Equal(t, "from cqlai", m.input.Value())
+}
+
+// TestAClipboardMessageNobodyAskedForIsIgnored: pasting into the prompt on its
+// own is how a stray sequence ends up as a query.
+func TestAClipboardMessageNobodyAskedForIsIgnored(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: "DROP TABLE users"})
+	assert.Empty(t, m.input.Value())
+}
+
+// TestARightClickGoesWhereTheKeysGo, the same as any other paste.
+func TestARightClickGoesWhereTheKeysGo(t *testing.T) {
+	m := prefModel(t, &config.Config{})
+	i := prefIndex(t, m, "AI.APIKey")
+	m.preferences.focusField(i)
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: pastedKey})
+
+	assert.Equal(t, pastedKey, m.preferences.fields[i].value())
+}
+
+// TestRightClickPastesWhatTheMachineHolds.
+//
+// The terminal is asked first, because OSC 52 is the only route that works
+// through ssh and tmux, but most terminals refuse to answer. The machine's own
+// clipboard is what "paste" means to everyone else, so it is asked too.
+func TestRightClickPastesWhatTheMachineHolds(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+	m.lastCopied = "an older copy of our own"
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	m, _ = m.handleSystemClipboard(systemClipboardMsg{request: m.pasteRequest, text: "copied somewhere else"})
+
+	assert.Equal(t, "copied somewhere else", m.input.Value())
+	assert.Zero(t, m.pasteRequest)
+}
+
+// TestAnEmptyAnswerLeavesTheRequestOpen: nothing here can read a clipboard, so
+// the terminal may yet answer - and failing that, what cqlai copied is still
+// better than nothing.
+func TestAnEmptyAnswerLeavesTheRequestOpen(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+	m.lastCopied = "from cqlai"
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	request := m.pasteRequest
+
+	m, _ = m.handleSystemClipboard(systemClipboardMsg{request: request, text: ""})
+	assert.Equal(t, request, m.pasteRequest, "an empty answer is not an answer")
+	assert.Empty(t, m.input.Value())
+
+	m, _ = m.handlePasteFallback(pasteFallbackMsg{request: request})
+	assert.Equal(t, "from cqlai", m.input.Value())
+}
+
+// TestALateAnswerFromTheMachineIsIgnored, the same as a late one from the
+// terminal: the click it belongs to has already been served.
+func TestALateAnswerFromTheMachineIsIgnored(t *testing.T) {
+	m := helpModel()
+	m.input.Focus()
+
+	m, _ = m.handleMouseInput(tea.MouseClickMsg{Button: tea.MouseRight, X: 10, Y: 5})
+	m, _ = m.handleClipboard(tea.ClipboardMsg{Content: "from the terminal"})
+	m, _ = m.handleSystemClipboard(systemClipboardMsg{request: 1, text: "from the machine"})
+
+	assert.Equal(t, "from the terminal", m.input.Value())
+}
+
+// TestEveryPlatformHasSomewhereToLook. The commands are a fixed table, and a
+// platform with nothing in it would silently never paste from outside.
+func TestEveryPlatformHasSomewhereToLook(t *testing.T) {
+	readers := clipboardReaders()
+	require.NotEmpty(t, readers)
+
+	for _, reader := range readers {
+		assert.NotEmpty(t, reader, "a command with no name")
+	}
+}

--- a/internal/ui/result_view.go
+++ b/internal/ui/result_view.go
@@ -90,17 +90,17 @@ func onePassFormat(format config.OutputFormat) bool {
 	return format == config.OutputFormatASCII || format == config.OutputFormatJSON
 }
 
-// moreRowsNotice says how much of a streaming result is showing, for the
-// formats that are built in one pass.
+// moreRowsNotice says how much of a result is showing, at the end of it.
 //
-// The boxed table and expand format grow as you page through them, and a line
-// at the bottom saying there is more is what the scrollbar already says. ASCII
-// art and JSON lines are drawn from whatever rows are in hand, so what is on
-// screen can be a fraction of the answer with nothing to say so.
-func (m *MainModel) moreRowsNotice(format config.OutputFormat) string {
-	if !onePassFormat(format) {
-		return ""
-	}
+// At the end because that is where the rows run out, and where you are looking
+// when you want the rest. It was written over the prompt's placeholder instead,
+// which is one row shared with whatever else has something to say there: a
+// statement typed over several lines lost its own hint to it.
+//
+// Every format says it. The boxed table and expand format page in as you
+// scroll, so the line moves down the result as more of it arrives; ASCII art
+// and JSON lines are drawn in one pass, so it sits under what there is.
+func (m *MainModel) moreRowsNotice(_ config.OutputFormat) string {
 	if m.slidingWindow == nil || !m.slidingWindow.hasMoreData {
 		return ""
 	}

--- a/internal/ui/result_view_test.go
+++ b/internal/ui/result_view_test.go
@@ -213,23 +213,27 @@ func TestMoreRowsArrivingMovesTheWidthWithThem(t *testing.T) {
 
 // TestTheNoticeFollowsTheRowsInHand: it is drawn with the content, so it says
 // what is true at the time rather than what was true when the result arrived.
+//
+// Every format says it, and says it at the end of the result. It used to be
+// written over the prompt's placeholder, which is one row shared with whatever
+// else has something to say there - a statement typed over several lines lost
+// its own hint to it.
 func TestTheNoticeFollowsTheRowsInHand(t *testing.T) {
-	m := outputModel(t, false, config.OutputFormatTable)
-	m.displayResult(m.slidingWindow.Headers, nil)
+	for _, format := range config.OutputFormats() {
+		parsed, err := config.ParseOutputFormat(format)
+		require.NoError(t, err)
 
-	// A boxed table pages in as you scroll, and the scrollbar says as much.
-	assert.NotContains(t, shown(m), "More data available")
+		m := outputModel(t, false, parsed)
+		m.displayResult(m.slidingWindow.Headers, nil)
 
-	// ASCII is drawn in one pass, so what is on screen can be a fraction of the
-	// answer with nothing else to say so.
-	m.processCommand("OUTPUT ASCII")
-	assert.Contains(t, shown(m), "More data available")
-	assert.Contains(t, shown(m), "Showing 2 rows")
+		assert.Contains(t, shown(m), "More data available", "%s", format)
+		assert.Contains(t, shown(m), "Showing 2 rows", "%s", format)
 
-	// And it goes when the rest arrives.
-	m.loadMoreTableDataHelper()
-	assert.NotContains(t, shown(m), "More data available")
-	assert.Contains(t, shown(m), "dave")
+		// And it goes when the rest arrives.
+		m.loadMoreTableDataHelper()
+		assert.NotContains(t, shown(m), "More data available", "%s", format)
+		assert.Contains(t, shown(m), "dave", "%s", format)
+	}
 }
 
 // TestSwitchingFormatFetchesNothingExtra.

--- a/internal/ui/save_window_test.go
+++ b/internal/ui/save_window_test.go
@@ -50,6 +50,7 @@ func TestBothRoutesToASaveDoTheSameThing(t *testing.T) {
 	typed.runCommand("SAVE TO '" + typedPath + "' AS CSV")
 
 	clicked := helpModel()
+	clicked.lastTableData = [][]string{{"id"}, {"1"}}
 	clicked.windowHeight = 30
 	clicked.lastTableData, clicked.columnTypes = data, types
 	clickedPath := filepath.Join(dir, "clicked.csv")

--- a/internal/ui/schema_browser.go
+++ b/internal/ui/schema_browser.go
@@ -52,6 +52,11 @@ type schemaBrowser struct {
 	detailScroll int
 	detailWidth  int // the widest line, for scrolling sideways later
 
+	// drawn is the view as it was last rendered, both panes together. Dragging
+	// the mouse selects out of it: there is no viewport behind this view to
+	// anchor a selection to, and what is on screen is what a selection is over.
+	drawn []string
+
 	message string // what to say when there is no tree to draw
 }
 
@@ -328,6 +333,28 @@ func (m *MainModel) leaveAIConversation() {
 // lipglossWidthOf is the drawn width of a line, ignoring any colour in it.
 func lipglossWidthOf(line string) int {
 	return len([]rune(stripAnsi(line)))
+}
+
+// schemaOwnsKeys reports whether the tree should take the keys that move around
+// it.
+//
+// Only when nothing in front of it wants them. The tree is the background of
+// this view, and the things drawn over it - the completion list under the
+// prompt, the command history, a confirmation waiting for an answer - are all
+// worked with the same arrows. Taking them unconditionally moved the tree while
+// the list you were looking at stood still.
+func (m *MainModel) schemaOwnsKeys() bool {
+	switch {
+	case m.viewMode != "schema":
+		return false
+	case m.showCompletions && len(m.completions) > 0:
+		return false
+	case m.historySearchMode:
+		return false
+	case m.modal.Type != ModalNone:
+		return false
+	}
+	return true
 }
 
 // schemaKey handles the keys that work the tree, and reports whether it took

--- a/internal/ui/schema_browser_test.go
+++ b/internal/ui/schema_browser_test.go
@@ -331,3 +331,146 @@ func TestSchemaSitsNextToTheConsole(t *testing.T) {
 	}
 	assert.Equal(t, []string{"F2", "F3", "F4", "F5", "F6"}, keys)
 }
+
+// TestTheCompletionListKeepsTheArrows.
+//
+// The tree is the background of this view, and the completion list is drawn
+// over it. Taking the arrows unconditionally moved the tree behind while the
+// list you were reading stood still.
+func TestTheCompletionListKeepsTheArrows(t *testing.T) {
+	m := schemaModel(t)
+	m.input.SetValue("SELECT * FROM ")
+	m.showCompletions = true
+	m.completions = []string{"events", "users"}
+	m.completionIndex = 0
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	assert.Equal(t, 1, m.completionIndex, "down should have moved the list")
+	assert.Equal(t, 0, m.schema.selected, "the tree behind it should not have moved")
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, 0, m.completionIndex)
+	assert.Equal(t, 0, m.schema.selected)
+
+	// With the list gone, the arrows are the tree's again.
+	m.showCompletions = false
+	m.completions = nil
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, 1, m.schema.selected)
+}
+
+// TestAQuestionOnScreenKeepsTheArrows, for the same reason: left and right
+// choose the answer, and Enter gives it.
+func TestAQuestionOnScreenKeepsTheArrows(t *testing.T) {
+	m := schemaModel(t)
+	m.modal = NewConfirmationModal("DROP TABLE users")
+
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyRight})
+
+	assert.Equal(t, 1, m.modal.Selected, "right should have moved to the other answer")
+	assert.Equal(t, 0, m.schema.selected)
+	assert.False(t, m.schema.expanded["my_keyspace"], "the tree should not have opened")
+}
+
+// TestTheHistoryListKeepsTheArrows.
+func TestTheHistoryListKeepsTheArrows(t *testing.T) {
+	m := schemaModel(t)
+	m.commandHistory = []string{"SELECT * FROM users", "DROP TABLE events"}
+	m, _ = m.handleCtrlR()
+	require.True(t, m.historySearchMode)
+
+	before := m.historySearchIndex
+	m, _ = m.handleKeyboardInput(tea.KeyPressMsg{Code: tea.KeyUp})
+
+	assert.NotEqual(t, before, m.historySearchIndex, "up should have moved the list")
+	assert.Equal(t, 0, m.schema.selected)
+}
+
+// TestTheDefinitionCanBeCopiedOut.
+//
+// The point of having the schema on screen is to take things out of it - a
+// column name, a whole CREATE TABLE - into the prompt. Selection was anchored to
+// a viewport, and this view has none: a drag over the definition recorded a span
+// against the console's content, so what reached the clipboard was whatever
+// happened to be on those rows of a view you were not looking at.
+func TestTheDefinitionCanBeCopiedOut(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow()
+	m, _ = m.selectSchemaRow(2) // my_keyspace.users
+
+	// What is on screen is what a selection is over, so it has to be drawn
+	// before it can be dragged across.
+	m.historyViewport.SetContent(strings.Repeat("console line\n", 40))
+	drawn := strings.Split(m.viewSchema(m.windowWidth, m.schemaHeight()), "\n")
+
+	// The row holding the CREATE TABLE line, and the columns it covers.
+	row, text := -1, ""
+	for i, line := range drawn {
+		if strings.Contains(stripAnsi(line), "CREATE TABLE") {
+			row, text = i, stripAnsi(line)
+			break
+		}
+	}
+	require.NotEqual(t, -1, row, "the definition should be on screen")
+
+	// In columns, not bytes: the line has a fold marker and a divider in it, and
+	// both are three bytes wide and one column wide.
+	from := columnOf(text, "CREATE TABLE")
+	to := from + len([]rune("CREATE TABLE my_keyspace.users ("))
+
+	cmd := drag(m, from, tabBarHeight+row, to, tabBarHeight+row)
+	assert.Equal(t, "CREATE TABLE my_keyspace.users (", clipboardText(t, cmd))
+	assert.NotContains(t, clipboardText(t, cmd), "console line",
+		"the selection should be over this view, not the one behind it")
+}
+
+// TestATreeNameCanBeCopiedOut too: the left-hand pane is text on screen like
+// any other.
+func TestATreeNameCanBeCopiedOut(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow()
+	drawn := strings.Split(m.viewSchema(m.windowWidth, m.schemaHeight()), "\n")
+
+	// Only the tree column: the definition beside it names the keyspace too.
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	row := -1
+	for i, line := range drawn {
+		pane := string([]rune(stripAnsi(line))[:g.treeWidth])
+		if strings.Contains(pane, "my_keyspace") {
+			row = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, row)
+
+	from := columnOf(stripAnsi(drawn[row]), "my_keyspace")
+	cmd := drag(m, from, tabBarHeight+row, from+len("my_keyspace"), tabBarHeight+row)
+	assert.Equal(t, "my_keyspace", clipboardText(t, cmd))
+}
+
+// TestADragInTheTreeIsNotAClick: a press on the tree selects a row, and one on
+// the definition starts a selection, so both have to be tried.
+func TestADragInTheTreeIsNotAClick(t *testing.T) {
+	m := schemaModel(t)
+	m, _ = m.toggleSchemaRow()
+	m.viewSchema(m.windowWidth, m.schemaHeight())
+
+	g := m.schemaGeometry(m.windowWidth, m.schemaHeight())
+	updated, _ := m.handleMousePress(tea.Mouse{
+		X: g.treeWidth + 6, Y: tabBarHeight + schemaHeaderRows, Button: tea.MouseLeft,
+	})
+	assert.True(t, updated.selection.dragging, "a press on the definition starts a selection")
+	assert.Equal(t, 0, updated.schema.selected, "and does not move the tree")
+}
+
+// columnOf is where a piece of text starts, counted in columns on screen rather
+// than in bytes: a fold marker and a divider are three bytes each and one column
+// each, and a selection is made of columns.
+func columnOf(line, text string) int {
+	i := strings.Index(line, text)
+	if i < 0 {
+		return -1
+	}
+	return len([]rune(line[:i]))
+}

--- a/internal/ui/schema_view.go
+++ b/internal/ui/schema_view.go
@@ -171,6 +171,10 @@ func (m *MainModel) viewSchema(width, height int) string {
 
 		lines = append(lines, left+ruleStyle.Render(schemaDivider)+right)
 	}
+
+	// Kept for the selection, which is over what is on screen rather than over
+	// a viewport this view does not have.
+	m.schema.drawn = lines
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -75,25 +75,66 @@ func (s textSelection) empty() bool {
 	return s.anchorLine == s.headLine && s.anchorCol == s.headCol
 }
 
-// selectionTarget returns the viewport a selection applies to and a name for
-// it, matching the viewport View draws. Both come from here so a selection
-// cannot end up recorded against one view and painted onto another.
+// selectionSource is what a selection is anchored to: the lines on screen, and
+// which of them is drawn at the top.
 //
-// It returns nil where the view has nothing to select: the "no table data" and
-// "no trace data" messages are drawn through a throwaway viewport, so there is
-// no content to anchor to.
-func (m *MainModel) selectionTarget() (*viewport.Model, string) {
+// Most views are a viewport, and for those it is the viewport's content and
+// scroll offset. The schema browser is not - it is two panes drawn side by side,
+// each scrolling on its own - so what it offers is the block of lines it just
+// drew. The selection does not care which it is: a span is lines and columns of
+// what is on screen either way.
+type selectionSource struct {
+	// vp is the viewport behind the lines, where there is one. Dragging past
+	// the top or bottom edge scrolls it; a view without one stops at the edge.
+	vp *viewport.Model
+
+	view   string // names it, so a span cannot be painted onto another view
+	lines  []string
+	offset int // content line drawn on the first row
+	height int // rows on screen
+}
+
+// selectionTarget returns what a selection applies to, matching what View
+// draws. Both come from here so a selection cannot end up recorded against one
+// view and painted onto another.
+//
+// It returns nothing where the view has nothing to select: the "no table data"
+// and "no trace data" messages are drawn through a throwaway viewport, so there
+// is no content to anchor to.
+func (m *MainModel) selectionTarget() (selectionSource, bool) {
+	fromViewport := func(vp *viewport.Model, view string) (selectionSource, bool) {
+		return selectionSource{
+			vp:     vp,
+			view:   view,
+			lines:  strings.Split(vp.GetContent(), "\n"),
+			offset: vp.YOffset(),
+			height: vp.Height(),
+		}, true
+	}
+
 	switch {
+	case m.viewMode == "schema":
+		// What it drew last, which is what is on screen: both panes, the
+		// headings and the divider between them. A definition is text like any
+		// other view's, and copying it out of here is the point of having it.
+		if len(m.schema.drawn) == 0 {
+			return selectionSource{}, false
+		}
+		return selectionSource{
+			view:   "schema",
+			lines:  m.schema.drawn,
+			height: len(m.schema.drawn),
+		}, true
 	case m.viewMode == "ai" && m.aiConversationActive:
-		return &m.aiConversationViewport, "ai"
+		return fromViewport(&m.aiConversationViewport, "ai")
 	case m.viewMode == "trace" && m.hasTrace:
-		return &m.traceViewport, "trace"
+		return fromViewport(&m.traceViewport, "trace")
 	case m.viewMode == "table" && m.hasTable:
-		return &m.tableViewport, "table"
+		return fromViewport(&m.tableViewport, "table")
 	case m.viewMode == "trace" || m.viewMode == "table":
-		return nil, ""
+		return selectionSource{}, false
 	default:
-		return &m.historyViewport, "history"
+		return fromViewport(&m.historyViewport, "history")
 	}
 }
 
@@ -124,18 +165,18 @@ func (m *MainModel) stickyHeaderRows() int {
 // docPosition converts a screen position into a line and column of the active
 // viewport's content.
 func (m *MainModel) docPosition(col, row int) (line, column int, ok bool) {
-	vp, _ := m.selectionTarget()
-	if vp == nil || col < 0 {
+	source, found := m.selectionTarget()
+	if !found || col < 0 {
 		return 0, 0, false
 	}
 
 	top := tabBarHeight + m.stickyHeaderRows()
-	bottom := tabBarHeight + vp.Height()
+	bottom := tabBarHeight + source.height
 	if row < top || row >= bottom {
 		return 0, 0, false
 	}
 
-	return vp.YOffset() + row - tabBarHeight, col, true
+	return source.offset + row - tabBarHeight, col, true
 }
 
 // beginSelection starts a drag, or picks out a word or a line if this press
@@ -146,7 +187,8 @@ func (m *MainModel) beginSelection(col, row int) (*MainModel, tea.Cmd) {
 		m.clearSelection()
 		return m, nil
 	}
-	_, view := m.selectionTarget()
+	source, _ := m.selectionTarget()
+	view := source.view
 
 	// A press soon after one on the same cell counts up: two for a word, three
 	// for a line, and a fourth starts over.
@@ -188,15 +230,22 @@ func (m *MainModel) extendSelection(col, row int) (*MainModel, tea.Cmd) {
 	if !m.selection.dragging {
 		return m, nil
 	}
-	vp, view := m.selectionTarget()
-	if vp == nil || view != m.selection.view {
+	source, found := m.selectionTarget()
+	if !found || source.view != m.selection.view {
 		return m, nil
 	}
 
 	top := tabBarHeight + m.stickyHeaderRows()
-	bottom := tabBarHeight + vp.Height()
+	bottom := tabBarHeight + source.height
+	vp := source.vp
 	switch {
 	case row < top:
+		if vp == nil {
+			// Nothing to scroll: the schema panes move on their own, and a drag
+			// that runs off the top stops there.
+			row = top
+			break
+		}
 		vp.SetYOffset(max(0, vp.YOffset()-1))
 		row = top
 	case row >= bottom:
@@ -233,6 +282,10 @@ func (m *MainModel) endSelection() (*MainModel, tea.Cmd) {
 		m.selection.active = false
 		return m, nil
 	}
+
+	// Kept as well as sent. A right click pastes this when the terminal will
+	// not say what its clipboard holds, which is most of them.
+	m.lastCopied = text
 	return m, tea.SetClipboard(text)
 }
 
@@ -282,13 +335,13 @@ func wordCell(r rune) bool {
 	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
-// documentLines splits the active viewport's content into lines.
+// documentLines is the content a selection is over, by line.
 func (m *MainModel) documentLines() ([]string, bool) {
-	vp, view := m.selectionTarget()
-	if vp == nil || view != m.selection.view {
+	source, found := m.selectionTarget()
+	if !found || source.view != m.selection.view {
 		return nil, false
 	}
-	return strings.Split(vp.GetContent(), "\n"), true
+	return source.lines, true
 }
 
 // documentCells returns one line of content as one rune per column.
@@ -373,13 +426,13 @@ func (m *MainModel) highlightSelection(section string) string {
 	if !m.selection.active || m.selection.empty() {
 		return section
 	}
-	vp, view := m.selectionTarget()
-	if vp == nil || view != m.selection.view {
+	source, found := m.selectionTarget()
+	if !found || source.view != m.selection.view {
 		return section
 	}
 
 	startLine, startCol, endLine, endCol := m.selection.span()
-	offset := vp.YOffset()
+	offset := source.offset
 	sticky := m.stickyHeaderRows()
 
 	rows := strings.Split(section, "\n")

--- a/internal/ui/selection_test.go
+++ b/internal/ui/selection_test.go
@@ -339,9 +339,9 @@ func TestStickyHeaderRowsAreNotSelectable(t *testing.T) {
 func TestSelectionIsOffWithoutContent(t *testing.T) {
 	m := &MainModel{styles: DefaultStyles(), viewMode: "table", hasTable: false}
 
-	vp, name := m.selectionTarget()
-	assert.Nil(t, vp)
-	assert.Equal(t, "", name)
+	source, found := m.selectionTarget()
+	assert.False(t, found)
+	assert.Empty(t, source.view)
 
 	m.beginSelection(2, 2)
 	assert.False(t, m.selection.active)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -62,3 +62,11 @@ func DefaultStyles() *Styles {
 
 	return st
 }
+
+// dimmedColour is what something that is there but has nothing to offer yet is
+// drawn in: a tab with no results behind it, a menu entry that cannot be picked.
+//
+// Dark enough to read as unavailable beside the ones that are, and light enough
+// to read at all. At #585858 a dimmed entry looked like one that was not there,
+// which is the opposite of what dimming rather than hiding is for.
+var dimmedColour = lipgloss.Color("#7A7A7A")

--- a/internal/ui/tabbar.go
+++ b/internal/ui/tabbar.go
@@ -300,7 +300,7 @@ func (m *MainModel) ViewTabBar(width int) string {
 		Foreground(lipgloss.Color("#87D7FF"))
 
 	unavailableStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#585858"))
+		Foreground(dimmedColour)
 
 	separatorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#3a3a3a"))

--- a/internal/ui/view_builder.go
+++ b/internal/ui/view_builder.go
@@ -108,26 +108,13 @@ func (m *MainModel) View() tea.View {
 			inputSection = m.aiConversationInput.View()
 		}
 	} else {
-		// Update placeholder if there's more data to fetch
-		if m.viewMode == "table" && m.slidingWindow != nil && m.slidingWindow.hasMoreData {
-			if m.session != nil && !m.session.AutoFetch() {
-				// Temporarily change placeholder to show more data hint
-				originalPlaceholder := m.input.Placeholder
-				m.input.Placeholder = "▼ MORE DATA AVAILABLE - Press Space or PgDn to load next page ▼"
-				inputSection = m.input.View()
-				m.input.Placeholder = originalPlaceholder // Restore original
-			} else {
-				inputSection = m.input.View()
-			}
-		} else {
-			inputSection = m.input.View()
-		}
+		// The prompt says what the prompt is for. That there are more rows to
+		// fetch is said at the end of the result, where the rows run out, which
+		// is where you are looking when you want them - it used to be written
+		// over the placeholder, so it collided with the hint for a statement
+		// being typed over several lines and took the row from it.
+		inputSection = m.input.View()
 
-		// If in multi-line mode, show the buffered lines above the input
-		if m.multiLineMode && len(m.multiLineBuffer) > 0 {
-			bufferedLines := m.styles.MutedText.Render("... " + strings.Join(m.multiLineBuffer, "\n... "))
-			inputSection = bufferedLines + "\n" + inputSection
-		}
 	}
 
 	// Function key hints are now shown in the status bar
@@ -214,7 +201,7 @@ func (m *MainModel) View() tea.View {
 	//
 	// selectionTarget names the view being drawn, which is the same question,
 	// so the two cannot disagree about which viewport is on screen.
-	if _, view := m.selectionTarget(); view == "history" {
+	if source, _ := m.selectionTarget(); source.view == "history" {
 		viewportSection = m.consoleScrollbar(viewportSection)
 	}
 


### PR DESCRIPTION
Closes #177.

Ten UI problems, gathered rather than raised one at a time: small, in the same
few screens, and sharing a set of tests. 925 lines added, 152 removed.

### The views

- **The schema tree took the arrows from whatever was drawn over it** - the
  completion list, the command history, a confirmation dialog where left and
  right were moving the tree rather than choosing between Cancel and Execute. It
  takes them only when nothing in front of it wants them.
- **Nothing could be copied out of the schema view.** A selection was anchored to
  a viewport, and that view has none - two panes side by side, each scrolling on
  its own - so a drag recorded a span against the console's content and copied
  whatever was on those rows of a view you were not looking at. A selection is
  over the lines on screen whether or not there is a viewport behind them.
- **The console filled from the top**, so early in a session the welcome message
  sat at the top of the screen and the command you had just run appeared under
  it, a long way from the prompt it was typed at. It is drawn at the foot of the
  view now, the way a shell puts it.

### Pasting

**A right click pastes.** Taking the mouse takes the terminal's own context menu
away, and with it the paste everyone reaches for. It asks three things and takes
the first answer: the terminal through OSC 52, which most refuse; the machine
cqlai runs on, through whichever of `wl-paste`, `xclip`, `xsel`, `pbpaste` or
`powershell.exe Get-Clipboard` is there - a local desktop, WSL included; and
failing both, whatever cqlai itself last copied. Late answers to a click already
served are ignored rather than pasted twice, and a clipboard message nobody asked
for is ignored entirely.

### The prompt

- **A statement typed over several lines walked over the bars.** The lines
  already typed were drawn above the prompt, which is a block that grows, and the
  window has one row for the input: the second line pushed the connection bar off
  the bottom and the third took the query line with it. They go into the console
  now, a line at a time, and the prompt says which line you are on - `>` or `...`.
  The box beside it is sized from whichever prompt is in front of it.
- **"MORE DATA AVAILABLE" shared the prompt's row**, being written over the
  input's placeholder. It goes at the end of the result now, where the rows run
  out, and says how many are showing. Every format says it.
- **Space could not start a continuation line**: it pages a partly loaded result
  when the prompt is empty, and the prompt is empty at the start of every
  continuation line. While a statement is being typed the space is the
  statement's.

### Files

- **SAVE RESULTS is back in the FILE menu**, and first in it. It was taken out in
  #164, reading "remove SAVE RESULTS as it doesn't apply to all menu items" as
  the entry when it meant the button on the tab line. It is pickable whether or
  not there is anything to save - dimming it until a query had run described the
  state accurately and looked like an entry that was not there - and picking it
  with nothing on screen says so, in the words the SAVE command uses. The grey
  for genuinely unavailable things went from `#585858` to `#7A7A7A`, in one place
  rather than two.
- **The AutoSave and SAVE path fields open on the file browser** rather than on a
  name with nothing around it, and suggest a path under the home directory.
  AutoSave suggests a directory that does not exist yet, so the listing walks up
  to the nearest one above it that does. Escape goes back a step rather than
  putting the listing away.
- **The SOURCE and COPY file fields start at the home directory** too. The
  starting value is a directory - a place to look rather than an answer - so the
  form says "that is a directory" until a file is named, which it already said
  for every other directory.

### Tests

Thirty-odd new ones: the arrows under each overlay, copying out of both schema
panes, a paste for each place one can land and the two that must be ignored, a
statement typed over six lines leaving the bars where they are, the notice at the
end of a result in every format, the console drawn from the bottom, the menu
entry before there are results, the listing walking up to a directory that
exists, and every form starting at home.
